### PR TITLE
feat: add Form and MultipartForm binding with file upload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A lightweight HTTP framework for Go built on top of the standard `net/http` libr
 - **Zero Dependencies**: No external dependencies
 - **Secure by Default**: Automatically applies essential security middlewares out of the box
 - **Response Rendering**: Built-in support for JSON, HTML, text, and file responses
-- **Request Binding**: JSON request body parsing
+- **Request Binding**: JSON, form, and multipart form parsing with struct tag binding
 - **Problem Details**: RFC 9457 Problem Details for HTTP APIs error responses
 - **Flexible Routing**: Method-based routing with route groups and parameter support
 - **Middleware Support**: Comprehensive middleware system with built-in security, logging, and utility middlewares
@@ -152,7 +152,9 @@ zh.Render.ProblemDetail(w, problem)
 
 ## Request Binding
 
-Simple JSON request parsing with validation:
+Structured request parsing with validation for JSON, form data, and multipart forms:
+
+### JSON Binding
 
 ```go
 app.POST("/api/users", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
@@ -174,9 +176,65 @@ app.POST("/api/users", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Reques
 }))
 ```
 
+### Form Binding
+
+```go
+app.POST("/login", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+    var form struct {
+        Username string   `form:"username"`
+        Password string   `form:"password"`
+        Remember bool     `form:"remember"`
+        Tags     []string `form:"tags"`       // Supports slices
+    }
+
+    // Bind application/x-www-form-urlencoded or query parameters
+    if err := zh.Bind.Form(r, &form); err != nil {
+        return zh.NewProblemDetail(400, err.Error()).Render(w)
+    }
+
+    // Process form data...
+    return zh.R.JSON(w, 200, zh.M{"user": form.Username})
+}))
+```
+
+### Multipart Form Binding (File Uploads)
+
+```go
+app.POST("/upload", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+    var form struct {
+        Description string            `form:"description"`
+        Document    *zh.FileHeader    `form:"document"`    // Single file
+        Images      []*zh.FileHeader  `form:"images"`      // Multiple files
+    }
+
+    // Bind multipart/form-data with file uploads
+    // maxMemory controls how much is stored in memory vs temp files
+    if err := zh.Bind.MultipartForm(r, &form, 32<<20); err != nil {
+        return zh.NewProblemDetail(400, err.Error()).Render(w)
+    }
+
+    // Access uploaded files
+    if form.Document != nil {
+        file, err := form.Document.Open()
+        if err != nil {
+            return err
+        }
+        defer file.Close()
+
+        // Process file...
+    }
+
+    return zh.R.JSON(w, 200, zh.M{
+        "description": form.Description,
+        "files":       len(form.Images),
+    })
+}))
+```
+
 **Short alias available**: Use `zh.B` instead of `zh.Bind` for convenience.
 
-The binder uses `json.Decoder` with `DisallowUnknownFields()` for stricter validation.
+The JSON binder uses `json.Decoder` with `DisallowUnknownFields()` for stricter validation.
+Form binding supports automatic type conversion for int, uint, float, bool, and slice types.
 
 ## Middleware
 
@@ -467,6 +525,16 @@ func (b *MyBinder) JSON(r io.Reader, dst any) error {
     decoder := json.NewDecoder(r)
     decoder.UseNumber() // Use json.Number instead of float64
     return decoder.Decode(dst)
+}
+
+func (b *MyBinder) Form(r *http.Request, dst any) error {
+    // Custom form binding logic
+    return nil
+}
+
+func (b *MyBinder) MultipartForm(r *http.Request, dst any, maxMemory int64) error {
+    // Custom multipart form binding logic
+    return nil
 }
 
 // Replace default

--- a/bind.go
+++ b/bind.go
@@ -2,7 +2,14 @@ package zerohttp
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
 )
 
 // Bind is the default binder instance used by the package
@@ -18,9 +25,21 @@ type Binder interface {
 	// It uses json.NewDecoder with DisallowUnknownFields enabled
 	// for safer JSON parsing that rejects unknown fields.
 	JSON(r io.Reader, dst any) error
+
+	// Form parses form data from the request body (application/x-www-form-urlencoded)
+	// and binds it to the destination struct using `form` tags.
+	// It also parses the query string and includes those values.
+	Form(r *http.Request, dst any) error
+
+	// MultipartForm parses multipart/form-data from the request,
+	// including file uploads, and binds values to the destination struct.
+	// The maxMemory parameter controls how much of the form data is stored in memory
+	// before being written to temp files (similar to http.Request.ParseMultipartForm).
+	// File uploads are bound to fields of type FileHeader or []FileHeader.
+	MultipartForm(r *http.Request, dst any, maxMemory int64) error
 }
 
-// defaultBinder implements the Binder interface with standard JSON decoding
+// defaultBinder implements the Binder interface with standard decoding
 type defaultBinder struct{}
 
 // JSON decodes JSON request body into the destination struct.
