### PR TITLE
feat: add path parameter extraction helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A lightweight HTTP framework for Go built on top of the standard `net/http` libr
 - [Request Binding](#request-binding)
 - [Middleware](#middleware)
 - [Route Groups](#route-groups)
+- [Path Parameters](#path-parameters)
 - [Static File Serving](#static-file-serving)
     - [Static File Methods](#static-file-methods)
 - [Error Handling](#error-handling)
@@ -281,6 +282,50 @@ app.Group(func(api zh.Router) {
     api.DELETE("/users/{id}", deleteUser)
 })
 ```
+
+
+## Path Parameters
+
+Type-safe path parameter extraction with generic support:
+
+```go
+// Basic string extraction
+app.GET("/users/{id}", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+    id := zh.Param(r, "id")  // Returns string
+    return zh.R.JSON(w, 200, zh.M{"user_id": id})
+}))
+
+// Typed extraction with error handling
+app.GET("/items/{itemID}", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+    itemID, err := zh.ParamAs[int](r, "itemID")
+    if err != nil {
+        return zh.R.ProblemDetail(w, zh.NewProblemDetail(400, "Invalid itemID"))
+    }
+    return zh.R.JSON(w, 200, zh.M{"item_id": itemID})
+}))
+
+// Multiple parameters
+app.GET("/users/{userID}/posts/{postID}", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+    userID, _ := zh.ParamAs[int](r, "userID")
+    postID, _ := zh.ParamAs[int](r, "postID")
+    return zh.R.JSON(w, 200, zh.M{"user_id": userID, "post_id": postID})
+}))
+
+// With default value (returns default if param missing or invalid)
+app.GET("/products/{category}", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+    category := zh.ParamOrDefault(r, "category", "all")
+    return zh.R.JSON(w, 200, zh.M{"category": category})
+}))
+```
+
+**Available Functions:**
+
+- `Param(r, "name")` - Extract parameter as string
+- `ParamAs[T](r, "name")` - Extract and convert to type T (int, int64, uint, float64, bool, etc.)
+- `ParamAsOrDefault[T](r, "name", defaultVal)` - Extract with fallback value
+- `ParamOrDefault(r, "name", "default")` - String extraction with fallback
+
+**Supported Types:** `string`, `int`, `int8`, `int16`, `int32`, `int64`, `uint`, `uint8`, `uint16`, `uint32`, `uint64`, `float32`, `float64`, `bool`
 
 
 ## Static File Serving

--- a/examples/params/main.go
+++ b/examples/params/main.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	zh "github.com/alexferl/zerohttp"
+)
+
+func main() {
+	app := zh.New()
+
+	// Basic string extraction
+	app.GET("/users/{id}", zh.HandlerFunc(getUser))
+
+	// Multiple parameters
+	app.GET("/users/{userID}/posts/{postID}", zh.HandlerFunc(getUserPost))
+
+	// Numeric IDs with type conversion
+	app.GET("/items/{itemID}", zh.HandlerFunc(getItem))
+
+	// Optional path parameter with default value
+	app.GET("/products/{$}", zh.HandlerFunc(listProducts))
+	app.GET("/products/{category}", zh.HandlerFunc(listProductsByCategory))
+
+	fmt.Println("Try these endpoints:")
+	fmt.Println("  GET /users/123                      - String param extraction")
+	fmt.Println("  GET /users/42/posts/99              - Multiple params")
+	fmt.Println("  GET /items/456                      - Typed int extraction")
+	fmt.Println("  GET /products                       - All products")
+	fmt.Println("  GET /products/electronics           - Filtered by category")
+
+	log.Fatal(app.Start())
+}
+
+// getUser demonstrates basic string parameter extraction
+func getUser(w http.ResponseWriter, r *http.Request) error {
+	// Simple string extraction
+	id := zh.Param(r, "id")
+
+	return zh.R.JSON(w, 200, zh.M{
+		"user_id": id,
+		"type":    "string",
+	})
+}
+
+// getUserPost demonstrates extracting multiple path parameters
+func getUserPost(w http.ResponseWriter, r *http.Request) error {
+	// Extract both parameters as typed ints
+	userID, err := zh.ParamAs[int](r, "userID")
+	if err != nil {
+		return zh.R.ProblemDetail(w, zh.NewProblemDetail(400, "Invalid userID"))
+	}
+
+	postID, err := zh.ParamAs[int](r, "postID")
+	if err != nil {
+		return zh.R.ProblemDetail(w, zh.NewProblemDetail(400, "Invalid postID"))
+	}
+
+	return zh.R.JSON(w, 200, zh.M{
+		"user_id": userID,
+		"post_id": postID,
+		"message": fmt.Sprintf("Fetched post %d for user %d", postID, userID),
+	})
+}
+
+// getItem demonstrates typed parameter extraction with error handling
+func getItem(w http.ResponseWriter, r *http.Request) error {
+	itemID, err := zh.ParamAs[int](r, "itemID")
+	if err != nil {
+		return zh.R.ProblemDetail(w, zh.NewProblemDetail(400, "Invalid itemID"))
+	}
+
+	return zh.R.JSON(w, 200, zh.M{
+		"item_id": itemID,
+		"found":   true,
+	})
+}
+
+// listProducts demonstrates listing all products (no path params)
+func listProducts(w http.ResponseWriter, r *http.Request) error {
+	// Parse query params for pagination
+	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+	if page < 1 {
+		page = 1
+	}
+
+	return zh.R.JSON(w, 200, zh.M{
+		"category": "all",
+		"page":     page,
+		"products": []string{"Product A", "Product B"},
+	})
+}
+
+// listProductsByCategory demonstrates ParamOrDefault for optional filtering
+func listProductsByCategory(w http.ResponseWriter, r *http.Request) error {
+	// Get category with default fallback
+	category := zh.ParamOrDefault(r, "category", "all")
+
+	return zh.R.JSON(w, 200, zh.M{
+		"category": category,
+		"products": []string{fmt.Sprintf("%s Item 1", category), fmt.Sprintf("%s Item 2", category)},
+	})
+}

--- a/params.go
+++ b/params.go
@@ -1,0 +1,168 @@
+package zerohttp
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+// Params is the default params extractor instance used by the package
+var Params = &defaultParamsExtractor{}
+
+// P is a short alias for Params for convenience
+var P = Params
+
+// ParamType is a type constraint for supported path parameter types.
+// Supported types: string, int, int8, int16, int32, int64,
+// uint, uint8, uint16, uint32, uint64, float32, float64, bool
+type ParamType interface {
+	~string | ~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 |
+		~float32 | ~float64 |
+		~bool
+}
+
+// ParamExtractor defines the interface for path parameter extraction
+type ParamExtractor interface {
+	// Param gets a path parameter by name as a string.
+	// Returns empty string if parameter is not found.
+	Param(r *http.Request, name string) string
+
+	// ParamOrDefault gets a path parameter with a fallback default value.
+	ParamOrDefault(r *http.Request, name, defaultVal string) string
+}
+
+// defaultParamsExtractor implements the ParamExtractor interface
+type defaultParamsExtractor struct{}
+
+// Param gets a path parameter by name as a string.
+// Returns empty string if parameter is not found.
+func (p *defaultParamsExtractor) Param(r *http.Request, name string) string {
+	return r.PathValue(name)
+}
+
+// ParamOrDefault gets a path parameter with a fallback default value.
+func (p *defaultParamsExtractor) ParamOrDefault(r *http.Request, name, defaultVal string) string {
+	val := r.PathValue(name)
+	if val == "" {
+		return defaultVal
+	}
+	return val
+}
+
+// ParamAs extracts and converts a path parameter to type T.
+// Returns an error if the parameter is missing or conversion fails.
+// Supported types: string, int, int8, int16, int32, int64,
+// uint, uint8, uint16, uint32, uint64, float32, float64, bool
+func ParamAs[T ParamType](r *http.Request, name string) (T, error) {
+	var zero T
+	val := r.PathValue(name)
+	if val == "" {
+		return zero, fmt.Errorf("parameter %q not found", name)
+	}
+
+	switch any(zero).(type) {
+	case string:
+		return any(val).(T), nil
+	case int:
+		n, err := strconv.Atoi(val)
+		if err != nil {
+			return zero, fmt.Errorf("parameter %q: invalid int: %w", name, err)
+		}
+		return any(n).(T), nil
+	case int8:
+		n, err := strconv.ParseInt(val, 10, 8)
+		if err != nil {
+			return zero, fmt.Errorf("parameter %q: invalid int8: %w", name, err)
+		}
+		return any(int8(n)).(T), nil
+	case int16:
+		n, err := strconv.ParseInt(val, 10, 16)
+		if err != nil {
+			return zero, fmt.Errorf("parameter %q: invalid int16: %w", name, err)
+		}
+		return any(int16(n)).(T), nil
+	case int32:
+		n, err := strconv.ParseInt(val, 10, 32)
+		if err != nil {
+			return zero, fmt.Errorf("parameter %q: invalid int32: %w", name, err)
+		}
+		return any(int32(n)).(T), nil
+	case int64:
+		n, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return zero, fmt.Errorf("parameter %q: invalid int64: %w", name, err)
+		}
+		return any(n).(T), nil
+	case uint:
+		n, err := strconv.ParseUint(val, 10, 0)
+		if err != nil {
+			return zero, fmt.Errorf("parameter %q: invalid uint: %w", name, err)
+		}
+		return any(uint(n)).(T), nil
+	case uint8:
+		n, err := strconv.ParseUint(val, 10, 8)
+		if err != nil {
+			return zero, fmt.Errorf("parameter %q: invalid uint8: %w", name, err)
+		}
+		return any(uint8(n)).(T), nil
+	case uint16:
+		n, err := strconv.ParseUint(val, 10, 16)
+		if err != nil {
+			return zero, fmt.Errorf("parameter %q: invalid uint16: %w", name, err)
+		}
+		return any(uint16(n)).(T), nil
+	case uint32:
+		n, err := strconv.ParseUint(val, 10, 32)
+		if err != nil {
+			return zero, fmt.Errorf("parameter %q: invalid uint32: %w", name, err)
+		}
+		return any(uint32(n)).(T), nil
+	case uint64:
+		n, err := strconv.ParseUint(val, 10, 64)
+		if err != nil {
+			return zero, fmt.Errorf("parameter %q: invalid uint64: %w", name, err)
+		}
+		return any(n).(T), nil
+	case float32:
+		n, err := strconv.ParseFloat(val, 32)
+		if err != nil {
+			return zero, fmt.Errorf("parameter %q: invalid float32: %w", name, err)
+		}
+		return any(float32(n)).(T), nil
+	case float64:
+		n, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			return zero, fmt.Errorf("parameter %q: invalid float64: %w", name, err)
+		}
+		return any(n).(T), nil
+	case bool:
+		n, err := strconv.ParseBool(val)
+		if err != nil {
+			return zero, fmt.Errorf("parameter %q: invalid bool: %w", name, err)
+		}
+		return any(n).(T), nil
+	default:
+		return zero, fmt.Errorf("parameter %q: unsupported type", name)
+	}
+}
+
+// ParamAsOrDefault extracts and converts a path parameter to type T,
+// returning a default value if the parameter is missing or conversion fails.
+func ParamAsOrDefault[T ParamType](r *http.Request, name string, defaultVal T) T {
+	val, err := ParamAs[T](r, name)
+	if err != nil {
+		return defaultVal
+	}
+	return val
+}
+
+// Param is a convenience function that calls Params.Param
+func Param(r *http.Request, name string) string {
+	return Params.Param(r, name)
+}
+
+// ParamOrDefault is a convenience function that calls Params.ParamOrDefault
+func ParamOrDefault(r *http.Request, name, defaultVal string) string {
+	return Params.ParamOrDefault(r, name, defaultVal)
+}

--- a/params.go
+++ b/params.go
@@ -9,9 +9,6 @@ import (
 // Params is the default params extractor instance used by the package
 var Params = &defaultParamsExtractor{}
 
-// P is a short alias for Params for convenience
-var P = Params
-
 // ParamType is a type constraint for supported path parameter types.
 // Supported types: string, int, int8, int16, int32, int64,
 // uint, uint8, uint16, uint32, uint64, float32, float64, bool

--- a/params.go
+++ b/params.go
@@ -56,7 +56,7 @@ func (p *defaultParamsExtractor) ParamOrDefault(r *http.Request, name, defaultVa
 // uint, uint8, uint16, uint32, uint64, float32, float64, bool
 func ParamAs[T ParamType](r *http.Request, name string) (T, error) {
 	var zero T
-	val := r.PathValue(name)
+	val := Params.Param(r, name)
 	if val == "" {
 		return zero, fmt.Errorf("parameter %q not found", name)
 	}

--- a/params_test.go
+++ b/params_test.go
@@ -630,22 +630,6 @@ func TestParamAs_InvalidValues(t *testing.T) {
 	}
 }
 
-func TestPAlias(t *testing.T) {
-	mux := http.NewServeMux()
-	var got string
-	mux.HandleFunc("/users/{id}", func(w http.ResponseWriter, r *http.Request) {
-		got = P.Param(r, "id")
-	})
-
-	req := httptest.NewRequest(http.MethodGet, "/users/123", nil)
-	rec := httptest.NewRecorder()
-	mux.ServeHTTP(rec, req)
-
-	if got != "123" {
-		t.Errorf("P.Param() = %q, want %q", got, "123")
-	}
-}
-
 func TestDefaultParamsExtractor(t *testing.T) {
 	t.Run("Param method", func(t *testing.T) {
 		mux := http.NewServeMux()

--- a/params_test.go
+++ b/params_test.go
@@ -385,6 +385,26 @@ func TestParamAs_Types(t *testing.T) {
 			},
 		},
 		{
+			name:      "int16 type",
+			pattern:   "/items/{id}",
+			path:      "/items/1000",
+			paramName: "id",
+			expected:  int16(1000),
+			fn: func(r *http.Request, n string) (any, error) {
+				return ParamAs[int16](r, n)
+			},
+		},
+		{
+			name:      "int32 type",
+			pattern:   "/items/{id}",
+			path:      "/items/100000",
+			paramName: "id",
+			expected:  int32(100000),
+			fn: func(r *http.Request, n string) (any, error) {
+				return ParamAs[int32](r, n)
+			},
+		},
+		{
 			name:      "uint type",
 			pattern:   "/items/{count}",
 			path:      "/items/50",
@@ -392,6 +412,46 @@ func TestParamAs_Types(t *testing.T) {
 			expected:  uint(50),
 			fn: func(r *http.Request, n string) (any, error) {
 				return ParamAs[uint](r, n)
+			},
+		},
+		{
+			name:      "uint8 type",
+			pattern:   "/items/{count}",
+			path:      "/items/200",
+			paramName: "count",
+			expected:  uint8(200),
+			fn: func(r *http.Request, n string) (any, error) {
+				return ParamAs[uint8](r, n)
+			},
+		},
+		{
+			name:      "uint16 type",
+			pattern:   "/items/{count}",
+			path:      "/items/5000",
+			paramName: "count",
+			expected:  uint16(5000),
+			fn: func(r *http.Request, n string) (any, error) {
+				return ParamAs[uint16](r, n)
+			},
+		},
+		{
+			name:      "uint32 type",
+			pattern:   "/items/{count}",
+			path:      "/items/100000",
+			paramName: "count",
+			expected:  uint32(100000),
+			fn: func(r *http.Request, n string) (any, error) {
+				return ParamAs[uint32](r, n)
+			},
+		},
+		{
+			name:      "uint64 type",
+			pattern:   "/items/{id}",
+			path:      "/items/9223372036854775807",
+			paramName: "id",
+			expected:  uint64(9223372036854775807),
+			fn: func(r *http.Request, n string) (any, error) {
+				return ParamAs[uint64](r, n)
 			},
 		},
 		{
@@ -428,4 +488,213 @@ func TestParamAs_Types(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParamAs_InvalidValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		wantErr string
+		fn      func(*http.Request) error
+	}{
+		{
+			name:    "invalid int8",
+			path:    "/val/999",
+			wantErr: `parameter "val": invalid int8`,
+			fn: func(r *http.Request) error {
+				_, err := ParamAs[int8](r, "val")
+				return err
+			},
+		},
+		{
+			name:    "invalid int16",
+			path:    "/val/99999",
+			wantErr: `parameter "val": invalid int16`,
+			fn: func(r *http.Request) error {
+				_, err := ParamAs[int16](r, "val")
+				return err
+			},
+		},
+		{
+			name:    "invalid int32",
+			path:    "/val/9999999999",
+			wantErr: `parameter "val": invalid int32`,
+			fn: func(r *http.Request) error {
+				_, err := ParamAs[int32](r, "val")
+				return err
+			},
+		},
+		{
+			name:    "invalid int64",
+			path:    "/val/9999999999999999999",
+			wantErr: `parameter "val": invalid int64`,
+			fn: func(r *http.Request) error {
+				_, err := ParamAs[int64](r, "val")
+				return err
+			},
+		},
+		{
+			name:    "invalid uint",
+			path:    "/val/abc",
+			wantErr: `parameter "val": invalid uint`,
+			fn: func(r *http.Request) error {
+				_, err := ParamAs[uint](r, "val")
+				return err
+			},
+		},
+		{
+			name:    "invalid uint8",
+			path:    "/val/999",
+			wantErr: `parameter "val": invalid uint8`,
+			fn: func(r *http.Request) error {
+				_, err := ParamAs[uint8](r, "val")
+				return err
+			},
+		},
+		{
+			name:    "invalid uint16",
+			path:    "/val/999999",
+			wantErr: `parameter "val": invalid uint16`,
+			fn: func(r *http.Request) error {
+				_, err := ParamAs[uint16](r, "val")
+				return err
+			},
+		},
+		{
+			name:    "invalid uint32",
+			path:    "/val/99999999999",
+			wantErr: `parameter "val": invalid uint32`,
+			fn: func(r *http.Request) error {
+				_, err := ParamAs[uint32](r, "val")
+				return err
+			},
+		},
+		{
+			name:    "invalid uint64",
+			path:    "/val/abc",
+			wantErr: `parameter "val": invalid uint64`,
+			fn: func(r *http.Request) error {
+				_, err := ParamAs[uint64](r, "val")
+				return err
+			},
+		},
+		{
+			name:    "invalid float32",
+			path:    "/val/abc",
+			wantErr: `parameter "val": invalid float32`,
+			fn: func(r *http.Request) error {
+				_, err := ParamAs[float32](r, "val")
+				return err
+			},
+		},
+		{
+			name:    "invalid float64",
+			path:    "/val/abc",
+			wantErr: `parameter "val": invalid float64`,
+			fn: func(r *http.Request) error {
+				_, err := ParamAs[float64](r, "val")
+				return err
+			},
+		},
+		{
+			name:    "invalid bool",
+			path:    "/val/maybe",
+			wantErr: `parameter "val": invalid bool`,
+			fn: func(r *http.Request) error {
+				_, err := ParamAs[bool](r, "val")
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			var gotErr error
+			mux.HandleFunc("/val/{val}", func(w http.ResponseWriter, r *http.Request) {
+				gotErr = tt.fn(r)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			if gotErr == nil {
+				t.Errorf("expected error, got nil")
+				return
+			}
+			if got := gotErr.Error(); got[:len(tt.wantErr)] != tt.wantErr {
+				t.Errorf("error = %q, want prefix %q", got, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPAlias(t *testing.T) {
+	mux := http.NewServeMux()
+	var got string
+	mux.HandleFunc("/users/{id}", func(w http.ResponseWriter, r *http.Request) {
+		got = P.Param(r, "id")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/users/123", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if got != "123" {
+		t.Errorf("P.Param() = %q, want %q", got, "123")
+	}
+}
+
+func TestDefaultParamsExtractor(t *testing.T) {
+	t.Run("Param method", func(t *testing.T) {
+		mux := http.NewServeMux()
+		extractor := &defaultParamsExtractor{}
+		var got string
+		mux.HandleFunc("/users/{id}", func(w http.ResponseWriter, r *http.Request) {
+			got = extractor.Param(r, "id")
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/users/456", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		if got != "456" {
+			t.Errorf("Param() = %q, want %q", got, "456")
+		}
+	})
+
+	t.Run("ParamOrDefault method with value", func(t *testing.T) {
+		mux := http.NewServeMux()
+		extractor := &defaultParamsExtractor{}
+		var got string
+		mux.HandleFunc("/users/{id}", func(w http.ResponseWriter, r *http.Request) {
+			got = extractor.ParamOrDefault(r, "id", "default")
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/users/789", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		if got != "789" {
+			t.Errorf("ParamOrDefault() = %q, want %q", got, "789")
+		}
+	})
+
+	t.Run("ParamOrDefault method with default", func(t *testing.T) {
+		mux := http.NewServeMux()
+		extractor := &defaultParamsExtractor{}
+		var got string
+		mux.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
+			got = extractor.ParamOrDefault(r, "id", "default")
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/users", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		if got != "default" {
+			t.Errorf("ParamOrDefault() = %q, want %q", got, "default")
+		}
+	})
 }

--- a/params_test.go
+++ b/params_test.go
@@ -1,0 +1,431 @@
+package zerohttp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParam(t *testing.T) {
+	tests := []struct {
+		name      string
+		pattern   string
+		path      string
+		paramName string
+		want      string
+	}{
+		{
+			name:      "extract string param",
+			pattern:   "/users/{id}",
+			path:      "/users/123",
+			paramName: "id",
+			want:      "123",
+		},
+		{
+			name:      "extract multiple params",
+			pattern:   "/users/{userID}/posts/{postID}",
+			path:      "/users/42/posts/99",
+			paramName: "postID",
+			want:      "99",
+		},
+		{
+			name:      "missing param returns empty",
+			pattern:   "/users",
+			path:      "/users",
+			paramName: "id",
+			want:      "",
+		},
+		{
+			name:      "extract slug",
+			pattern:   "/blog/{slug}",
+			path:      "/blog/hello-world",
+			paramName: "slug",
+			want:      "hello-world",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			var got string
+			mux.HandleFunc(tt.pattern, func(w http.ResponseWriter, r *http.Request) {
+				got = Param(r, tt.paramName)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			if got != tt.want {
+				t.Errorf("Param() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParamOrDefault(t *testing.T) {
+	tests := []struct {
+		name       string
+		pattern    string
+		path       string
+		paramName  string
+		defaultVal string
+		want       string
+	}{
+		{
+			name:       "returns param when present",
+			pattern:    "/users/{id}",
+			path:       "/users/123",
+			paramName:  "id",
+			defaultVal: "default",
+			want:       "123",
+		},
+		{
+			name:       "returns default when missing",
+			pattern:    "/users",
+			path:       "/users",
+			paramName:  "id",
+			defaultVal: "default",
+			want:       "default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			var got string
+			mux.HandleFunc(tt.pattern, func(w http.ResponseWriter, r *http.Request) {
+				got = ParamOrDefault(r, tt.paramName, tt.defaultVal)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			if got != tt.want {
+				t.Errorf("ParamOrDefault() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParamAs(t *testing.T) {
+	tests := []struct {
+		name      string
+		pattern   string
+		path      string
+		paramName string
+		value     string
+		wantErr   bool
+		errMsg    string
+	}{
+		{
+			name:      "valid int",
+			pattern:   "/users/{id}",
+			path:      "/users/123",
+			paramName: "id",
+			value:     "123",
+			wantErr:   false,
+		},
+		{
+			name:      "invalid int",
+			pattern:   "/users/{id}",
+			path:      "/users/abc",
+			paramName: "id",
+			wantErr:   true,
+			errMsg:    `parameter "id": invalid int`,
+		},
+		{
+			name:      "missing param",
+			pattern:   "/users",
+			path:      "/users",
+			paramName: "id",
+			wantErr:   true,
+			errMsg:    `parameter "id" not found`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			var gotErr error
+			mux.HandleFunc(tt.pattern, func(w http.ResponseWriter, r *http.Request) {
+				_, gotErr = ParamAs[int](r, tt.paramName)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			if tt.wantErr {
+				if gotErr == nil {
+					t.Errorf("ParamAs() expected error, got nil")
+					return
+				}
+				if tt.errMsg != "" {
+					if got := gotErr.Error(); got[:len(tt.errMsg)] != tt.errMsg {
+						t.Errorf("ParamAs() error = %q, want prefix %q", got, tt.errMsg)
+					}
+				}
+			} else {
+				if gotErr != nil {
+					t.Errorf("ParamAs() unexpected error: %v", gotErr)
+				}
+			}
+		})
+	}
+}
+
+func TestParamAs_Bool(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/flag/true", true},
+		{"/flag/1", true},
+		{"/flag/false", false},
+		{"/flag/0", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/flag/{enabled}", func(w http.ResponseWriter, r *http.Request) {
+				val, err := ParamAs[bool](r, "enabled")
+				if err != nil {
+					t.Errorf("ParamAs[bool]() error = %v", err)
+					return
+				}
+				if val != tt.want {
+					t.Errorf("ParamAs[bool]() = %v, want %v", val, tt.want)
+				}
+			})
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+		})
+	}
+}
+
+func TestParamAs_CommonTypes(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		path    string
+		testFn  func(*http.Request) error
+	}{
+		{
+			name:    "int",
+			pattern: "/users/{id}",
+			path:    "/users/42",
+			testFn: func(r *http.Request) error {
+				val, err := ParamAs[int](r, "id")
+				if err != nil {
+					return err
+				}
+				if val != 42 {
+					t.Errorf("ParamAs[int]() = %d, want 42", val)
+				}
+				return nil
+			},
+		},
+		{
+			name:    "int64",
+			pattern: "/items/{id}",
+			path:    "/items/9223372036854775807",
+			testFn: func(r *http.Request) error {
+				val, err := ParamAs[int64](r, "id")
+				if err != nil {
+					return err
+				}
+				if val != 9223372036854775807 {
+					t.Errorf("ParamAs[int64]() = %d, want max int64", val)
+				}
+				return nil
+			},
+		},
+		{
+			name:    "uint",
+			pattern: "/count/{n}",
+			path:    "/count/100",
+			testFn: func(r *http.Request) error {
+				val, err := ParamAs[uint](r, "n")
+				if err != nil {
+					return err
+				}
+				if val != 100 {
+					t.Errorf("ParamAs[uint]() = %d, want 100", val)
+				}
+				return nil
+			},
+		},
+		{
+			name:    "float64",
+			pattern: "/price/{amount}",
+			path:    "/price/19.99",
+			testFn: func(r *http.Request) error {
+				val, err := ParamAs[float64](r, "amount")
+				if err != nil {
+					return err
+				}
+				if val != 19.99 {
+					t.Errorf("ParamAs[float64]() = %f, want 19.99", val)
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			var gotErr error
+			mux.HandleFunc(tt.pattern, func(w http.ResponseWriter, r *http.Request) {
+				gotErr = tt.testFn(r)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			if gotErr != nil {
+				t.Errorf("ParamAs[%s]() error = %v", tt.name, gotErr)
+			}
+		})
+	}
+}
+
+func TestParamExtractor_Interface(t *testing.T) {
+	// Ensure defaultParamsExtractor implements ParamExtractor
+	var _ ParamExtractor = Params
+}
+
+func TestParamAsOrDefault(t *testing.T) {
+	tests := []struct {
+		name       string
+		pattern    string
+		path       string
+		paramName  string
+		defaultVal int
+		want       int
+	}{
+		{
+			name:       "returns param when present",
+			pattern:    "/users/{id}",
+			path:       "/users/123",
+			paramName:  "id",
+			defaultVal: 0,
+			want:       123,
+		},
+		{
+			name:       "returns default when param missing",
+			pattern:    "/users",
+			path:       "/users",
+			paramName:  "id",
+			defaultVal: 42,
+			want:       42,
+		},
+		{
+			name:       "returns default on invalid type",
+			pattern:    "/users/{id}",
+			path:       "/users/abc",
+			paramName:  "id",
+			defaultVal: 99,
+			want:       99,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			var got int
+			mux.HandleFunc(tt.pattern, func(w http.ResponseWriter, r *http.Request) {
+				got = ParamAsOrDefault(r, tt.paramName, tt.defaultVal)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			if got != tt.want {
+				t.Errorf("ParamAsOrDefault() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParamAs_Types(t *testing.T) {
+	tests := []struct {
+		name      string
+		pattern   string
+		path      string
+		paramName string
+		expected  any
+		fn        func(*http.Request, string) (any, error)
+	}{
+		{
+			name:      "string type",
+			pattern:   "/items/{name}",
+			path:      "/items/widget",
+			paramName: "name",
+			expected:  "widget",
+			fn: func(r *http.Request, n string) (any, error) {
+				return ParamAs[string](r, n)
+			},
+		},
+		{
+			name:      "int8 type",
+			pattern:   "/items/{id}",
+			path:      "/items/100",
+			paramName: "id",
+			expected:  int8(100),
+			fn: func(r *http.Request, n string) (any, error) {
+				return ParamAs[int8](r, n)
+			},
+		},
+		{
+			name:      "uint type",
+			pattern:   "/items/{count}",
+			path:      "/items/50",
+			paramName: "count",
+			expected:  uint(50),
+			fn: func(r *http.Request, n string) (any, error) {
+				return ParamAs[uint](r, n)
+			},
+		},
+		{
+			name:      "float32 type",
+			pattern:   "/items/{price}",
+			path:      "/items/19.99",
+			paramName: "price",
+			expected:  float32(19.99),
+			fn: func(r *http.Request, n string) (any, error) {
+				return ParamAs[float32](r, n)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			var got any
+			var err error
+			mux.HandleFunc(tt.pattern, func(w http.ResponseWriter, r *http.Request) {
+				got, err = tt.fn(r, tt.paramName)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			if err != nil {
+				t.Errorf("ParamAs() error = %v", err)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("ParamAs() = %v (%T), want %v (%T)", got, got, tt.expected, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add type-safe path param extraction with generics:
- Param() for string extraction
- ParamAs[T]() for typed extraction
- ParamAsOrDefault[T]() with fallback
- Example and README docs included