### PR TITLE
feat: add WebTransport with AutoTLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ A lightweight HTTP framework for Go built on top of the standard `net/http` libr
 - [Disabling Default Security](#disabling-default-security)
 - [Available Middlewares](#available-middlewares)
 - [Extensible Interfaces](#extensible-interfaces)
-- [Auto-TLS](#auto-tls)
-- [HTTP/3 Support](#http3-support)
-- [WebTransport Support](#webtransport-support)
+- [Pluggable Features](#pluggable-features)
+    - [Auto-TLS](#auto-tls)
+    - [HTTP/3 Support](#http3-support)
+    - [WebTransport Support](#webtransport-support)
 - [Health Checks](#health-checks)
 - [Circuit Breaker](#circuit-breaker)
 - [Configuration Reference](#configuration-reference)
@@ -45,9 +46,7 @@ A lightweight HTTP framework for Go built on top of the standard `net/http` libr
 - **Flexible Routing**: Method-based routing with route groups and parameter support
 - **Middleware Support**: Comprehensive middleware system with built-in security, logging, and utility middlewares
 - **Built-in Security**: CORS, rate limiting, request body size limits, security headers, and more
-- **Auto-TLS**: Pluggable automatic certificate management (e.g., Let's Encrypt, custom ACME providers)
-- **HTTP/3 Support**: Pluggable HTTP/3 support for modern web performance
-- **WebTransport Support**: Pluggable WebTransport for low-latency bidirectional communication
+- **HTTP/2 & HTTP/3**: Automatic HTTP/2 support for TLS; optional HTTP/3 via pluggable interface
 - **Request Tracing**: Built-in request ID generation and propagation
 - **Circuit Breaker**: Prevent cascading failures with configurable circuit breaker middleware
 - **Structured Logging**: Integrated structured logging with customizable fields
@@ -474,7 +473,18 @@ zh.Bind = &MyBinder{}
 ```
 
 
-## Auto-TLS
+## Pluggable Features
+
+zerohttp provides several pluggable features that extend the core functionality through interfaces.
+These features require external dependencies and are opt-in:
+
+- **Auto-TLS** - Automatic certificate management (e.g., Let's Encrypt)
+- **HTTP/3** - HTTP/3 support over QUIC (HTTP/2 is enabled by default for TLS)
+- **WebTransport** - Low-latency bidirectional communication over HTTP/3
+
+Each feature uses a pluggable interface pattern - you bring your own implementation.
+
+### Auto-TLS
 
 AutoTLS provides automatic certificate management via a pluggable interface. You can use
 [golang.org/x/crypto/acme/autocert](https://pkg.go.dev/golang.org/x/crypto/acme/autocert)
@@ -501,12 +511,12 @@ app.StartAutoTLS()
 ```
 
 
-## HTTP/3 Support
+### HTTP/3 Support
 
 zerohttp supports HTTP/3 through a pluggable interface. Users can inject their own HTTP/3
 implementation (e.g., [quic-go/http3](https://github.com/quic-go/quic-go)).
 
-### Basic HTTP/3 with TLS certificates
+#### Basic HTTP/3 with TLS certificates
 
 ```go
 import "github.com/quic-go/quic-go/http3"
@@ -531,7 +541,7 @@ app.StartTLS("cert.pem", "key.pem")
 ```
 
 
-## WebTransport Support
+### WebTransport Support
 
 WebTransport provides low-latency, bidirectional communication over HTTP/3:
 

--- a/config/config.go
+++ b/config/config.go
@@ -360,6 +360,19 @@ type WebTransportServer interface {
 	Close() error
 }
 
+// WebTransportServerWithAutocert is an optional interface for WebTransport servers that support
+// automatic certificate management via autocert.Manager. If a WebTransport server
+// implements this interface, it will be used by StartAutoTLS to configure
+// WebTransport with Let's Encrypt certificates.
+type WebTransportServerWithAutocert interface {
+	WebTransportServer
+
+	// ListenAndServeTLSWithAutocert starts the WebTransport server with automatic
+	// certificate management using the provided autocert manager.
+	// The manager's GetCertificate function is used to obtain TLS certificates.
+	ListenAndServeTLSWithAutocert(manager AutocertManager) error
+}
+
 // WithHTTP3Server sets a custom HTTP/3 server instance.
 func WithHTTP3Server(server HTTP3Server) Option {
 	return func(c *Config) {

--- a/examples/webtransport/README.md
+++ b/examples/webtransport/README.md
@@ -14,7 +14,18 @@ A complete WebTransport echo server using zerohttp with HTTP/3 support.
 - [mkcert](https://github.com/FiloSottile/mkcert) for local HTTPS certificates
 - Chrome, Firefox, or Safari with WebTransport support
 
-## Setup
+## Examples
+
+This directory contains two examples:
+
+- **`main.go`** - WebTransport with local certificates (for development)
+- **`autotls.go`** - WebTransport with Let's Encrypt AutoTLS (for production)
+
+---
+
+## Development Setup (main.go)
+
+Use this for local development with self-signed certificates.
 
 ### 1. Install mkcert
 
@@ -161,13 +172,92 @@ func handleSession(sess *webtransport.Session) {
    Just set the WebTransport server with `app.SetWebTransportServer()` and then call
    `app.ListenAndServeTLS()`. The WebTransport server will be started automatically.
 
-## Production Considerations
+## Production Setup (autotls.go)
 
-- Replace mkcert certificates with proper ones from Let's Encrypt
-- Implement proper origin checking in `CheckOrigin`
+For production with automatic Let's Encrypt certificates:
+
+```bash
+go run autotls.go -domain=your-domain.com
+```
+
+### Requirements
+
+- A publicly accessible domain name
+- Ports 80 and 443 open and accessible from the internet
+- The domain must resolve to the server's IP address
+
+### How It Works
+
+The `autotls.go` example uses `golang.org/x/crypto/acme/autocert` for automatic certificate management:
+
+1. **Certificate Acquisition**: On first start, the server obtains a certificate from Let's Encrypt
+2. **Auto-Renewal**: Certificates are automatically renewed before expiry
+3. **HTTP Challenge**: The ACME HTTP-01 challenge is handled on port 80
+4. **WebTransport**: Runs on port 443 with the auto-obtained certificate
+
+### Key Differences from Development Setup
+
+The `autotls.go` example uses a wrapper to implement the `WebTransportServerWithAutocert` interface:
+
+```go
+// Wrapper implements config.WebTransportServerWithAutocert
+type webtransportAutocertServer struct {
+    server *webtransport.Server
+}
+
+func (w *webtransportAutocertServer) ListenAndServeTLS(certFile, keyFile string) error {
+    return w.server.ListenAndServeTLS(certFile, keyFile)
+}
+
+func (w *webtransportAutocertServer) Close() error {
+    return w.server.Close()
+}
+
+func (w *webtransportAutocertServer) ListenAndServeTLSWithAutocert(manager config.AutocertManager) error {
+    // Configure TLS with autocert on the underlying HTTP/3 server
+    w.server.H3.TLSConfig = &tls.Config{
+        GetCertificate: manager.GetCertificate,
+        NextProtos:     []string{"h3"},
+    }
+    return w.server.H3.ListenAndServe()
+}
+```
+
+Then use the wrapper with zerohttp:
+
+```go
+// Create autocert manager
+mgr := &autocert.Manager{
+    Cache:      autocert.DirCache("/var/cache/certs"),
+    Prompt:     autocert.AcceptTOS,
+    HostPolicy: autocert.HostWhitelist("your-domain.com"),
+}
+
+// Create zerohttp app with autocert manager
+app := zh.New(
+    config.WithAutocertManager(mgr),
+)
+
+// Create HTTP/3 and WebTransport servers
+h3 := &http3.Server{Addr: ":443", Handler: app}
+wt := &webtransport.Server{H3: h3, CheckOrigin: ...}
+webtransport.ConfigureHTTP3Server(h3)
+
+// Wrap the server to enable AutoTLS support
+wtServer := &webtransportAutocertServer{server: wt}
+app.SetWebTransportServer(wtServer)
+
+// Start with AutoTLS - WebTransport starts automatically!
+app.StartAutoTLS()
+```
+
+### Production Considerations
+
+- Implement proper origin checking in `CheckOrigin` (don't allow all origins)
 - Add rate limiting for WebTransport connections
 - Consider connection limits per client
 - Use structured logging for session events
+- Store certificates in a persistent location (not `/tmp`)
 
 ## Resources
 

--- a/examples/webtransport/autotls.go
+++ b/examples/webtransport/autotls.go
@@ -1,0 +1,428 @@
+//go:build ignore
+
+// WebTransport with AutoTLS Example
+//
+// This example shows how to use WebTransport with automatic TLS certificate
+// management via Let's Encrypt (autocert).
+//
+// Requirements:
+// - A publicly accessible domain name
+// - Ports 80 and 443 open for HTTP and HTTPS
+//
+// Usage:
+//
+//	go run autotls.go -domain=your-domain.com
+//
+// The server will:
+// - Obtain and renew certificates automatically from Let's Encrypt
+// - Serve HTTP on port 80 (redirects to HTTPS + ACME challenges)
+// - Serve HTTPS on port 443 with WebTransport support
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
+	"github.com/quic-go/quic-go/http3"
+	webtransport "github.com/quic-go/webtransport-go"
+	"golang.org/x/crypto/acme/autocert"
+)
+
+var (
+	_ config.WebTransportServer             = (*webtransportAutocertServer)(nil)
+	_ config.WebTransportServerWithAutocert = (*webtransportAutocertServer)(nil)
+)
+
+// webtransportAutocertServer wraps quic-go's webtransport.Server to implement
+// config.WebTransportServerWithAutocert interface
+type webtransportAutocertServer struct {
+	server *webtransport.Server
+}
+
+func (w *webtransportAutocertServer) ListenAndServeTLS(certFile, keyFile string) error {
+	return w.server.ListenAndServeTLS(certFile, keyFile)
+}
+
+func (w *webtransportAutocertServer) Close() error {
+	return w.server.Close()
+}
+
+func (w *webtransportAutocertServer) ListenAndServeTLSWithAutocert(manager config.AutocertManager) error {
+	// Configure TLS with autocert on the underlying HTTP/3 server
+	w.server.H3.TLSConfig = &tls.Config{
+		GetCertificate: manager.GetCertificate,
+		NextProtos:     []string{"h3"},
+	}
+
+	// ListenAndServe on the HTTP/3 server (WebTransport runs over it)
+	err := w.server.H3.ListenAndServe()
+	if err != nil {
+		log.Printf("[ERROR] WebTransport server failed: %v", err)
+	}
+	return err
+}
+
+func main() {
+	domain := flag.String("domain", "", "Domain name for Let's Encrypt certificate (required)")
+	flag.Parse()
+
+	if *domain == "" {
+		log.Fatal("Please provide a domain name with -domain flag")
+	}
+
+	// Create autocert manager for Let's Encrypt
+	mgr := &autocert.Manager{
+		Cache:      autocert.DirCache("/var/cache/certs"),
+		Prompt:     autocert.AcceptTOS,
+		HostPolicy: autocert.HostWhitelist(*domain),
+	}
+
+	// Create zerohttp app with autocert manager
+	app := zh.New(
+		config.WithDisableDefaultMiddlewares(),
+		config.WithAutocertManager(mgr),
+	)
+
+	// Create HTTP/3 server
+	h3 := &http3.Server{
+		Addr:    ":443",
+		Handler: app,
+	}
+
+	// Create WebTransport server
+	wt := &webtransport.Server{
+		H3:          h3,
+		CheckOrigin: func(r *http.Request) bool { return true },
+	}
+
+	// Wire WebTransport into HTTP/3 server
+	webtransport.ConfigureHTTP3Server(h3)
+
+	// Wrap the server to implement WebTransportServerWithAutocert
+	wtServer := &webtransportAutocertServer{server: wt}
+
+	// Set WebTransport server - zerohttp will start it automatically
+	app.SetWebTransportServer(wtServer)
+
+	// Serve the HTML client
+	app.GET("/", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		w.Header().Set("Content-Type", "text/html")
+		w.Header().Add("Alt-Svc", `h3=":443"; ma=86400`)
+		w.Write([]byte(clientHTML))
+		return nil
+	}))
+
+	// WebTransport endpoint - register CONNECT handler
+	app.CONNECT("/wt", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sess, err := wt.Upgrade(w, r)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		go handleSession(sess)
+	}))
+
+	log.Printf("Starting WebTransport server with AutoTLS on https://%s", *domain)
+	log.Println("Ports 80 and 443 must be open and accessible from the internet")
+
+	// Start with AutoTLS - WebTransport starts automatically with Let's Encrypt!
+	log.Fatal(app.StartAutoTLS())
+}
+
+func handleSession(sess *webtransport.Session) {
+	defer sess.CloseWithError(0, "done")
+
+	log.Printf("WebTransport session from %s", sess.RemoteAddr())
+
+	// Handle datagrams
+	go func() {
+		for {
+			msg, err := sess.ReceiveDatagram(context.Background())
+			if err != nil {
+				return
+			}
+			sess.SendDatagram(append([]byte("Echo: "), msg...))
+		}
+	}()
+
+	// Handle streams
+	for {
+		stream, err := sess.AcceptStream(context.Background())
+		if err != nil {
+			return
+		}
+		go func(str *webtransport.Stream) {
+			defer str.Close()
+			buf := make([]byte, 1024)
+			for {
+				n, err := str.Read(buf)
+				if n > 0 {
+					msg := string(buf[:n])
+					response := fmt.Sprintf("[%s] Echo: %s", time.Now().Format("15:04:05"), msg)
+					str.Write([]byte(response))
+				}
+				if err != nil {
+					return
+				}
+			}
+		}(stream)
+	}
+}
+
+const clientHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>WebTransport with AutoTLS</title>
+    <style>
+        body { font-family: system-ui, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; background: #f5f5f5; }
+        h1 { color: #333; }
+        .container { background: white; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin-bottom: 20px; }
+        button { background: #0066cc; color: white; border: none; padding: 10px 20px; border-radius: 4px; cursor: pointer; margin: 5px; }
+        button:hover { background: #0052a3; }
+        button:disabled { background: #ccc; cursor: not-allowed; }
+        input[type="text"] { padding: 10px; border: 1px solid #ddd; border-radius: 4px; width: 300px; margin-right: 10px; }
+        #log { background: #1a1a1a; color: #00ff00; padding: 15px; border-radius: 4px; font-family: monospace; font-size: 13px; height: 300px; overflow-y: auto; white-space: pre-wrap; }
+        .status { display: inline-block; padding: 4px 8px; border-radius: 4px; font-size: 12px; font-weight: bold; }
+        .status.connected { background: #4caf50; color: white; }
+        .status.disconnected { background: #f44336; color: white; }
+        .status.connecting { background: #ff9800; color: white; }
+        .section { margin: 15px 0; padding: 15px; background: #f9f9f9; border-radius: 4px; }
+        .section h3 { margin-top: 0; color: #555; }
+        .info { background: #e3f2fd; padding: 15px; border-radius: 4px; margin-bottom: 20px; }
+    </style>
+</head>
+<body>
+    <h1>WebTransport with AutoTLS</h1>
+
+    <div class="info">
+        <strong>AutoTLS Enabled:</strong> This server uses Let's Encrypt for automatic certificate management.
+        The certificate is obtained and renewed automatically.
+    </div>
+
+    <div class="container">
+        <h2>Connection</h2>
+        <p>Status: <span id="status" class="status disconnected">Disconnected</span></p>
+        <button id="connectBtn" onclick="connect()">Connect</button>
+        <button id="disconnectBtn" onclick="disconnect()" disabled>Disconnect</button>
+    </div>
+
+    <div class="container">
+        <h2>Messaging</h2>
+        <div class="section">
+            <h3>Datagrams (Unreliable)</h3>
+            <input type="text" id="datagramInput" placeholder="Enter message..." disabled>
+            <button id="sendDatagramBtn" onclick="sendDatagram()" disabled>Send Datagram</button>
+        </div>
+        <div class="section">
+            <h3>Bidirectional Streams</h3>
+            <input type="text" id="streamInput" placeholder="Enter message..." disabled>
+            <button id="sendStreamBtn" onclick="sendStreamMessage()" disabled>Send on Stream</button>
+            <button id="createStreamBtn" onclick="createStream()" disabled>Create New Stream</button>
+        </div>
+    </div>
+
+    <div class="container">
+        <h2>Log</h2>
+        <div id="log"></div>
+        <button onclick="clearLog()">Clear Log</button>
+    </div>
+
+    <script>
+        let wt = null;
+        let currentStream = null;
+        const logEl = document.getElementById('log');
+        const statusEl = document.getElementById('status');
+
+        function log(msg) {
+            const timestamp = new Date().toLocaleTimeString();
+            logEl.textContent += '[' + timestamp + '] ' + msg + '\n';
+            logEl.scrollTop = logEl.scrollHeight;
+        }
+
+        function setStatus(status) {
+            statusEl.className = 'status ' + status;
+            statusEl.textContent = status.charAt(0).toUpperCase() + status.slice(1);
+        }
+
+        function updateUI(connected) {
+            document.getElementById('connectBtn').disabled = connected;
+            document.getElementById('disconnectBtn').disabled = !connected;
+            document.getElementById('datagramInput').disabled = !connected;
+            document.getElementById('sendDatagramBtn').disabled = !connected;
+            document.getElementById('streamInput').disabled = !connected;
+            document.getElementById('sendStreamBtn').disabled = !connected;
+            document.getElementById('createStreamBtn').disabled = !connected;
+        }
+
+        async function connect() {
+            try {
+                setStatus('connecting');
+                log('Connecting to WebTransport server with AutoTLS...');
+
+                if (typeof WebTransport === 'undefined') {
+                    throw new Error('WebTransport is not supported in this browser');
+                }
+
+                wt = new WebTransport('https://' + window.location.host + '/wt');
+
+                wt.ready.then(() => {
+                    log('Connected successfully! (AutoTLS certificate)');
+                    setStatus('connected');
+                    updateUI(true);
+                    startReceiving();
+                });
+
+                wt.closed.then((info) => {
+                    log('Connection closed: ' + JSON.stringify(info));
+                    setStatus('disconnected');
+                    updateUI(false);
+                    wt = null;
+                    currentStream = null;
+                });
+
+                wt.ready.catch((error) => {
+                    log('Connection failed: ' + error.message);
+                    setStatus('disconnected');
+                    updateUI(false);
+                });
+
+            } catch (error) {
+                log('Error: ' + error.message);
+                setStatus('disconnected');
+                updateUI(false);
+            }
+        }
+
+        async function disconnect() {
+            if (wt) {
+                log('Closing connection...');
+                await wt.close();
+            }
+        }
+
+        async function startReceiving() {
+            if (wt.datagrams) {
+                const datagramReader = wt.datagrams.readable.getReader();
+                try {
+                    while (true) {
+                        const { value, done } = await datagramReader.read();
+                        if (done) break;
+                        const text = new TextDecoder().decode(value);
+                        log('Received datagram: ' + text);
+                    }
+                } catch (e) {
+                    log('Datagram error: ' + e.message);
+                }
+            }
+
+            try {
+                for await (const stream of wt.incomingBidirectionalStreams) {
+                    log('New incoming bidirectional stream');
+                    handleStream(stream);
+                }
+            } catch (e) {
+                log('Stream error: ' + e.message);
+            }
+        }
+
+        async function handleStream(stream) {
+            const reader = stream.readable.getReader();
+            try {
+                while (true) {
+                    const { value, done } = await reader.read();
+                    if (done) break;
+                    const text = new TextDecoder().decode(value);
+                    log('Received on stream: ' + text);
+                }
+            } catch (e) {
+                log('Stream read error: ' + e.message);
+            }
+        }
+
+        async function sendDatagram() {
+            if (!wt || !wt.datagrams) {
+                log('Datagrams not available');
+                return;
+            }
+
+            const input = document.getElementById('datagramInput');
+            const message = input.value.trim();
+            if (!message) return;
+
+            try {
+                const writer = wt.datagrams.writable.getWriter();
+                const data = new TextEncoder().encode(message);
+                await writer.write(data);
+                writer.releaseLock();
+                log('Sent datagram: ' + message);
+                input.value = '';
+            } catch (e) {
+                log('Send datagram error: ' + e.message);
+            }
+        }
+
+        async function createStream() {
+            if (!wt) {
+                log('Not connected');
+                return;
+            }
+
+            try {
+                currentStream = await wt.createBidirectionalStream();
+                log('Created new bidirectional stream');
+                handleStream(currentStream);
+            } catch (e) {
+                log('Create stream error: ' + e.message);
+            }
+        }
+
+        async function sendStreamMessage() {
+            if (!wt) {
+                log('Not connected');
+                return;
+            }
+
+            if (!currentStream) {
+                await createStream();
+            }
+
+            const input = document.getElementById('streamInput');
+            const message = input.value.trim();
+            if (!message) return;
+
+            try {
+                const writer = currentStream.writable.getWriter();
+                const data = new TextEncoder().encode(message + '\n');
+                await writer.write(data);
+                writer.releaseLock();
+                log('Sent on stream: ' + message);
+                input.value = '';
+            } catch (e) {
+                log('Send stream error: ' + e.message);
+            }
+        }
+
+        function clearLog() {
+            logEl.textContent = '';
+        }
+
+        document.getElementById('datagramInput').addEventListener('keypress', function(e) {
+            if (e.key === 'Enter') sendDatagram();
+        });
+        document.getElementById('streamInput').addEventListener('keypress', function(e) {
+            if (e.key === 'Enter') sendStreamMessage();
+        });
+
+        log('Page loaded. Click "Connect" to start.');
+    </script>
+</body>
+</html>`

--- a/server.go
+++ b/server.go
@@ -427,7 +427,7 @@ func (s *Server) StartAutoTLS() error {
 
 	s.logger.Info("Starting server with AutoTLS...")
 
-	errCh := make(chan error, 2)
+	errCh := make(chan error, 4)
 
 	// Start HTTP server for ACME challenges and redirects
 	if s.server != nil {
@@ -465,6 +465,16 @@ func (s *Server) StartAutoTLS() error {
 			go func() {
 				s.logger.Info("Starting HTTP/3 server with AutoTLS")
 				errCh <- h3Autocert.ListenAndServeTLSWithAutocert(s.autocertManager)
+			}()
+		}
+	}
+
+	// Start WebTransport server with autocert if supported
+	if s.webTransportServer != nil {
+		if wtAutocert, ok := s.webTransportServer.(config.WebTransportServerWithAutocert); ok {
+			go func() {
+				s.logger.Info("Starting WebTransport server with AutoTLS")
+				errCh <- wtAutocert.ListenAndServeTLSWithAutocert(s.autocertManager)
 			}()
 		}
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -695,6 +695,78 @@ func TestServer_StartAutoTLS_WithHTTP3NoAutocert(t *testing.T) {
 	}
 }
 
+// mockWebTransportServerWithAutocert implements both WebTransportServer and WebTransportServerWithAutocert
+type mockWebTransportServerWithAutocert struct {
+	mockWebTransportServer
+	mu                                  sync.Mutex
+	listenAndServeTLSWithAutocertCalled bool
+	autocertManager                     config.AutocertManager
+}
+
+func (m *mockWebTransportServerWithAutocert) ListenAndServeTLSWithAutocert(manager config.AutocertManager) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.listenAndServeTLSWithAutocertCalled = true
+	m.autocertManager = manager
+	return nil
+}
+
+func (m *mockWebTransportServerWithAutocert) wasListenAndServeTLSWithAutocertCalled() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.listenAndServeTLSWithAutocertCalled
+}
+
+func TestServer_StartAutoTLS_WithWebTransportAutocert(t *testing.T) {
+	mgr := &mockAutocertManager{}
+	wtServer := &mockWebTransportServerWithAutocert{}
+
+	server := New(config.WithAutocertManager(mgr))
+	server.SetWebTransportServer(wtServer)
+
+	// Run StartAutoTLS in a goroutine since it blocks
+	go func() {
+		// Suppress the error since we're just testing the setup
+		_ = server.StartAutoTLS()
+	}()
+
+	// Give it a moment to start
+	time.Sleep(50 * time.Millisecond)
+
+	// The WebTransport server with autocert support should have the autocert method called
+	if !wtServer.wasListenAndServeTLSWithAutocertCalled() {
+		t.Error("Expected WebTransport server ListenAndServeTLSWithAutocert to be called")
+	}
+
+	if wtServer.autocertManager != mgr {
+		t.Error("Expected WebTransport server to receive the autocert manager")
+	}
+}
+
+func TestServer_StartAutoTLS_WithWebTransportNoAutocert(t *testing.T) {
+	// Test WebTransport server that does NOT support autocert
+	mgr := &mockAutocertManager{}
+	wtServer := &mockWebTransportServer{} // This doesn't implement WebTransportServerWithAutocert
+
+	server := New(config.WithAutocertManager(mgr))
+	server.SetWebTransportServer(wtServer)
+
+	// Run StartAutoTLS in a goroutine since it blocks
+	go func() {
+		// Suppress the error since we're just testing the setup
+		_ = server.StartAutoTLS()
+	}()
+
+	// Give it a moment to start
+	time.Sleep(50 * time.Millisecond)
+
+	// The WebTransport server without autocert support should not have ListenAndServeTLS called
+	// since it doesn't implement WebTransportServerWithAutocert
+	if wtServer.wasListenAndServeTLSCalled() {
+		t.Log("WebTransport server ListenAndServeTLS was not called (expected - no autocert support)")
+	}
+}
+
 func TestServer_ListenAndServeTLS(t *testing.T) {
 	server := New()
 	// Set up a TLS server but no listener - it should try to create one


### PR DESCRIPTION
- Add WebTransportServerWithAutocert interface for automatic cert management
- Update StartAutoTLS to start WebTransport with Let's Encrypt
- Reorganize README with Pluggable Features section (Auto-TLS, HTTP/3, WebTransport)
- Add autotls.go example showing WebTransport + Let's Encrypt
- Add tests for WebTransport autocert integration
- Mention HTTP/2 support (enabled by default for TLS)