@@ -30,4 +49,318 @@ func (b *defaultBinder) JSON(r io.Reader, dst any) error {
 	decoder := json.NewDecoder(r)
 	decoder.DisallowUnknownFields()
 	return decoder.Decode(dst)
+}
+
+// FileHeader represents an uploaded file in a multipart form.
+// It provides access to the file's metadata and content.
+type FileHeader struct {
+	Filename string
+	Size     int64
+	Header   map[string][]string
+	file     multipart.File // internal reference to the open file
+}
+
+// Open opens the uploaded file for reading.
+// The caller is responsible for closing the file.
+// Returns an error if the file cannot be opened or has already been closed.
+func (fh *FileHeader) Open() (multipart.File, error) {
+	if fh.file == nil {
+		return nil, fmt.Errorf("file %s: no longer available (already processed or closed)", fh.Filename)
+	}
+	return fh.file, nil
+}
+
+// ReadAll reads the entire file content into a byte slice.
+// This is a convenience method that opens, reads, and closes the file.
+// Note: This loads the entire file into memory; use Open() for large files.
+func (fh *FileHeader) ReadAll() (data []byte, err error) {
+	file, err := fh.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if cerr := file.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+	return io.ReadAll(file)
+}
+
+// Form binds form data from a url.Values to a destination struct.
+func (b *defaultBinder) Form(r *http.Request, dst any) error {
+	if err := r.ParseForm(); err != nil {
+		return fmt.Errorf("parse form: %w", err)
+	}
+	return bindValues(r.Form, dst, false)
+}
+
+// MultipartForm parses multipart form data including file uploads.
+func (b *defaultBinder) MultipartForm(r *http.Request, dst any, maxMemory int64) error {
+	if err := r.ParseMultipartForm(maxMemory); err != nil {
+		return fmt.Errorf("parse multipart form: %w", err)
+	}
+
+	if r.MultipartForm == nil {
+		return fmt.Errorf("no multipart form data")
+	}
+
+	// Bind form values first
+	if err := bindValues(r.MultipartForm.Value, dst, true); err != nil {
+		return err
+	}
+
+	// Bind files to struct fields
+	return BindMultipartFormFiles(r, dst)
+}
+
+// bindValues binds url.Values to a struct, optionally handling file uploads.
+func bindValues(values url.Values, dst any, allowFiles bool) error {
+	v := reflect.ValueOf(dst)
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return fmt.Errorf("destination must be a non-nil pointer")
+	}
+
+	v = v.Elem()
+	if v.Kind() != reflect.Struct {
+		return fmt.Errorf("destination must be a pointer to a struct")
+	}
+
+	t := v.Type()
+
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		fieldType := t.Field(i)
+
+		// Skip unexported fields
+		if !field.CanSet() {
+			continue
+		}
+
+		// Get form tag
+		tag := fieldType.Tag.Get("form")
+		if tag == "-" {
+			continue
+		}
+
+		// Use field name as default
+		if tag == "" {
+			tag = camelToSnake(fieldType.Name)
+		}
+
+		// Handle embedded structs
+		if fieldType.Anonymous && field.Kind() == reflect.Struct {
+			if err := bindValues(values, field.Addr().Interface(), allowFiles); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// Check for file uploads first (only in multipart mode)
+		if allowFiles {
+			if handled, err := bindFileField(field, tag); handled {
+				if err != nil {
+					return err
+				}
+				continue
+			}
+		}
+
+		// Get form value(s)
+		formValues, exists := values[tag]
+		if !exists || len(formValues) == 0 {
+			continue
+		}
+
+		if err := setFieldValue(field, formValues); err != nil {
+			return fmt.Errorf("field %s: %w", fieldType.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// bindFileField attempts to bind a file upload to a field.
+// Returns true if the field was handled as a file field.
+func bindFileField(field reflect.Value, tag string) (bool, error) {
+	// Check if it's a FileHeader field
+	switch field.Type() {
+	case reflect.TypeOf(&FileHeader{}):
+		// Single file - will be set later when processing multipart form
+		return true, nil
+	case reflect.TypeOf([]*FileHeader{}):
+		// Multiple files - will be set later
+		return true, nil
+	case reflect.TypeOf(FileHeader{}):
+		// Non-pointer FileHeader - not supported for binding
+		return false, fmt.Errorf("FileHeader field must be a pointer (*FileHeader)")
+	}
+	return false, nil
+}
+
+// setFieldValue sets a field's value from form string values.
+func setFieldValue(field reflect.Value, values []string) error {
+	switch field.Kind() {
+	case reflect.String:
+		field.SetString(values[0])
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		val, err := strconv.ParseInt(values[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid integer: %s", values[0])
+		}
+		field.SetInt(val)
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		val, err := strconv.ParseUint(values[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid unsigned integer: %s", values[0])
+		}
+		field.SetUint(val)
+
+	case reflect.Float32, reflect.Float64:
+		val, err := strconv.ParseFloat(values[0], 64)
+		if err != nil {
+			return fmt.Errorf("invalid float: %s", values[0])
+		}
+		field.SetFloat(val)
+
+	case reflect.Bool:
+		val, err := strconv.ParseBool(values[0])
+		if err != nil {
+			return fmt.Errorf("invalid boolean: %s", values[0])
+		}
+		field.SetBool(val)
+
+	case reflect.Slice:
+		return setSliceValue(field, values)
+
+	case reflect.Ptr:
+		if field.IsNil() {
+			field.Set(reflect.New(field.Type().Elem()))
+		}
+		return setFieldValue(field.Elem(), values)
+
+	default:
+		return fmt.Errorf("unsupported field type: %s", field.Kind())
+	}
+
+	return nil
+}
+
+// setSliceValue sets a slice field's value.
+func setSliceValue(field reflect.Value, values []string) error {
+	slice := reflect.MakeSlice(field.Type(), len(values), len(values))
+
+	for i, v := range values {
+		elem := slice.Index(i)
+		if err := setFieldValue(elem, []string{v}); err != nil {
+			return fmt.Errorf("slice element %d: %w", i, err)
+		}
+	}
+
+	field.Set(slice)
+	return nil
+}
+
+// camelToSnake converts CamelCase to snake_case.
+func camelToSnake(s string) string {
+	var result strings.Builder
+	for i, r := range s {
+		if i > 0 && r >= 'A' && r <= 'Z' {
+			result.WriteByte('_')
+		}
+		result.WriteRune(r)
+	}
+	return strings.ToLower(result.String())
+}
+
+// BindMultipartFormFiles binds file uploads to struct fields after the main form binding.
+// This is called internally by handler logic when processing multipart forms.
+// Exported for advanced use cases.
+func BindMultipartFormFiles(r *http.Request, dst any) error {
+	if r.MultipartForm == nil {
+		return nil
+	}
+
+	v := reflect.ValueOf(dst)
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return fmt.Errorf("destination must be a non-nil pointer")
+	}
+
+	v = v.Elem()
+	if v.Kind() != reflect.Struct {
+		return fmt.Errorf("destination must be a pointer to a struct")
+	}
+
+	return bindFilesToStruct(v, r.MultipartForm.File)
+}
+
+// bindFilesToStruct recursively binds multipart files to struct fields.
+func bindFilesToStruct(v reflect.Value, files map[string][]*multipart.FileHeader) error {
+	t := v.Type()
+
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		fieldType := t.Field(i)
+
+		if !field.CanSet() {
+			continue
+		}
+
+		// Handle embedded structs
+		if fieldType.Anonymous && field.Kind() == reflect.Struct {
+			if err := bindFilesToStruct(field, files); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// Get form tag
+		tag := fieldType.Tag.Get("form")
+		if tag == "-" || tag == "" {
+			tag = camelToSnake(fieldType.Name)
+		}
+
+		// Check for files with this field name
+		fileHeaders, exists := files[tag]
+		if !exists {
+			continue
+		}
+
+		// Bind based on field type
+		switch field.Type() {
+		case reflect.TypeOf(&FileHeader{}):
+			if len(fileHeaders) > 0 {
+				fh := fileHeaders[0]
+				file, err := fh.Open()
+				if err != nil {
+					return fmt.Errorf("open file %s: %w", fh.Filename, err)
+				}
+				field.Set(reflect.ValueOf(&FileHeader{
+					Filename: fh.Filename,
+					Size:     fh.Size,
+					Header:   fh.Header,
+					file:     file,
+				}))
+			}
+
+		case reflect.TypeOf([]*FileHeader{}):
+			fileList := make([]*FileHeader, len(fileHeaders))
+			for j, fh := range fileHeaders {
+				file, err := fh.Open()
+				if err != nil {
+					return fmt.Errorf("open file %s: %w", fh.Filename, err)
+				}
+				fileList[j] = &FileHeader{
+					Filename: fh.Filename,
+					Size:     fh.Size,
+					Header:   fh.Header,
+					file:     file,
+				}
+			}
+			field.Set(reflect.ValueOf(fileList))
+		}
+	}
+
+	return nil
 }

--- a/bind_test.go
+++ b/bind_test.go
@@ -1,6 +1,12 @@
 package zerohttp
 
 import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -76,4 +82,554 @@ func TestBinder_JSON(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBinder_Form(t *testing.T) {
+	tests := []struct {
+		name      string
+		formData  url.Values
+		wantError bool
+		expected  func(t *testing.T, result *testFormStruct)
+	}{
+		{
+			name: "basic fields",
+			formData: url.Values{
+				"name":  []string{"John"},
+				"email": []string{"john@example.com"},
+			},
+			wantError: false,
+			expected: func(t *testing.T, result *testFormStruct) {
+				if result.Name != "John" {
+					t.Errorf("expected Name='John', got %q", result.Name)
+				}
+				if result.Email != "john@example.com" {
+					t.Errorf("expected Email='john@example.com', got %q", result.Email)
+				}
+			},
+		},
+		{
+			name: "numeric fields",
+			formData: url.Values{
+				"age":    []string{"30"},
+				"score":  []string{"95.5"},
+				"count":  []string{"100"},
+				"active": []string{"true"},
+			},
+			wantError: false,
+			expected: func(t *testing.T, result *testFormStruct) {
+				if result.Age != 30 {
+					t.Errorf("expected Age=30, got %d", result.Age)
+				}
+				if result.Score != 95.5 {
+					t.Errorf("expected Score=95.5, got %f", result.Score)
+				}
+				if result.Count != 100 {
+					t.Errorf("expected Count=100, got %d", result.Count)
+				}
+				if !result.Active {
+					t.Errorf("expected Active=true, got %v", result.Active)
+				}
+			},
+		},
+		{
+			name: "slice fields",
+			formData: url.Values{
+				"tags": []string{"go", "web", "api"},
+			},
+			wantError: false,
+			expected: func(t *testing.T, result *testFormStruct) {
+				expected := []string{"go", "web", "api"}
+				if len(result.Tags) != len(expected) {
+					t.Errorf("expected %d tags, got %d", len(expected), len(result.Tags))
+					return
+				}
+				for i, tag := range result.Tags {
+					if tag != expected[i] {
+						t.Errorf("expected tag[%d]=%q, got %q", i, expected[i], tag)
+					}
+				}
+			},
+		},
+		{
+			name: "custom tag names",
+			formData: url.Values{
+				"user_name": []string{"johndoe"},
+			},
+			wantError: false,
+			expected: func(t *testing.T, result *testFormStruct) {
+				if result.Username != "johndoe" {
+					t.Errorf("expected Username='johndoe', got %q", result.Username)
+				}
+			},
+		},
+		{
+			name: "ignored field",
+			formData: url.Values{
+				"ignored": []string{"should not be set"},
+			},
+			wantError: false,
+			expected: func(t *testing.T, result *testFormStruct) {
+				if result.Ignored != "" {
+					t.Errorf("expected Ignored to be empty, got %q", result.Ignored)
+				}
+			},
+		},
+		{
+			name:      "empty form",
+			formData:  url.Values{},
+			wantError: false,
+			expected: func(t *testing.T, result *testFormStruct) {
+				// All fields should remain at zero values
+				if result.Name != "" {
+					t.Errorf("expected empty Name, got %q", result.Name)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(tt.formData.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+			var result testFormStruct
+			err := B.Form(req, &result)
+
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			tt.expected(t, &result)
+		})
+	}
+}
+
+func TestBinder_Form_Errors(t *testing.T) {
+	tests := []struct {
+		name     string
+		formData url.Values
+		errMsg   string
+	}{
+		{
+			name:     "invalid integer",
+			formData: url.Values{"age": []string{"not a number"}},
+			errMsg:   "invalid integer",
+		},
+		{
+			name:     "invalid float",
+			formData: url.Values{"score": []string{"not a float"}},
+			errMsg:   "invalid float",
+		},
+		{
+			name:     "invalid boolean",
+			formData: url.Values{"active": []string{"not a bool"}},
+			errMsg:   "invalid boolean",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(tt.formData.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+			var result testFormStruct
+			err := B.Form(req, &result)
+
+			if err == nil {
+				t.Fatal("expected error but got none")
+			}
+			if !strings.Contains(err.Error(), tt.errMsg) {
+				t.Errorf("expected error to contain %q, got %v", tt.errMsg, err)
+			}
+		})
+	}
+}
+
+func TestBinder_Form_InvalidDestination(t *testing.T) {
+	tests := []struct {
+		name string
+		dst  interface{}
+	}{
+		{
+			name: "nil pointer",
+			dst:  nil,
+		},
+		{
+			name: "non-pointer",
+			dst:  testFormStruct{},
+		},
+		{
+			name: "pointer to non-struct",
+			dst:  new(string),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("name=test"))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+			var err error
+			if tt.dst == nil {
+				err = bindValues(url.Values{"name": []string{"test"}}, tt.dst, false)
+			} else {
+				err = B.Form(req, tt.dst)
+			}
+
+			if err == nil {
+				t.Fatal("expected error but got none")
+			}
+		})
+	}
+}
+
+func TestBinder_MultipartForm(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupForm func(*multipart.Writer)
+		wantError bool
+		expected  func(t *testing.T, result *testMultipartStruct)
+	}{
+		{
+			name: "form values only",
+			setupForm: func(w *multipart.Writer) {
+				_ = w.WriteField("name", "John")
+				_ = w.WriteField("age", "30")
+			},
+			wantError: false,
+			expected: func(t *testing.T, result *testMultipartStruct) {
+				if result.Name != "John" {
+					t.Errorf("expected Name='John', got %q", result.Name)
+				}
+				if result.Age != 30 {
+					t.Errorf("expected Age=30, got %d", result.Age)
+				}
+			},
+		},
+		{
+			name: "single file upload",
+			setupForm: func(w *multipart.Writer) {
+				_ = w.WriteField("name", "Test Upload")
+				fileWriter, _ := w.CreateFormFile("document", "test.txt")
+				_, _ = fileWriter.Write([]byte("Hello, World!"))
+			},
+			wantError: false,
+			expected: func(t *testing.T, result *testMultipartStruct) {
+				if result.Document == nil {
+					t.Fatal("expected Document to be set")
+				}
+				if result.Document.Filename != "test.txt" {
+					t.Errorf("expected Filename='test.txt', got %q", result.Document.Filename)
+				}
+				if result.Document.Size != 13 {
+					t.Errorf("expected Size=13, got %d", result.Document.Size)
+				}
+			},
+		},
+		{
+			name: "multiple file uploads",
+			setupForm: func(w *multipart.Writer) {
+				for i := 0; i < 3; i++ {
+					fileWriter, _ := w.CreateFormFile("attachments", "file"+string(rune('0'+i))+".txt")
+					_, _ = fileWriter.Write([]byte("content" + string(rune('0'+i))))
+				}
+			},
+			wantError: false,
+			expected: func(t *testing.T, result *testMultipartStruct) {
+				if len(result.Attachments) != 3 {
+					t.Errorf("expected 3 attachments, got %d", len(result.Attachments))
+					return
+				}
+				expectedNames := []string{"file0.txt", "file1.txt", "file2.txt"}
+				for i, fh := range result.Attachments {
+					if fh.Filename != expectedNames[i] {
+						t.Errorf("expected attachment[%d].Filename=%q, got %q", i, expectedNames[i], fh.Filename)
+					}
+				}
+			},
+		},
+		{
+			name: "files and values together",
+			setupForm: func(w *multipart.Writer) {
+				_ = w.WriteField("name", "Mixed Content")
+				_ = w.WriteField("age", "25")
+				fileWriter, _ := w.CreateFormFile("document", "mixed.txt")
+				_, _ = fileWriter.Write([]byte("Mixed"))
+			},
+			wantError: false,
+			expected: func(t *testing.T, result *testMultipartStruct) {
+				if result.Name != "Mixed Content" {
+					t.Errorf("expected Name='Mixed Content', got %q", result.Name)
+				}
+				if result.Age != 25 {
+					t.Errorf("expected Age=25, got %d", result.Age)
+				}
+				if result.Document == nil {
+					t.Fatal("expected Document to be set")
+				}
+				if result.Document.Filename != "mixed.txt" {
+					t.Errorf("expected Filename='mixed.txt', got %q", result.Document.Filename)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var body bytes.Buffer
+			writer := multipart.NewWriter(&body)
+			tt.setupForm(writer)
+			_ = writer.Close()
+
+			req := httptest.NewRequest(http.MethodPost, "/", &body)
+			req.Header.Set("Content-Type", writer.FormDataContentType())
+
+			var result testMultipartStruct
+			err := B.MultipartForm(req, &result, 32<<20)
+
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			tt.expected(t, &result)
+
+			// Cleanup: close any open file handles
+			if result.Document != nil && result.Document.file != nil {
+				_ = result.Document.file.Close()
+			}
+			for _, fh := range result.Attachments {
+				if fh != nil && fh.file != nil {
+					_ = fh.file.Close()
+				}
+			}
+		})
+	}
+}
+
+func TestFileHeader_Open(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	fileWriter, _ := writer.CreateFormFile("test", "hello.txt")
+	_, _ = fileWriter.Write([]byte("Hello"))
+	_ = writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	if err := req.ParseMultipartForm(32 << 20); err != nil {
+		t.Fatalf("failed to parse multipart form: %v", err)
+	}
+
+	fileHeaders := req.MultipartForm.File["test"]
+	if len(fileHeaders) == 0 {
+		t.Fatal("no files found")
+	}
+
+	file, err := fileHeaders[0].Open()
+	if err != nil {
+		t.Fatalf("failed to open file: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+
+	if string(content) != "Hello" {
+		t.Errorf("expected content 'Hello', got %q", string(content))
+	}
+}
+
+func TestFileHeader_ReadAll(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	fileWriter, _ := writer.CreateFormFile("test", "hello.txt")
+	_, _ = fileWriter.Write([]byte("Hello, World!"))
+	_ = writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	var result struct {
+		File *FileHeader `form:"test"`
+	}
+
+	err := B.MultipartForm(req, &result, 32<<20)
+	if err != nil {
+		t.Fatalf("failed to bind multipart form: %v", err)
+	}
+
+	if result.File == nil {
+		t.Fatal("expected File to be set")
+	}
+
+	content, err := result.File.ReadAll()
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+
+	if string(content) != "Hello, World!" {
+		t.Errorf("expected content 'Hello, World!', got %q", string(content))
+	}
+}
+
+func TestFileHeader_Open_AfterClose(t *testing.T) {
+	fh := &FileHeader{
+		Filename: "test.txt",
+		Size:     5,
+		file:     nil, // Simulate closed file
+	}
+
+	_, err := fh.Open()
+	if err == nil {
+		t.Fatal("expected error when opening closed file")
+	}
+
+	if !strings.Contains(err.Error(), "no longer available") {
+		t.Errorf("expected 'no longer available' error, got %v", err)
+	}
+}
+
+func TestCamelToSnake(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"Name", "name"},
+		{"UserName", "user_name"},
+		{"EmailAddress", "email_address"},
+		{"ID", "i_d"},
+		{"Simple", "simple"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := camelToSnake(tt.input)
+			if result != tt.expected {
+				t.Errorf("camelToSnake(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBindValues_EmbeddedStruct(t *testing.T) {
+	type Embedded struct {
+		Name string `form:"name"`
+	}
+
+	type Container struct {
+		Embedded
+		Email string `form:"email"`
+	}
+
+	values := url.Values{
+		"name":  []string{"John"},
+		"email": []string{"john@example.com"},
+	}
+
+	var result Container
+	err := bindValues(values, &result, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Name != "John" {
+		t.Errorf("expected Name='John', got %q", result.Name)
+	}
+	if result.Email != "john@example.com" {
+		t.Errorf("expected Email='john@example.com', got %q", result.Email)
+	}
+}
+
+func TestBindValues_PointerFields(t *testing.T) {
+	type WithPointers struct {
+		Name  *string  `form:"name"`
+		Age   *int     `form:"age"`
+		Score *float64 `form:"score"`
+	}
+
+	values := url.Values{
+		"name":  []string{"John"},
+		"age":   []string{"30"},
+		"score": []string{"95.5"},
+	}
+
+	var result WithPointers
+	err := bindValues(values, &result, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Name == nil || *result.Name != "John" {
+		t.Errorf("expected Name='John', got %v", result.Name)
+	}
+	if result.Age == nil || *result.Age != 30 {
+		t.Errorf("expected Age=30, got %v", result.Age)
+	}
+	if result.Score == nil || *result.Score != 95.5 {
+		t.Errorf("expected Score=95.5, got %v", result.Score)
+	}
+}
+
+func TestBindValues_IntSlice(t *testing.T) {
+	type WithIntSlice struct {
+		IDs []int `form:"ids"`
+	}
+
+	values := url.Values{
+		"ids": []string{"1", "2", "3"},
+	}
+
+	var result WithIntSlice
+	err := bindValues(values, &result, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := []int{1, 2, 3}
+	if len(result.IDs) != len(expected) {
+		t.Fatalf("expected %d IDs, got %d", len(expected), len(result.IDs))
+	}
+
+	for i, id := range result.IDs {
+		if id != expected[i] {
+			t.Errorf("expected IDs[%d]=%d, got %d", i, expected[i], id)
+		}
+	}
+}
+
+// Test struct types
+type testFormStruct struct {
+	Name     string   `form:"name"`
+	Email    string   `form:"email"`
+	Age      int      `form:"age"`
+	Score    float64  `form:"score"`
+	Count    uint     `form:"count"`
+	Active   bool     `form:"active"`
+	Tags     []string `form:"tags"`
+	Username string   `form:"user_name"`
+	Ignored  string   `form:"-"`
+}
+
+type testMultipartStruct struct {
+	Name        string        `form:"name"`
+	Age         int           `form:"age"`
+	Document    *FileHeader   `form:"document"`
+	Attachments []*FileHeader `form:"attachments"`
 }

--- a/examples/file_upload/main.go
+++ b/examples/file_upload/main.go
@@ -19,6 +19,12 @@ const (
 	maxFormSize = 32 << 20 // 32 MB total
 )
 
+// UploadForm represents the multipart form structure
+type UploadForm struct {
+	Description string           `form:"description"`
+	Files       []*zh.FileHeader `form:"files"`
+}
+
 func main() {
 	app := zh.New(
 		config.WithRequestBodySizeOptions(
@@ -53,23 +59,30 @@ func uploadFormHandler(w http.ResponseWriter, r *http.Request) error {
 }
 
 func uploadHandler(w http.ResponseWriter, r *http.Request) error {
-	if err := r.ParseMultipartForm(maxFormSize); err != nil {
+	var form UploadForm
+
+	// Use the new Bind.MultipartForm method
+	if err := zh.B.MultipartForm(r, &form, maxFormSize); err != nil {
 		problem := zh.NewProblemDetail(400, "Failed to parse form")
 		problem.Set("error", err.Error())
 		return problem.Render(w)
 	}
 
-	description := r.FormValue("description")
-	files := r.MultipartForm.File["files"]
-
-	if len(files) == 0 {
+	if len(form.Files) == 0 {
 		return zh.NewProblemDetail(400, "No files uploaded").Render(w)
 	}
 
 	var uploadedFiles []zh.M
 	var errors []string
 
-	for _, fileHeader := range files {
+	for _, fileHeader := range form.Files {
+		// Check file size
+		if fileHeader.Size > maxFileSize {
+			errors = append(errors, fmt.Sprintf("%s: file too large", fileHeader.Filename))
+			continue
+		}
+
+		// Open the file using FileHeader.Open()
 		file, err := fileHeader.Open()
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("%s: %v", fileHeader.Filename, err))
@@ -78,17 +91,7 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) error {
 
 		// Use anonymous function to handle defer properly in loop
 		func() {
-			defer func() {
-				if err := file.Close(); err != nil {
-					errors = append(errors, fmt.Sprintf("%s: failed to close - %v", fileHeader.Filename, err))
-				}
-			}()
-
-			// Check file size
-			if fileHeader.Size > maxFileSize {
-				errors = append(errors, fmt.Sprintf("%s: file too large", fileHeader.Filename))
-				return
-			}
+			defer func() { _ = file.Close() }()
 
 			filename := fmt.Sprintf("%d_%s", time.Now().UnixNano(), fileHeader.Filename)
 			destPath := filepath.Join(uploadDir, filename)
@@ -101,19 +104,19 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) error {
 
 			_, err = io.Copy(dest, file)
 			if err != nil {
-				_ = dest.Close()        // Try to close before cleanup
-				_ = os.Remove(destPath) // Remove failed upload
+				_ = dest.Close()
+				_ = os.Remove(destPath)
 				errors = append(errors, fmt.Sprintf("%s: copy failed", fileHeader.Filename))
 				return
 			}
 
 			if err := dest.Close(); err != nil {
-				_ = os.Remove(destPath) // Remove on close failure
+				_ = os.Remove(destPath)
 				errors = append(errors, fmt.Sprintf("%s: failed to close destination - %v", fileHeader.Filename, err))
 				return
 			}
 
-			// Success - file saved successfully, add to results
+			// Success - file saved successfully
 			uploadedFiles = append(uploadedFiles, zh.M{
 				"filename":     filename,
 				"original":     fileHeader.Filename,
@@ -124,9 +127,9 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	response := zh.M{
-		"message":     fmt.Sprintf("Uploaded %d of %d files", len(uploadedFiles), len(files)),
+		"message":     fmt.Sprintf("Uploaded %d of %d files", len(uploadedFiles), len(form.Files)),
 		"files":       uploadedFiles,
-		"description": description,
+		"description": form.Description,
 	}
 
 	if len(errors) > 0 {

--- a/examples/form_binding/main.go
+++ b/examples/form_binding/main.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	zh "github.com/alexferl/zerohttp"
+)
+
+// LoginForm demonstrates simple form binding with basic types
+type LoginForm struct {
+	Username string `form:"username"`
+	Password string `form:"password"`
+	Remember bool   `form:"remember"`
+}
+
+// SearchForm demonstrates query parameter binding and slices
+type SearchForm struct {
+	Query    string   `form:"q"`
+	Category string   `form:"category"`
+	Tags     []string `form:"tags"`
+	Page     int      `form:"page"`
+	Limit    int      `form:"limit"`
+}
+
+// ContactForm demonstrates multipart form with mixed data
+type ContactForm struct {
+	Name    string         `form:"name"`
+	Email   string         `form:"email"`
+	Subject string         `form:"subject"`
+	Message string         `form:"message"`
+	Avatar  *zh.FileHeader `form:"avatar"`
+}
+
+// UploadForm demonstrates multiple file uploads
+type UploadForm struct {
+	Description string           `form:"description"`
+	Documents   []*zh.FileHeader `form:"documents"`
+}
+
+func main() {
+	app := zh.New()
+
+	// Routes
+	app.GET("/", zh.HandlerFunc(indexHandler))
+	app.POST("/login", zh.HandlerFunc(loginHandler))
+	app.GET("/search", zh.HandlerFunc(searchHandler))
+	app.GET("/contact", zh.HandlerFunc(contactFormHandler))
+	app.POST("/contact", zh.HandlerFunc(contactHandler))
+	app.GET("/upload", zh.HandlerFunc(uploadFormHandler))
+	app.POST("/upload", zh.HandlerFunc(uploadHandler))
+
+	log.Println("Server starting on :8080")
+	log.Println("Try these endpoints:")
+	log.Println("  GET  /          - Overview")
+	log.Println("  POST /login     - Form binding (application/x-www-form-urlencoded)")
+	log.Println("  GET  /search    - Query binding with slices")
+	log.Println("  GET  /contact   - Multipart form page")
+	log.Println("  POST /contact   - Multipart form with single file")
+	log.Println("  GET  /upload    - Multiple file upload page")
+	log.Println("  POST /upload    - Multipart form with multiple files")
+	log.Fatal(app.Start())
+}
+
+func indexHandler(w http.ResponseWriter, r *http.Request) error {
+	html := `<!DOCTYPE html>
+<html>
+<head>
+    <title>Form Binding Examples</title>
+    <style>
+        body { font-family: sans-serif; max-width: 800px; margin: 40px auto; padding: 20px; }
+        h1 { color: #333; }
+        h2 { color: #555; margin-top: 30px; }
+        code { background: #f4f4f4; padding: 2px 6px; border-radius: 3px; }
+        pre { background: #f4f4f4; padding: 15px; border-radius: 5px; overflow-x: auto; }
+        .endpoint { margin: 20px 0; padding: 15px; background: #f9f9f9; border-left: 4px solid #007bff; }
+        .method { font-weight: bold; color: #007bff; }
+    </style>
+</head>
+<body>
+    <h1>Form/Multipart Binding Examples</h1>
+    <p>This example demonstrates zerohttp's form binding capabilities using <code>Bind.Form()</code> and <code>Bind.MultipartForm()</code>.</p>
+
+    <h2>Available Endpoints</h2>
+
+    <div class="endpoint">
+        <span class="method">POST</span> <code>/login</code>
+        <p>Simple form binding with basic types (string, bool).</p>
+        <pre>curl -X POST http://localhost:8080/login \
+  -d "username=johndoe" \
+  -d "password=secret" \
+  -d "remember=true"</pre>
+    </div>
+
+    <div class="endpoint">
+        <span class="method">GET</span> <code>/search</code>
+        <p>Query parameter binding with slices.</p>
+        <pre>curl "http://localhost:8080/search?q=golang&category=tech&tags=api&tags=web&page=1&limit=10"</pre>
+    </div>
+
+    <div class="endpoint">
+        <span class="method">GET/POST</span> <code>/contact</code>
+        <p>Multipart form with single file upload. Visit in browser or use:</p>
+        <pre>curl -X POST http://localhost:8080/contact \
+  -F "name=John Doe" \
+  -F "email=john@example.com" \
+  -F "subject=Hello" \
+  -F "message=This is a test" \
+  -F "avatar=@/path/to/avatar.png"</pre>
+    </div>
+
+    <div class="endpoint">
+        <span class="method">GET/POST</span> <code>/upload</code>
+        <p>Multiple file upload. Visit in browser or use:</p>
+        <pre>curl -X POST http://localhost:8080/upload \
+  -F "description=My documents" \
+  -F "documents=@file1.pdf" \
+  -F "documents=@file2.pdf" \
+  -F "documents=@file3.pdf"</pre>
+    </div>
+
+    <h2>Features Demonstrated</h2>
+    <ul>
+        <li><strong>Bind.Form()</strong> - <code>application/x-www-form-urlencoded</code> parsing</li>
+        <li><strong>Bind.MultipartForm()</strong> - <code>multipart/form-data</code> with file uploads</li>
+        <li><strong>Struct tags</strong> - <code>form:"fieldname"</code> for custom field names</li>
+        <li><strong>Type conversion</strong> - Automatic string to int, bool, float conversion</li>
+        <li><strong>Slice binding</strong> - Multiple values with same field name</li>
+        <li><strong>File uploads</strong> - Single and multiple file handling</li>
+    </ul>
+</body>
+</html>`
+	return zh.R.HTML(w, http.StatusOK, html)
+}
+
+func loginHandler(w http.ResponseWriter, r *http.Request) error {
+	var form LoginForm
+	if err := zh.B.Form(r, &form); err != nil {
+		return zh.NewProblemDetail(http.StatusBadRequest, err.Error()).Render(w)
+	}
+
+	// In a real app, you'd validate credentials here
+	return zh.R.JSON(w, http.StatusOK, zh.M{
+		"message":  "Login form received",
+		"username": form.Username,
+		"remember": form.Remember,
+		"note":     "Password would be validated in production",
+	})
+}
+
+func searchHandler(w http.ResponseWriter, r *http.Request) error {
+	var form SearchForm
+	// Form() parses both POST body and query string
+	if err := zh.B.Form(r, &form); err != nil {
+		return zh.NewProblemDetail(http.StatusBadRequest, err.Error()).Render(w)
+	}
+
+	// Set defaults
+	if form.Page < 1 {
+		form.Page = 1
+	}
+	if form.Limit < 1 {
+		form.Limit = 20
+	}
+
+	return zh.R.JSON(w, http.StatusOK, zh.M{
+		"query":    form.Query,
+		"category": form.Category,
+		"tags":     form.Tags,
+		"page":     form.Page,
+		"limit":    form.Limit,
+	})
+}
+
+func contactFormHandler(w http.ResponseWriter, r *http.Request) error {
+	html := `<!DOCTYPE html>
+<html>
+<head>
+    <title>Contact Form</title>
+    <style>
+        body { font-family: sans-serif; max-width: 600px; margin: 40px auto; padding: 20px; }
+        label { display: block; margin: 15px 0 5px; }
+        input, textarea { width: 100%; padding: 8px; box-sizing: border-box; }
+        button { margin-top: 20px; padding: 10px 20px; }
+    </style>
+</head>
+<body>
+    <h1>Contact Form</h1>
+    <form method="POST" enctype="multipart/form-data">
+        <label>Name: <input type="text" name="name" required></label>
+        <label>Email: <input type="email" name="email" required></label>
+        <label>Subject: <input type="text" name="subject" required></label>
+        <label>Message: <textarea name="message" rows="5" required></textarea></label>
+        <label>Avatar: <input type="file" name="avatar" accept="image/*"></label>
+        <button type="submit">Submit</button>
+    </form>
+</body>
+</html>`
+	return zh.R.HTML(w, http.StatusOK, html)
+}
+
+func contactHandler(w http.ResponseWriter, r *http.Request) error {
+	var form ContactForm
+	if err := zh.B.MultipartForm(r, &form, 32<<20); err != nil {
+		return zh.NewProblemDetail(http.StatusBadRequest, err.Error()).Render(w)
+	}
+
+	response := zh.M{
+		"message": "Contact form received",
+		"data": zh.M{
+			"name":    form.Name,
+			"email":   form.Email,
+			"subject": form.Subject,
+			"message": form.Message,
+		},
+	}
+
+	// Handle optional file upload
+	if form.Avatar != nil {
+		response["avatar"] = zh.M{
+			"filename": form.Avatar.Filename,
+			"size":     form.Avatar.Size,
+			"header":   form.Avatar.Header,
+		}
+
+		// Example: Read file content (in production, save to disk or cloud storage)
+		content, err := form.Avatar.ReadAll()
+		if err == nil {
+			response["avatar"].(zh.M)["content_length"] = len(content)
+		}
+	}
+
+	return zh.R.JSON(w, http.StatusOK, response)
+}
+
+func uploadFormHandler(w http.ResponseWriter, r *http.Request) error {
+	html := `<!DOCTYPE html>
+<html>
+<head>
+    <title>Multi-File Upload</title>
+    <style>
+        body { font-family: sans-serif; max-width: 600px; margin: 40px auto; padding: 20px; }
+        label { display: block; margin: 15px 0 5px; }
+        input, textarea { width: 100%; padding: 8px; box-sizing: border-box; }
+        button { margin-top: 20px; padding: 10px 20px; }
+    </style>
+</head>
+<body>
+    <h1>Multi-File Upload</h1>
+    <form method="POST" enctype="multipart/form-data">
+        <label>Description: <textarea name="description" rows="3"></textarea></label>
+        <label>Documents: <input type="file" name="documents" multiple></label>
+        <button type="submit">Upload</button>
+    </form>
+</body>
+</html>`
+	return zh.R.HTML(w, http.StatusOK, html)
+}
+
+func uploadHandler(w http.ResponseWriter, r *http.Request) error {
+	var form UploadForm
+	if err := zh.B.MultipartForm(r, &form, 32<<20); err != nil {
+		return zh.NewProblemDetail(http.StatusBadRequest, err.Error()).Render(w)
+	}
+
+	files := make([]zh.M, len(form.Documents))
+	for i, doc := range form.Documents {
+		files[i] = zh.M{
+			"filename": doc.Filename,
+			"size":     doc.Size,
+			"header":   doc.Header,
+		}
+	}
+
+	return zh.R.JSON(w, http.StatusOK, zh.M{
+		"message":     fmt.Sprintf("Received %d file(s)", len(form.Documents)),
+		"description": form.Description,
+		"files":       files,
+	})
+}


### PR DESCRIPTION
Add Bind.Form() for application/x-www-form-urlencoded data and Bind.MultipartForm() for multipart/form-data including file uploads. Supports struct tags, automatic type conversion, slices, and embedded structs. Includes FileHeader type for accessing uploaded files.

- Update README with form binding documentation
- Add comprehensive tests
- Update file_upload example to use new API
- Add form_binding example demonstrating all features