### PR TITLE
feat: add query parameter binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ A lightweight HTTP framework for Go built on top of the standard `net/http` libr
 - [Quick Start](#quick-start)
 - [Response Rendering](#response-rendering)
 - [Request Binding](#request-binding)
+- [Path Parameters](#path-parameters)
+- [Query Parameters](#query-parameters)
 - [Middleware](#middleware)
 - [Route Groups](#route-groups)
-- [Path Parameters](#path-parameters)
 - [Static File Serving](#static-file-serving)
     - [Static File Methods](#static-file-methods)
 - [Error Handling](#error-handling)
@@ -42,7 +43,7 @@ A lightweight HTTP framework for Go built on top of the standard `net/http` libr
 - **Zero Dependencies**: No external dependencies
 - **Secure by Default**: Automatically applies essential security middlewares out of the box
 - **Response Rendering**: Built-in support for JSON, HTML, text, and file responses
-- **Request Binding**: JSON, form, and multipart form parsing with struct tag binding
+- **Request Binding**: JSON, form, multipart form, and query parameter parsing with struct tag binding
 - **Problem Details**: RFC 9457 Problem Details for HTTP APIs error responses
 - **Flexible Routing**: Method-based routing with route groups and parameter support
 - **Middleware Support**: Comprehensive middleware system with built-in security, logging, and utility middlewares
@@ -237,6 +238,144 @@ app.POST("/upload", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) 
 The JSON binder uses `json.Decoder` with `DisallowUnknownFields()` for stricter validation.
 Form binding supports automatic type conversion for int, uint, float, bool, and slice types.
 
+## Path Parameters
+
+Type-safe path parameter extraction with generic support:
+
+```go
+// Basic string extraction
+app.GET("/users/{id}", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+    id := zh.Param(r, "id")  // Returns string
+    return zh.R.JSON(w, 200, zh.M{"user_id": id})
+}))
+
+// Typed extraction with error handling
+app.GET("/items/{itemID}", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+    itemID, err := zh.ParamAs[int](r, "itemID")
+    if err != nil {
+        return zh.R.ProblemDetail(w, zh.NewProblemDetail(400, "Invalid itemID"))
+    }
+    return zh.R.JSON(w, 200, zh.M{"item_id": itemID})
+}))
+
+// Multiple parameters
+app.GET("/users/{userID}/posts/{postID}", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+    userID, _ := zh.ParamAs[int](r, "userID")
+    postID, _ := zh.ParamAs[int](r, "postID")
+    return zh.R.JSON(w, 200, zh.M{"user_id": userID, "post_id": postID})
+}))
+
+// With default value (returns default if param missing or invalid)
+app.GET("/products/{category}", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+    category := zh.ParamOrDefault(r, "category", "all")
+    return zh.R.JSON(w, 200, zh.M{"category": category})
+}))
+```
+
+**Available Functions:**
+
+- `Param(r, "name")` - Extract parameter as string
+- `ParamAs[T](r, "name")` - Extract and convert to type T (int, int64, uint, float64, bool, etc.)
+- `ParamAsOrDefault[T](r, "name", defaultVal)` - Extract with fallback value
+- `ParamOrDefault(r, "name", "default")` - String extraction with fallback
+
+**Supported Types:** `string`, `int`, `int8`, `int16`, `int32`, `int64`, `uint`, `uint8`, `uint16`, `uint32`, `uint64`, `float32`, `float64`, `bool`
+
+
+## Query Parameters
+
+Structured query parameter binding with struct tags and type-safe extraction:
+
+```go
+// Struct-based binding
+app.GET("/search", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+    var req struct {
+        Query    string   `query:"q"`
+        Category string   `query:"category"`
+        Tags     []string `query:"tags"`      // Supports multiple values
+        Page     int      `query:"page"`
+        Limit    int      `query:"limit"`
+        IsActive *bool    `query:"is_active"` // Pointer = optional
+    }
+
+    if err := zh.Bind.Query(r, &req); err != nil {
+        return zh.NewProblemDetail(400, err.Error()).Render(w)
+    }
+
+    // Set defaults
+    if req.Page < 1 {
+        req.Page = 1
+    }
+    if req.Limit < 1 {
+        req.Limit = 20
+    }
+
+    return zh.R.JSON(w, 200, zh.M{
+        "query":    req.Query,
+        "category": req.Category,
+        "tags":     req.Tags,
+        "page":     req.Page,
+    })
+}))
+
+// Embedded structs for reusable pagination
+type Pagination struct {
+    Page  int `query:"page"`
+    Limit int `query:"limit"`
+}
+
+type ListRequest struct {
+    Pagination        // Embeds page, limit fields
+    Search string `query:"search"`
+}
+
+app.GET("/items", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+    var req ListRequest
+    if err := zh.B.Query(r, &req); err != nil {
+        return err
+    }
+    return zh.R.JSON(w, 200, req)
+}))
+```
+
+### Individual Parameter Extraction
+
+For simple cases, extract individual parameters with type conversion:
+
+```go
+app.GET("/extract", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+    // Extract with type conversion and error handling
+    userID, err := zh.QueryParamAs[int](r, "user_id")
+    if err != nil {
+        return zh.NewProblemDetail(400, "Invalid user_id").Render(w)
+    }
+
+    // Extract with default value
+    page := zh.QueryParamAsOrDefault(r, "page", 1)
+    limit := zh.QueryParamAsOrDefault(r, "limit", 20)
+
+    // Simple string extraction
+    sort := zh.QueryParam(r, "sort") // Empty string if missing
+
+    return zh.R.JSON(w, 200, zh.M{
+        "user_id": userID,
+        "page":    page,
+        "limit":   limit,
+        "sort":    sort,
+    })
+}))
+```
+
+**Available Functions:**
+
+- `Bind.Query(r, &dst)` - Bind all query params to struct with `query` tags
+- `QueryParam(r, "name")` - Extract parameter as string
+- `QueryParamAs[T](r, "name")` - Extract and convert to type T
+- `QueryParamAsOrDefault[T](r, "name", defaultVal)` - Extract with fallback
+
+**Supported Types:** Same as Path Parameters - all primitives, slices, and pointers
+
+
 ## Middleware
 
 zerohttp includes a comprehensive set of built-in middlewares:
@@ -282,50 +421,6 @@ app.Group(func(api zh.Router) {
     api.DELETE("/users/{id}", deleteUser)
 })
 ```
-
-
-## Path Parameters
-
-Type-safe path parameter extraction with generic support:
-
-```go
-// Basic string extraction
-app.GET("/users/{id}", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-    id := zh.Param(r, "id")  // Returns string
-    return zh.R.JSON(w, 200, zh.M{"user_id": id})
-}))
-
-// Typed extraction with error handling
-app.GET("/items/{itemID}", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-    itemID, err := zh.ParamAs[int](r, "itemID")
-    if err != nil {
-        return zh.R.ProblemDetail(w, zh.NewProblemDetail(400, "Invalid itemID"))
-    }
-    return zh.R.JSON(w, 200, zh.M{"item_id": itemID})
-}))
-
-// Multiple parameters
-app.GET("/users/{userID}/posts/{postID}", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-    userID, _ := zh.ParamAs[int](r, "userID")
-    postID, _ := zh.ParamAs[int](r, "postID")
-    return zh.R.JSON(w, 200, zh.M{"user_id": userID, "post_id": postID})
-}))
-
-// With default value (returns default if param missing or invalid)
-app.GET("/products/{category}", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-    category := zh.ParamOrDefault(r, "category", "all")
-    return zh.R.JSON(w, 200, zh.M{"category": category})
-}))
-```
-
-**Available Functions:**
-
-- `Param(r, "name")` - Extract parameter as string
-- `ParamAs[T](r, "name")` - Extract and convert to type T (int, int64, uint, float64, bool, etc.)
-- `ParamAsOrDefault[T](r, "name", defaultVal)` - Extract with fallback value
-- `ParamOrDefault(r, "name", "default")` - String extraction with fallback
-
-**Supported Types:** `string`, `int`, `int8`, `int16`, `int32`, `int64`, `uint`, `uint8`, `uint16`, `uint32`, `uint64`, `float32`, `float64`, `bool`
 
 
 ## Static File Serving
@@ -579,6 +674,11 @@ func (b *MyBinder) Form(r *http.Request, dst any) error {
 
 func (b *MyBinder) MultipartForm(r *http.Request, dst any, maxMemory int64) error {
     // Custom multipart form binding logic
+    return nil
+}
+
+func (b *MyBinder) Query(r *http.Request, dst any) error {
+    // Custom query parameter binding logic
     return nil
 }
 

--- a/bind.go
+++ b/bind.go
@@ -37,6 +37,12 @@ type Binder interface {
 	// before being written to temp files (similar to http.Request.ParseMultipartForm).
 	// File uploads are bound to fields of type FileHeader or []FileHeader.
 	MultipartForm(r *http.Request, dst any, maxMemory int64) error
+
+	// Query binds query parameters from the request URL to a destination struct.
+	// Uses `query` struct tags for field mapping. Fields without tags are mapped
+	// using snake_case conversion of the field name.
+	// Returns an error if binding fails due to type mismatch.
+	Query(r *http.Request, dst any) error
 }
 
 // defaultBinder implements the Binder interface with standard decoding
@@ -91,7 +97,7 @@ func (b *defaultBinder) Form(r *http.Request, dst any) error {
 	if err := r.ParseForm(); err != nil {
 		return fmt.Errorf("parse form: %w", err)
 	}
-	return bindValues(r.Form, dst, false)
+	return bindValues(r.Form, dst, "form", false)
 }
 
 // MultipartForm parses multipart form data including file uploads.
@@ -105,7 +111,7 @@ func (b *defaultBinder) MultipartForm(r *http.Request, dst any, maxMemory int64)
 	}
 
 	// Bind form values first
-	if err := bindValues(r.MultipartForm.Value, dst, true); err != nil {
+	if err := bindValues(r.MultipartForm.Value, dst, "form", true); err != nil {
 		return err
 	}
 
@@ -113,8 +119,17 @@ func (b *defaultBinder) MultipartForm(r *http.Request, dst any, maxMemory int64)
 	return BindMultipartFormFiles(r, dst)
 }
 
-// bindValues binds url.Values to a struct, optionally handling file uploads.
-func bindValues(values url.Values, dst any, allowFiles bool) error {
+// Query binds query parameters from the request URL to a destination struct.
+// Uses `query` struct tags for field mapping. Fields without tags are mapped
+// using snake_case conversion of the field name.
+// Returns an error if binding fails due to type mismatch.
+func (b *defaultBinder) Query(r *http.Request, dst any) error {
+	return bindValues(r.URL.Query(), dst, "query", false)
+}
+
+// bindValues binds url.Values to a struct using the specified tag name.
+// The tagName parameter specifies which struct tag to use (e.g., "form", "query").
+func bindValues(values url.Values, dst any, tagName string, allowFiles bool) error {
 	v := reflect.ValueOf(dst)
 	if v.Kind() != reflect.Ptr || v.IsNil() {
 		return fmt.Errorf("destination must be a non-nil pointer")
@@ -131,13 +146,21 @@ func bindValues(values url.Values, dst any, allowFiles bool) error {
 		field := v.Field(i)
 		fieldType := t.Field(i)
 
-		// Skip unexported fields
+		// Handle embedded structs - inline their fields
+		if fieldType.Anonymous && field.Kind() == reflect.Struct {
+			if err := bindEmbeddedStruct(values, field, tagName, allowFiles); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// Skip unexported fields (for non-embedded fields)
 		if !field.CanSet() {
 			continue
 		}
 
-		// Get form tag
-		tag := fieldType.Tag.Get("form")
+		// Get the tag value
+		tag := fieldType.Tag.Get(tagName)
 		if tag == "-" {
 			continue
 		}
@@ -147,31 +170,80 @@ func bindValues(values url.Values, dst any, allowFiles bool) error {
 			tag = camelToSnake(fieldType.Name)
 		}
 
-		// Handle embedded structs
+		// Check for file uploads first (only in multipart mode)
+		if allowFiles {
+			handled, err := bindFileField(field)
+			if err != nil {
+				return err
+			}
+			if handled {
+				continue
+			}
+		}
+
+		// Get value(s) from url.Values
+		fieldValues, exists := values[tag]
+		if !exists || len(fieldValues) == 0 {
+			continue
+		}
+
+		if err := setFieldValue(field, fieldValues); err != nil {
+			return fmt.Errorf("field %s: %w", fieldType.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// bindEmbeddedStruct binds values to an embedded struct's fields directly.
+// This avoids the reflection issues with getting an interface from embedded struct fields.
+func bindEmbeddedStruct(values url.Values, structField reflect.Value, tagName string, allowFiles bool) error {
+	structType := structField.Type()
+
+	for j := 0; j < structField.NumField(); j++ {
+		field := structField.Field(j)
+		fieldType := structType.Field(j)
+
+		// Skip unexported fields
+		if !field.CanSet() {
+			continue
+		}
+
+		// Handle nested embedded structs recursively
 		if fieldType.Anonymous && field.Kind() == reflect.Struct {
-			if err := bindValues(values, field.Addr().Interface(), allowFiles); err != nil {
+			if err := bindEmbeddedStruct(values, field, tagName, allowFiles); err != nil {
 				return err
 			}
 			continue
 		}
 
+		// Get the tag value
+		tag := fieldType.Tag.Get(tagName)
+		if tag == "-" {
+			continue
+		}
+		if tag == "" {
+			tag = camelToSnake(fieldType.Name)
+		}
+
 		// Check for file uploads first (only in multipart mode)
 		if allowFiles {
-			if handled, err := bindFileField(field, tag); handled {
-				if err != nil {
-					return err
-				}
+			handled, err := bindFileField(field)
+			if err != nil {
+				return err
+			}
+			if handled {
 				continue
 			}
 		}
 
-		// Get form value(s)
-		formValues, exists := values[tag]
-		if !exists || len(formValues) == 0 {
+		// Get value(s) from url.Values
+		fieldValues, exists := values[tag]
+		if !exists || len(fieldValues) == 0 {
 			continue
 		}
 
-		if err := setFieldValue(field, formValues); err != nil {
+		if err := setFieldValue(field, fieldValues); err != nil {
 			return fmt.Errorf("field %s: %w", fieldType.Name, err)
 		}
 	}
@@ -181,7 +253,7 @@ func bindValues(values url.Values, dst any, allowFiles bool) error {
 
 // bindFileField attempts to bind a file upload to a field.
 // Returns true if the field was handled as a file field.
-func bindFileField(field reflect.Value, tag string) (bool, error) {
+func bindFileField(field reflect.Value) (bool, error) {
 	// Check if it's a FileHeader field
 	switch field.Type() {
 	case reflect.TypeOf(&FileHeader{}):
@@ -235,6 +307,10 @@ func setFieldValue(field reflect.Value, values []string) error {
 		return setSliceValue(field, values)
 
 	case reflect.Ptr:
+		// If value is empty, leave pointer as nil (optional parameter)
+		if values[0] == "" {
+			return nil
+		}
 		if field.IsNil() {
 			field.Set(reflect.New(field.Type().Elem()))
 		}

--- a/bind_test.go
+++ b/bind_test.go
@@ -2,6 +2,7 @@ package zerohttp
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -278,7 +279,7 @@ func TestBinder_Form_InvalidDestination(t *testing.T) {
 
 			var err error
 			if tt.dst == nil {
-				err = bindValues(url.Values{"name": []string{"test"}}, tt.dst, false)
+				err = bindValues(url.Values{"name": []string{"test"}}, tt.dst, "form", false)
 			} else {
 				err = B.Form(req, tt.dst)
 			}
@@ -544,7 +545,7 @@ func TestBindValues_EmbeddedStruct(t *testing.T) {
 	}
 
 	var result Container
-	err := bindValues(values, &result, false)
+	err := bindValues(values, &result, "form", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -571,7 +572,7 @@ func TestBindValues_PointerFields(t *testing.T) {
 	}
 
 	var result WithPointers
-	err := bindValues(values, &result, false)
+	err := bindValues(values, &result, "form", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -597,7 +598,7 @@ func TestBindValues_IntSlice(t *testing.T) {
 	}
 
 	var result WithIntSlice
-	err := bindValues(values, &result, false)
+	err := bindValues(values, &result, "form", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -632,4 +633,666 @@ type testMultipartStruct struct {
 	Age         int           `form:"age"`
 	Document    *FileHeader   `form:"document"`
 	Attachments []*FileHeader `form:"attachments"`
+}
+
+// Query binding test structs
+type testQueryStruct struct {
+	Page     int      `query:"page"`
+	Limit    int      `query:"limit"`
+	Search   string   `query:"search"`
+	Active   bool     `query:"active"`
+	Tags     []string `query:"tags"`
+	Category string   `query:"category"`
+	Ignored  string   `query:"-"`
+}
+
+type testQueryEmbedded struct {
+	Page  int `query:"page"`
+	Limit int `query:"limit"`
+}
+
+type testQueryContainer struct {
+	testQueryEmbedded
+	Search string `query:"search"`
+}
+
+type testQueryPointers struct {
+	Name   *string `query:"name"`
+	Age    *int    `query:"age"`
+	Active *bool   `query:"active"`
+}
+
+type testQuerySlices struct {
+	IDs     []int     `query:"ids"`
+	Scores  []float64 `query:"scores"`
+	Enabled []bool    `query:"enabled"`
+}
+
+func TestBinder_Query(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		wantError  bool
+		expected   func(t *testing.T, result *testQueryStruct)
+		errContain string
+	}{
+		{
+			name:      "basic fields",
+			query:     "page=1&limit=20&search=hello",
+			wantError: false,
+			expected: func(t *testing.T, result *testQueryStruct) {
+				if result.Page != 1 {
+					t.Errorf("expected Page=1, got %d", result.Page)
+				}
+				if result.Limit != 20 {
+					t.Errorf("expected Limit=20, got %d", result.Limit)
+				}
+				if result.Search != "hello" {
+					t.Errorf("expected Search='hello', got %q", result.Search)
+				}
+			},
+		},
+		{
+			name:      "boolean field",
+			query:     "active=true",
+			wantError: false,
+			expected: func(t *testing.T, result *testQueryStruct) {
+				if !result.Active {
+					t.Errorf("expected Active=true, got %v", result.Active)
+				}
+			},
+		},
+		{
+			name:      "slice values",
+			query:     "tags=go&tags=web&tags=api",
+			wantError: false,
+			expected: func(t *testing.T, result *testQueryStruct) {
+				expected := []string{"go", "web", "api"}
+				if len(result.Tags) != len(expected) {
+					t.Errorf("expected %d tags, got %d", len(expected), len(result.Tags))
+					return
+				}
+				for i, tag := range result.Tags {
+					if tag != expected[i] {
+						t.Errorf("expected tag[%d]=%q, got %q", i, expected[i], tag)
+					}
+				}
+			},
+		},
+		{
+			name:      "ignored field",
+			query:     "ignored=shouldnotset",
+			wantError: false,
+			expected: func(t *testing.T, result *testQueryStruct) {
+				if result.Ignored != "" {
+					t.Errorf("expected Ignored to be empty, got %q", result.Ignored)
+				}
+			},
+		},
+		{
+			name:      "empty query",
+			query:     "",
+			wantError: false,
+			expected: func(t *testing.T, result *testQueryStruct) {
+				if result.Page != 0 {
+					t.Errorf("expected Page=0, got %d", result.Page)
+				}
+				if result.Search != "" {
+					t.Errorf("expected Search='', got %q", result.Search)
+				}
+			},
+		},
+		{
+			name:       "invalid integer",
+			query:      "page=abc",
+			wantError:  true,
+			errContain: "invalid integer",
+		},
+		{
+			name:       "invalid boolean",
+			query:      "active=notabool",
+			wantError:  true,
+			errContain: "invalid boolean",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/?"+tt.query, nil)
+
+			var result testQueryStruct
+			err := B.Query(req, &result)
+
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+				if tt.errContain != "" && !strings.Contains(err.Error(), tt.errContain) {
+					t.Errorf("expected error to contain %q, got %v", tt.errContain, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			tt.expected(t, &result)
+		})
+	}
+}
+
+func TestBinder_Query_EmbeddedStruct(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/?page=2&limit=50&search=test", nil)
+
+	var result testQueryContainer
+	err := B.Query(req, &result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Page != 2 {
+		t.Errorf("expected Page=2, got %d", result.Page)
+	}
+	if result.Limit != 50 {
+		t.Errorf("expected Limit=50, got %d", result.Limit)
+	}
+	if result.Search != "test" {
+		t.Errorf("expected Search='test', got %q", result.Search)
+	}
+}
+
+func TestBinder_Query_PointerFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    string
+		expected func(t *testing.T, result *testQueryPointers)
+	}{
+		{
+			name:  "all fields provided",
+			query: "name=John&age=30&active=true",
+			expected: func(t *testing.T, result *testQueryPointers) {
+				if result.Name == nil || *result.Name != "John" {
+					t.Errorf("expected Name='John', got %v", result.Name)
+				}
+				if result.Age == nil || *result.Age != 30 {
+					t.Errorf("expected Age=30, got %v", result.Age)
+				}
+				if result.Active == nil || *result.Active != true {
+					t.Errorf("expected Active=true, got %v", result.Active)
+				}
+			},
+		},
+		{
+			name:  "some fields missing",
+			query: "name=Jane",
+			expected: func(t *testing.T, result *testQueryPointers) {
+				if result.Name == nil || *result.Name != "Jane" {
+					t.Errorf("expected Name='Jane', got %v", result.Name)
+				}
+				if result.Age != nil {
+					t.Errorf("expected Age=nil, got %v", result.Age)
+				}
+				if result.Active != nil {
+					t.Errorf("expected Active=nil, got %v", result.Active)
+				}
+			},
+		},
+		{
+			name:  "empty values are nil for pointers",
+			query: "name=&age=",
+			expected: func(t *testing.T, result *testQueryPointers) {
+				// Per design doc: empty string = not provided for pointers
+				if result.Name != nil {
+					t.Errorf("expected Name=nil for empty value, got %q", *result.Name)
+				}
+				if result.Age != nil {
+					t.Errorf("expected Age=nil for empty value, got %d", *result.Age)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/?"+tt.query, nil)
+
+			var result testQueryPointers
+			err := B.Query(req, &result)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			tt.expected(t, &result)
+		})
+	}
+}
+
+func TestBinder_Query_SliceTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    string
+		expected func(t *testing.T, result *testQuerySlices)
+	}{
+		{
+			name:  "int slice",
+			query: "ids=1&ids=2&ids=3",
+			expected: func(t *testing.T, result *testQuerySlices) {
+				expected := []int{1, 2, 3}
+				if len(result.IDs) != len(expected) {
+					t.Fatalf("expected %d IDs, got %d", len(expected), len(result.IDs))
+				}
+				for i, id := range result.IDs {
+					if id != expected[i] {
+						t.Errorf("expected IDs[%d]=%d, got %d", i, expected[i], id)
+					}
+				}
+			},
+		},
+		{
+			name:  "float64 slice",
+			query: "scores=95.5&scores=87.2&scores=100",
+			expected: func(t *testing.T, result *testQuerySlices) {
+				expected := []float64{95.5, 87.2, 100}
+				if len(result.Scores) != len(expected) {
+					t.Fatalf("expected %d scores, got %d", len(expected), len(result.Scores))
+				}
+				for i, score := range result.Scores {
+					if score != expected[i] {
+						t.Errorf("expected Scores[%d]=%f, got %f", i, expected[i], score)
+					}
+				}
+			},
+		},
+		{
+			name:  "bool slice",
+			query: "enabled=true&enabled=false&enabled=1",
+			expected: func(t *testing.T, result *testQuerySlices) {
+				expected := []bool{true, false, true}
+				if len(result.Enabled) != len(expected) {
+					t.Fatalf("expected %d enabled values, got %d", len(expected), len(result.Enabled))
+				}
+				for i, val := range result.Enabled {
+					if val != expected[i] {
+						t.Errorf("expected Enabled[%d]=%v, got %v", i, expected[i], val)
+					}
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/?"+tt.query, nil)
+
+			var result testQuerySlices
+			err := B.Query(req, &result)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			tt.expected(t, &result)
+		})
+	}
+}
+
+func TestBinder_Query_ImplicitSnakeCase(t *testing.T) {
+	type ImplicitNaming struct {
+		UserName   string `query:"user_name"`
+		FirstName  string // should map to first_name
+		LastName   string // should map to last_name
+		HTTPMethod string // should map to h_t_t_p_method
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/?user_name=johndoe&first_name=John&last_name=Doe&h_t_t_p_method=GET", nil)
+
+	var result ImplicitNaming
+	err := B.Query(req, &result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.UserName != "johndoe" {
+		t.Errorf("expected UserName='johndoe', got %q", result.UserName)
+	}
+	if result.FirstName != "John" {
+		t.Errorf("expected FirstName='John', got %q", result.FirstName)
+	}
+	if result.LastName != "Doe" {
+		t.Errorf("expected LastName='Doe', got %q", result.LastName)
+	}
+	if result.HTTPMethod != "GET" {
+		t.Errorf("expected HTTPMethod='GET', got %q", result.HTTPMethod)
+	}
+}
+
+func TestBinder_Query_InvalidDestination(t *testing.T) {
+	tests := []struct {
+		name string
+		dst  interface{}
+	}{
+		{
+			name: "nil pointer",
+			dst:  nil,
+		},
+		{
+			name: "non-pointer",
+			dst:  testQueryStruct{},
+		},
+		{
+			name: "pointer to non-struct",
+			dst:  new(string),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/?page=1", nil)
+
+			var err error
+			if tt.dst == nil {
+				err = bindValues(req.URL.Query(), tt.dst, "query", false)
+			} else {
+				err = B.Query(req, tt.dst)
+			}
+
+			if err == nil {
+				t.Fatal("expected error but got none")
+			}
+		})
+	}
+}
+
+func TestBinder_Query_URLEncodedValues(t *testing.T) {
+	type URLValues struct {
+		Search string `query:"search"`
+		Path   string `query:"path"`
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/?search=hello%20world&path=%2Ffoo%2Fbar", nil)
+
+	var result URLValues
+	err := B.Query(req, &result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Search != "hello world" {
+		t.Errorf("expected Search='hello world', got %q", result.Search)
+	}
+	if result.Path != "/foo/bar" {
+		t.Errorf("expected Path='/foo/bar', got %q", result.Path)
+	}
+}
+
+func TestBindEmbeddedStruct_NestedEmbedded(t *testing.T) {
+	type DeepNested struct {
+		Deep string `form:"deep"`
+	}
+	type Nested struct {
+		DeepNested
+		Middle string `form:"middle"`
+	}
+	type Container struct {
+		Nested
+		Top string `form:"top"`
+	}
+
+	values := url.Values{
+		"top":    []string{"top_value"},
+		"middle": []string{"middle_value"},
+		"deep":   []string{"deep_value"},
+	}
+
+	var result Container
+	err := bindValues(values, &result, "form", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Top != "top_value" {
+		t.Errorf("expected Top='top_value', got %q", result.Top)
+	}
+	if result.Middle != "middle_value" {
+		t.Errorf("expected Middle='middle_value', got %q", result.Middle)
+	}
+	if result.Deep != "deep_value" {
+		t.Errorf("expected Deep='deep_value', got %q", result.Deep)
+	}
+}
+
+func TestBindSliceValue_InvalidElement(t *testing.T) {
+	type WithIntSlice struct {
+		IDs []int `form:"ids"`
+	}
+
+	values := url.Values{
+		"ids": []string{"1", "not_a_number", "3"},
+	}
+
+	var result WithIntSlice
+	err := bindValues(values, &result, "form", false)
+	if err == nil {
+		t.Fatal("expected error for invalid slice element")
+	}
+	if !strings.Contains(err.Error(), "invalid integer") {
+		t.Errorf("expected error to contain 'invalid integer', got %v", err)
+	}
+}
+
+func TestBindSliceValue_InvalidFloatSlice(t *testing.T) {
+	type WithFloatSlice struct {
+		Scores []float64 `form:"scores"`
+	}
+
+	values := url.Values{
+		"scores": []string{"1.5", "invalid", "3.5"},
+	}
+
+	var result WithFloatSlice
+	err := bindValues(values, &result, "form", false)
+	if err == nil {
+		t.Fatal("expected error for invalid float slice element")
+	}
+}
+
+func TestBindSliceValue_InvalidBoolSlice(t *testing.T) {
+	type WithBoolSlice struct {
+		Flags []bool `form:"flags"`
+	}
+
+	values := url.Values{
+		"flags": []string{"true", "not_a_bool", "false"},
+	}
+
+	var result WithBoolSlice
+	err := bindValues(values, &result, "form", false)
+	if err == nil {
+		t.Fatal("expected error for invalid bool slice element")
+	}
+}
+
+func TestBindFileField_NonPointerFileHeader(t *testing.T) {
+	type WithNonPointerFileHeader struct {
+		Document FileHeader `form:"document"`
+	}
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	_ = writer.WriteField("name", "Test")
+	fileWriter, _ := writer.CreateFormFile("document", "test.txt")
+	_, _ = fileWriter.Write([]byte("content"))
+	_ = writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	var result WithNonPointerFileHeader
+	err := B.MultipartForm(req, &result, 32<<20)
+	if err == nil {
+		t.Fatal("expected error for non-pointer FileHeader")
+	}
+	if !strings.Contains(err.Error(), "must be a pointer") {
+		t.Errorf("expected error to contain 'must be a pointer', got %v", err)
+	}
+}
+
+func TestBindEmbeddedStruct_WithFiles(t *testing.T) {
+	type FileContainer struct {
+		Name     string      `form:"name"`
+		Document *FileHeader `form:"document"`
+	}
+
+	type Wrapper struct {
+		FileContainer
+		Extra string `form:"extra"`
+	}
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	_ = writer.WriteField("name", "TestName")
+	_ = writer.WriteField("extra", "ExtraValue")
+	fileWriter, _ := writer.CreateFormFile("document", "embedded.txt")
+	_, _ = fileWriter.Write([]byte("embedded content"))
+	_ = writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	var result Wrapper
+	err := B.MultipartForm(req, &result, 32<<20)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Name != "TestName" {
+		t.Errorf("expected Name='TestName', got %q", result.Name)
+	}
+	if result.Extra != "ExtraValue" {
+		t.Errorf("expected Extra='ExtraValue', got %q", result.Extra)
+	}
+	if result.Document == nil {
+		t.Fatal("expected Document to be set")
+	}
+	if result.Document.Filename != "embedded.txt" {
+		t.Errorf("expected Filename='embedded.txt', got %q", result.Document.Filename)
+	}
+}
+
+func TestFileHeader_ReadAll_OpenError(t *testing.T) {
+	// Create a FileHeader with no internal file reference
+	fh := &FileHeader{
+		Filename: "test.txt",
+		Size:     5,
+		file:     nil, // Simulate closed/unavailable file
+	}
+
+	_, err := fh.ReadAll()
+	if err == nil {
+		t.Fatal("expected error when file is not available")
+	}
+	if !strings.Contains(err.Error(), "no longer available") {
+		t.Errorf("expected 'no longer available' error, got %v", err)
+	}
+}
+
+func TestBinder_Form_ParseFormError(t *testing.T) {
+	// Create a request with invalid content type that causes ParseForm to fail
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("not=valid"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Body = &errReader{}
+
+	var result testFormStruct
+	err := B.Form(req, &result)
+	if err == nil {
+		t.Fatal("expected error for invalid form data")
+	}
+}
+
+// errReader simulates a read error
+type errReader struct{}
+
+func (e *errReader) Read(p []byte) (n int, err error) {
+	return 0, fmt.Errorf("read error")
+}
+
+func (e *errReader) Close() error {
+	return nil
+}
+
+func TestBinder_MultipartForm_ParseError(t *testing.T) {
+	// Request with malformed multipart data
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("not valid multipart"))
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=xyz")
+
+	var result testMultipartStruct
+	err := B.MultipartForm(req, &result, 32<<20)
+	if err == nil {
+		t.Fatal("expected error for invalid multipart form")
+	}
+}
+
+func TestBinder_MultipartForm_NoFormData(t *testing.T) {
+	// Create a request that parses but has no multipart form
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	_ = writer.WriteField("name", "test")
+	_ = writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	// Manually parse then nil out the MultipartForm
+	_ = req.ParseMultipartForm(32 << 20)
+	req.MultipartForm = nil
+
+	var result testMultipartStruct
+	err := B.MultipartForm(req, &result, 32<<20)
+	if err == nil {
+		t.Fatal("expected error when MultipartForm is nil")
+	}
+}
+
+func TestBindFilesToStruct_NoMultipartForm(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	err := BindMultipartFormFiles(req, &testMultipartStruct{})
+	if err != nil {
+		t.Errorf("expected no error when no multipart form, got %v", err)
+	}
+}
+
+func TestBindFilesToStruct_InvalidDestination(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	fileWriter, _ := writer.CreateFormFile("test", "file.txt")
+	_, _ = fileWriter.Write([]byte("content"))
+	_ = writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	_ = req.ParseMultipartForm(32 << 20)
+
+	tests := []struct {
+		name string
+		dst  interface{}
+	}{
+		{
+			name: "non-pointer",
+			dst:  testMultipartStruct{},
+		},
+		{
+			name: "pointer to non-struct",
+			dst:  new(string),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := BindMultipartFormFiles(req, tt.dst)
+			if err == nil {
+				t.Fatal("expected error but got none")
+			}
+		})
+	}
 }

--- a/bind_test.go
+++ b/bind_test.go
@@ -1216,14 +1216,20 @@ func TestBindEmbeddedStruct_UnexportedField(t *testing.T) {
 	}
 
 	values := url.Values{
-		"name":  []string{"container"},
-		"value": []string{"inner_value"},
+		"name":    []string{"container"},
+		"value":   []string{"inner_value"},
+		"visible": []string{"should_not_bind"},
 	}
 
 	var result Container
 	err := bindValues(values, &result, "form", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// visible is unexported so it should not be bound
+	if result.visible != "" {
+		t.Errorf("expected visible to remain empty (unexported), got %q", result.visible)
 	}
 
 	if result.Name != "container" {

--- a/bind_test.go
+++ b/bind_test.go
@@ -1179,6 +1179,138 @@ func TestBindEmbeddedStruct_WithFiles(t *testing.T) {
 	}
 }
 
+func TestBindValues_UnexportedFields(t *testing.T) {
+	type WithUnexported struct {
+		Name    string `form:"name"`
+		ignored string `form:"ignored"` // Unexported field should be skipped
+	}
+
+	values := url.Values{
+		"name":    []string{"John"},
+		"ignored": []string{"should not bind"},
+	}
+
+	var result WithUnexported
+	err := bindValues(values, &result, "form", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Name != "John" {
+		t.Errorf("expected Name='John', got %q", result.Name)
+	}
+	if result.ignored != "" {
+		t.Errorf("expected ignored to remain empty, got %q", result.ignored)
+	}
+}
+
+func TestBindEmbeddedStruct_UnexportedField(t *testing.T) {
+	type Inner struct {
+		visible string // Unexported within embedded struct
+		Value   string `form:"value"`
+	}
+
+	type Container struct {
+		Inner
+		Name string `form:"name"`
+	}
+
+	values := url.Values{
+		"name":  []string{"container"},
+		"value": []string{"inner_value"},
+	}
+
+	var result Container
+	err := bindValues(values, &result, "form", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Name != "container" {
+		t.Errorf("expected Name='container', got %q", result.Name)
+	}
+	if result.Value != "inner_value" {
+		t.Errorf("expected Value='inner_value', got %q", result.Value)
+	}
+}
+
+func TestBindEmbeddedStruct_IgnoredField(t *testing.T) {
+	type Inner struct {
+		Ignored string `form:"-"`
+		Value   string `form:"value"`
+	}
+
+	type Container struct {
+		Inner
+	}
+
+	values := url.Values{
+		"ignored": []string{"should_not_set"},
+		"value":   []string{"actual_value"},
+	}
+
+	var result Container
+	err := bindValues(values, &result, "form", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Ignored != "" {
+		t.Errorf("expected Ignored to remain empty, got %q", result.Ignored)
+	}
+	if result.Value != "actual_value" {
+		t.Errorf("expected Value='actual_value', got %q", result.Value)
+	}
+}
+
+func TestBindValues_EmptyTagName(t *testing.T) {
+	type NoTag struct {
+		UserName string // Will use snake_case: user_name
+	}
+
+	values := url.Values{
+		"user_name": []string{"johndoe"},
+	}
+
+	var result NoTag
+	err := bindValues(values, &result, "form", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.UserName != "johndoe" {
+		t.Errorf("expected UserName='johndoe', got %q", result.UserName)
+	}
+}
+
+func TestBindEmbeddedStruct_ErrorPropagation(t *testing.T) {
+	// Test that errors from nested embedded structs propagate correctly
+	type DeepNested struct {
+		Value int `form:"value"`
+	}
+
+	type Middle struct {
+		DeepNested
+	}
+
+	type Container struct {
+		Middle
+	}
+
+	values := url.Values{
+		"value": []string{"not_a_number"},
+	}
+
+	var result Container
+	err := bindValues(values, &result, "form", false)
+	if err == nil {
+		t.Fatal("expected error for invalid int conversion in nested embedded struct")
+	}
+	if !strings.Contains(err.Error(), "invalid integer") {
+		t.Errorf("expected 'invalid integer' error, got %v", err)
+	}
+}
+
 func TestFileHeader_ReadAll_OpenError(t *testing.T) {
 	// Create a FileHeader with no internal file reference
 	fh := &FileHeader{

--- a/examples/query_binding/main.go
+++ b/examples/query_binding/main.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	zh "github.com/alexferl/zerohttp"
+)
+
+// SearchRequest demonstrates basic query parameter binding
+type SearchRequest struct {
+	Query    string   `query:"q"`
+	Category string   `query:"category"`
+	Tags     []string `query:"tags"`
+}
+
+// PaginationRequest demonstrates numeric types and optional params
+type PaginationRequest struct {
+	Page    int   `query:"page"`
+	Limit   int   `query:"limit"`
+	Offset  int   `query:"offset"`
+	IsAdmin *bool `query:"is_admin"` // Pointer = optional
+}
+
+// FilterRequest demonstrates slices and multiple types
+type FilterRequest struct {
+	IDs      []int    `query:"id"`
+	Statuses []string `query:"status"`
+	MinPrice float64  `query:"min_price"`
+	MaxPrice float64  `query:"max_price"`
+	InStock  bool     `query:"in_stock"`
+}
+
+// EmbeddedPagination demonstrates embedded structs
+type EmbeddedPagination struct {
+	Page  int `query:"page"`
+	Limit int `query:"limit"`
+}
+
+// ListRequest combines embedded pagination with search
+type ListRequest struct {
+	EmbeddedPagination
+	Search string `query:"search"`
+}
+
+func main() {
+	app := zh.New()
+
+	// Routes
+	app.GET("/", zh.HandlerFunc(indexHandler))
+	app.GET("/search", zh.HandlerFunc(searchHandler))
+	app.GET("/items", zh.HandlerFunc(itemsHandler))
+	app.GET("/products", zh.HandlerFunc(productsHandler))
+	app.GET("/users", zh.HandlerFunc(listUsersHandler))
+
+	// Individual query parameter extraction
+	app.GET("/extract", zh.HandlerFunc(extractHandler))
+
+	log.Println("Server starting on :8080")
+	log.Println("Try these endpoints:")
+	log.Println("  GET /search?q=golang&category=tech&tags=api&tags=web")
+	log.Println("  GET /items?page=2&limit=50&is_admin=true")
+	log.Println("  GET /products?id=1&id=2&id=3&status=active&min_price=10.99")
+	log.Println("  GET /users?search=john&page=1&limit=20")
+	log.Println("  GET /extract?user_id=123&active=true&score=95.5")
+
+	log.Fatal(app.Start())
+}
+
+func indexHandler(w http.ResponseWriter, r *http.Request) error {
+	html := `<!DOCTYPE html>
+<html>
+<head>
+    <title>Query Parameter Binding Examples</title>
+    <style>
+        body { font-family: sans-serif; max-width: 800px; margin: 40px auto; padding: 20px; }
+        h1 { color: #333; }
+        h2 { color: #555; margin-top: 30px; }
+        code { background: #f4f4f4; padding: 2px 6px; border-radius: 3px; }
+        pre { background: #f4f4f4; padding: 15px; border-radius: 5px; overflow-x: auto; }
+        .endpoint { margin: 20px 0; padding: 15px; background: #f9f9f9; border-left: 4px solid #28a745; }
+        .method { font-weight: bold; color: #28a745; }
+    </style>
+</head>
+<body>
+    <h1>Query Parameter Binding Examples</h1>
+    <p>This example demonstrates zerohttp's query parameter binding using <code>Bind.Query()</code>.</p>
+
+    <h2>Available Endpoints</h2>
+
+    <div class="endpoint">
+        <span class="method">GET</span> <code>/search</code>
+        <p>Basic search with strings and slices.</p>
+        <pre>curl "http://localhost:8080/search?q=golang&category=tech&tags=api&tags=web"</pre>
+    </div>
+
+    <div class="endpoint">
+        <span class="method">GET</span> <code>/items</code>
+        <p>Pagination with optional boolean pointer.</p>
+        <pre>curl "http://localhost:8080/items?page=2&limit=50&is_admin=true"</pre>
+    </div>
+
+    <div class="endpoint">
+        <span class="method">GET</span> <code>/products</code>
+        <p>Filter with int slices and float values.</p>
+        <pre>curl "http://localhost:8080/products?id=1&id=2&id=3&status=active&min_price=10.99"</pre>
+    </div>
+
+    <div class="endpoint">
+        <span class="method">GET</span> <code>/users</code>
+        <p>Embedded struct with pagination.</p>
+        <pre>curl "http://localhost:8080/users?search=john&page=1&limit=20"</pre>
+    </div>
+
+    <div class="endpoint">
+        <span class="method">GET</span> <code>/extract</code>
+        <p>Individual parameter extraction helpers.</p>
+        <pre>curl "http://localhost:8080/extract?user_id=123&active=true&score=95.5"</pre>
+    </div>
+
+    <h2>Features Demonstrated</h2>
+    <ul>
+        <li><strong>Bind.Query()</strong> - Bind query params to structs using <code>query:"name"</code> tags</li>
+        <li><strong>QueryParamAs[T]()</strong> - Type-safe individual parameter extraction</li>
+        <li><strong>QueryParamAsOrDefault()</strong> - Extract with default value fallback</li>
+        <li><strong>Slice binding</strong> - Multiple values with same param name</li>
+        <li><strong>Optional params</strong> - Pointer types for optional values</li>
+        <li><strong>Type conversion</strong> - Automatic string to int, float, bool conversion</li>
+        <li><strong>Embedded structs</strong> - Pagination structs embedded in request types</li>
+    </ul>
+</body>
+</html>`
+	return zh.R.HTML(w, http.StatusOK, html)
+}
+
+// searchHandler demonstrates basic query binding with slices
+func searchHandler(w http.ResponseWriter, r *http.Request) error {
+	var req SearchRequest
+	if err := zh.B.Query(r, &req); err != nil {
+		return zh.NewProblemDetail(http.StatusBadRequest, err.Error()).Render(w)
+	}
+
+	// Set defaults
+	if req.Category == "" {
+		req.Category = "all"
+	}
+
+	return zh.R.JSON(w, http.StatusOK, zh.M{
+		"query":    req.Query,
+		"category": req.Category,
+		"tags":     req.Tags,
+		"count":    len(req.Tags),
+	})
+}
+
+// itemsHandler demonstrates numeric types and optional boolean pointer
+func itemsHandler(w http.ResponseWriter, r *http.Request) error {
+	var req PaginationRequest
+	if err := zh.B.Query(r, &req); err != nil {
+		return zh.NewProblemDetail(http.StatusBadRequest, err.Error()).Render(w)
+	}
+
+	// Set defaults
+	if req.Page < 1 {
+		req.Page = 1
+	}
+	if req.Limit < 1 {
+		req.Limit = 20
+	}
+	if req.Limit > 100 {
+		req.Limit = 100 // Max limit
+	}
+
+	response := zh.M{
+		"page":   req.Page,
+		"limit":  req.Limit,
+		"offset": req.Offset,
+	}
+
+	// Optional pointer field - nil if not provided, true/false if provided
+	if req.IsAdmin != nil {
+		response["is_admin"] = *req.IsAdmin
+		response["is_admin_provided"] = true
+	} else {
+		response["is_admin"] = nil
+		response["is_admin_provided"] = false
+	}
+
+	return zh.R.JSON(w, http.StatusOK, response)
+}
+
+// productsHandler demonstrates int slices and float types
+func productsHandler(w http.ResponseWriter, r *http.Request) error {
+	var req FilterRequest
+	if err := zh.B.Query(r, &req); err != nil {
+		return zh.NewProblemDetail(http.StatusBadRequest, err.Error()).Render(w)
+	}
+
+	return zh.R.JSON(w, http.StatusOK, zh.M{
+		"ids":             req.IDs,
+		"statuses":        req.Statuses,
+		"min_price":       req.MinPrice,
+		"max_price":       req.MaxPrice,
+		"in_stock":        req.InStock,
+		"filters_applied": len(req.IDs) + len(req.Statuses),
+	})
+}
+
+// listUsersHandler demonstrates embedded struct binding
+func listUsersHandler(w http.ResponseWriter, r *http.Request) error {
+	var req ListRequest
+	if err := zh.B.Query(r, &req); err != nil {
+		return zh.NewProblemDetail(http.StatusBadRequest, err.Error()).Render(w)
+	}
+
+	// Set defaults
+	if req.Page < 1 {
+		req.Page = 1
+	}
+	if req.Limit < 1 {
+		req.Limit = 20
+	}
+
+	return zh.R.JSON(w, http.StatusOK, zh.M{
+		"search": req.Search,
+		"page":   req.Page,
+		"limit":  req.Limit,
+		"note":   "Pagination fields come from EmbeddedPagination struct",
+	})
+}
+
+// extractHandler demonstrates individual parameter extraction helpers
+func extractHandler(w http.ResponseWriter, r *http.Request) error {
+	// Extract user_id as int with error handling
+	userID, err := zh.QueryParamAs[int](r, "user_id")
+	if err != nil {
+		return zh.NewProblemDetail(http.StatusBadRequest, "Invalid user_id: "+err.Error()).Render(w)
+	}
+
+	// Extract score as float64 with error handling
+	score, err := zh.QueryParamAs[float64](r, "score")
+	if err != nil {
+		return zh.NewProblemDetail(http.StatusBadRequest, "Invalid score: "+err.Error()).Render(w)
+	}
+
+	// Extract active as bool with error handling
+	active, err := zh.QueryParamAs[bool](r, "active")
+	if err != nil {
+		return zh.NewProblemDetail(http.StatusBadRequest, "Invalid active: "+err.Error()).Render(w)
+	}
+
+	// Extract optional name with default
+	name := zh.QueryParamAsOrDefault(r, "name", "Anonymous")
+
+	// Extract optional limit with default
+	limit := zh.QueryParamAsOrDefault(r, "limit", 10)
+
+	return zh.R.JSON(w, http.StatusOK, zh.M{
+		"user_id":   userID,
+		"active":    active,
+		"score":     score,
+		"name":      name,
+		"limit":     limit,
+		"extracted": "Individual parameters using QueryParamAs[T]()",
+	})
+}

--- a/query.go
+++ b/query.go
@@ -1,0 +1,164 @@
+package zerohttp
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+// Query is the default query extractor instance used by the package
+var Query = &defaultQueryExtractor{}
+
+// QueryExtractor defines the interface for query parameter extraction
+type QueryExtractor interface {
+	// QueryParam gets a query parameter by name as a string.
+	// Returns empty string if parameter is not found.
+	QueryParam(r *http.Request, name string) string
+
+	// QueryParamOrDefault gets a query parameter with a fallback default value.
+	QueryParamOrDefault(r *http.Request, name, defaultVal string) string
+}
+
+// defaultQueryExtractor implements the QueryExtractor interface
+type defaultQueryExtractor struct{}
+
+// QueryParam gets a query parameter by name as a string.
+// Returns empty string if parameter is not found.
+func (q *defaultQueryExtractor) QueryParam(r *http.Request, name string) string {
+	return r.URL.Query().Get(name)
+}
+
+// QueryParamOrDefault gets a query parameter with a fallback default value.
+func (q *defaultQueryExtractor) QueryParamOrDefault(r *http.Request, name, defaultVal string) string {
+	val := r.URL.Query().Get(name)
+	if val == "" {
+		return defaultVal
+	}
+	return val
+}
+
+// QueryParamAs extracts and converts a query parameter to type T.
+// Returns an error if conversion fails.
+// For missing parameters, returns the zero value and no error (use pointer types for optional params).
+// Supported types: string, int, int8, int16, int32, int64,
+// uint, uint8, uint16, uint32, uint64, float32, float64, bool
+func QueryParamAs[T ParamType](r *http.Request, name string) (T, error) {
+	var zero T
+	val := Query.QueryParam(r, name)
+	if val == "" {
+		return zero, nil
+	}
+
+	switch any(zero).(type) {
+	case string:
+		return any(val).(T), nil
+	case int:
+		n, err := strconv.Atoi(val)
+		if err != nil {
+			return zero, fmt.Errorf("query param %q: invalid int: %w", name, err)
+		}
+		return any(n).(T), nil
+	case int8:
+		n, err := strconv.ParseInt(val, 10, 8)
+		if err != nil {
+			return zero, fmt.Errorf("query param %q: invalid int8: %w", name, err)
+		}
+		return any(int8(n)).(T), nil
+	case int16:
+		n, err := strconv.ParseInt(val, 10, 16)
+		if err != nil {
+			return zero, fmt.Errorf("query param %q: invalid int16: %w", name, err)
+		}
+		return any(int16(n)).(T), nil
+	case int32:
+		n, err := strconv.ParseInt(val, 10, 32)
+		if err != nil {
+			return zero, fmt.Errorf("query param %q: invalid int32: %w", name, err)
+		}
+		return any(int32(n)).(T), nil
+	case int64:
+		n, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return zero, fmt.Errorf("query param %q: invalid int64: %w", name, err)
+		}
+		return any(n).(T), nil
+	case uint:
+		n, err := strconv.ParseUint(val, 10, 0)
+		if err != nil {
+			return zero, fmt.Errorf("query param %q: invalid uint: %w", name, err)
+		}
+		return any(uint(n)).(T), nil
+	case uint8:
+		n, err := strconv.ParseUint(val, 10, 8)
+		if err != nil {
+			return zero, fmt.Errorf("query param %q: invalid uint8: %w", name, err)
+		}
+		return any(uint8(n)).(T), nil
+	case uint16:
+		n, err := strconv.ParseUint(val, 10, 16)
+		if err != nil {
+			return zero, fmt.Errorf("query param %q: invalid uint16: %w", name, err)
+		}
+		return any(uint16(n)).(T), nil
+	case uint32:
+		n, err := strconv.ParseUint(val, 10, 32)
+		if err != nil {
+			return zero, fmt.Errorf("query param %q: invalid uint32: %w", name, err)
+		}
+		return any(uint32(n)).(T), nil
+	case uint64:
+		n, err := strconv.ParseUint(val, 10, 64)
+		if err != nil {
+			return zero, fmt.Errorf("query param %q: invalid uint64: %w", name, err)
+		}
+		return any(n).(T), nil
+	case float32:
+		n, err := strconv.ParseFloat(val, 32)
+		if err != nil {
+			return zero, fmt.Errorf("query param %q: invalid float32: %w", name, err)
+		}
+		return any(float32(n)).(T), nil
+	case float64:
+		n, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			return zero, fmt.Errorf("query param %q: invalid float64: %w", name, err)
+		}
+		return any(n).(T), nil
+	case bool:
+		n, err := strconv.ParseBool(val)
+		if err != nil {
+			return zero, fmt.Errorf("query param %q: invalid bool: %w", name, err)
+		}
+		return any(n).(T), nil
+	default:
+		return zero, fmt.Errorf("query param %q: unsupported type", name)
+	}
+}
+
+// QueryParamAsOrDefault extracts and converts a query parameter to type T,
+// returning a default value if the parameter is missing or conversion fails.
+func QueryParamAsOrDefault[T ParamType](r *http.Request, name string, defaultVal T) T {
+	val, err := QueryParamAs[T](r, name)
+	if err != nil {
+		return defaultVal
+	}
+	// Check for zero value (missing param) and return default
+	var zero T
+	if any(val) == any(zero) {
+		// Check if param actually exists
+		if Query.QueryParam(r, name) == "" {
+			return defaultVal
+		}
+	}
+	return val
+}
+
+// QueryParam is a convenience function that calls Query.QueryParam
+func QueryParam(r *http.Request, name string) string {
+	return Query.QueryParam(r, name)
+}
+
+// QueryParamOrDefault is a convenience function that calls Query.QueryParamOrDefault
+func QueryParamOrDefault(r *http.Request, name, defaultVal string) string {
+	return Query.QueryParamOrDefault(r, name, defaultVal)
+}

--- a/query_test.go
+++ b/query_test.go
@@ -1,0 +1,548 @@
+package zerohttp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestQueryExtractor_QueryParam(t *testing.T) {
+	tests := []struct {
+		name        string
+		query       string
+		paramName   string
+		expectedVal string
+	}{
+		{
+			name:        "existing param",
+			query:       "page=10&limit=20",
+			paramName:   "page",
+			expectedVal: "10",
+		},
+		{
+			name:        "another existing param",
+			query:       "page=10&limit=20",
+			paramName:   "limit",
+			expectedVal: "20",
+		},
+		{
+			name:        "missing param",
+			query:       "page=10",
+			paramName:   "limit",
+			expectedVal: "",
+		},
+		{
+			name:        "empty query",
+			query:       "",
+			paramName:   "page",
+			expectedVal: "",
+		},
+		{
+			name:        "empty param value",
+			query:       "page=",
+			paramName:   "page",
+			expectedVal: "",
+		},
+		{
+			name:        "url encoded value",
+			query:       "search=hello%20world",
+			paramName:   "search",
+			expectedVal: "hello world",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/?"+tt.query, nil)
+
+			result := Query.QueryParam(req, tt.paramName)
+			if result != tt.expectedVal {
+				t.Errorf("QueryParam(%q) = %q, want %q", tt.paramName, result, tt.expectedVal)
+			}
+
+			// Also test convenience function
+			result2 := QueryParam(req, tt.paramName)
+			if result2 != tt.expectedVal {
+				t.Errorf("QueryParam() convenience function = %q, want %q", result2, tt.expectedVal)
+			}
+		})
+	}
+}
+
+func TestQueryExtractor_QueryParamOrDefault(t *testing.T) {
+	tests := []struct {
+		name        string
+		query       string
+		paramName   string
+		defaultVal  string
+		expectedVal string
+	}{
+		{
+			name:        "existing param uses value",
+			query:       "page=10",
+			paramName:   "page",
+			defaultVal:  "1",
+			expectedVal: "10",
+		},
+		{
+			name:        "missing param uses default",
+			query:       "other=value",
+			paramName:   "page",
+			defaultVal:  "1",
+			expectedVal: "1",
+		},
+		{
+			name:        "empty param uses default",
+			query:       "page=",
+			paramName:   "page",
+			defaultVal:  "1",
+			expectedVal: "1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/?"+tt.query, nil)
+
+			result := Query.QueryParamOrDefault(req, tt.paramName, tt.defaultVal)
+			if result != tt.expectedVal {
+				t.Errorf("QueryParamOrDefault(%q, %q) = %q, want %q",
+					tt.paramName, tt.defaultVal, result, tt.expectedVal)
+			}
+
+			// Also test convenience function
+			result2 := QueryParamOrDefault(req, tt.paramName, tt.defaultVal)
+			if result2 != tt.expectedVal {
+				t.Errorf("QueryParamOrDefault() convenience function = %q, want %q", result2, tt.expectedVal)
+			}
+		})
+	}
+}
+
+func TestQueryParamAs_String(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/?name=John", nil)
+
+	result, err := QueryParamAs[string](req, "name")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if result != "John" {
+		t.Errorf("expected 'John', got %q", result)
+	}
+
+	// Missing param returns zero value
+	missing, err := QueryParamAs[string](req, "missing")
+	if err != nil {
+		t.Errorf("unexpected error for missing param: %v", err)
+	}
+	if missing != "" {
+		t.Errorf("expected empty string for missing param, got %q", missing)
+	}
+}
+
+func TestQueryParamAs_IntTypes(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/?num=42&neg=-10&big=10000000000", nil)
+
+	tests := []struct {
+		name     string
+		fn       func() (any, error)
+		expected any
+	}{
+		{
+			name: "int",
+			fn: func() (any, error) {
+				return QueryParamAs[int](req, "num")
+			},
+			expected: 42,
+		},
+		{
+			name: "int8",
+			fn: func() (any, error) {
+				return QueryParamAs[int8](req, "num")
+			},
+			expected: int8(42),
+		},
+		{
+			name: "int16",
+			fn: func() (any, error) {
+				return QueryParamAs[int16](req, "num")
+			},
+			expected: int16(42),
+		},
+		{
+			name: "int32",
+			fn: func() (any, error) {
+				return QueryParamAs[int32](req, "num")
+			},
+			expected: int32(42),
+		},
+		{
+			name: "int64",
+			fn: func() (any, error) {
+				return QueryParamAs[int64](req, "big")
+			},
+			expected: int64(10000000000),
+		},
+		{
+			name: "negative int",
+			fn: func() (any, error) {
+				return QueryParamAs[int](req, "neg")
+			},
+			expected: -10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.fn()
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestQueryParamAs_UintTypes(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/?num=42&big=10000000000", nil)
+
+	tests := []struct {
+		name     string
+		fn       func() (any, error)
+		expected any
+	}{
+		{
+			name: "uint",
+			fn: func() (any, error) {
+				return QueryParamAs[uint](req, "num")
+			},
+			expected: uint(42),
+		},
+		{
+			name: "uint8",
+			fn: func() (any, error) {
+				return QueryParamAs[uint8](req, "num")
+			},
+			expected: uint8(42),
+		},
+		{
+			name: "uint16",
+			fn: func() (any, error) {
+				return QueryParamAs[uint16](req, "num")
+			},
+			expected: uint16(42),
+		},
+		{
+			name: "uint32",
+			fn: func() (any, error) {
+				return QueryParamAs[uint32](req, "num")
+			},
+			expected: uint32(42),
+		},
+		{
+			name: "uint64",
+			fn: func() (any, error) {
+				return QueryParamAs[uint64](req, "big")
+			},
+			expected: uint64(10000000000),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.fn()
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestQueryParamAs_FloatTypes(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/?pi=3.14&big=1.7976931348623157e+308", nil)
+
+	// float32
+	result32, err := QueryParamAs[float32](req, "pi")
+	if err != nil {
+		t.Errorf("unexpected error for float32: %v", err)
+	}
+	if result32 != 3.14 {
+		t.Errorf("expected 3.14, got %f", result32)
+	}
+
+	// float64
+	result64, err := QueryParamAs[float64](req, "pi")
+	if err != nil {
+		t.Errorf("unexpected error for float64: %v", err)
+	}
+	if result64 != 3.14 {
+		t.Errorf("expected 3.14, got %f", result64)
+	}
+}
+
+func TestQueryParamAs_Bool(t *testing.T) {
+	tests := []struct {
+		value    string
+		expected bool
+	}{
+		{"true", true},
+		{"True", true},
+		{"TRUE", true},
+		{"1", true},
+		{"t", true},
+		{"T", true},
+		{"false", false},
+		{"False", false},
+		{"FALSE", false},
+		{"0", false},
+		{"f", false},
+		{"F", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/?active="+tt.value, nil)
+
+			result, err := QueryParamAs[bool](req, "active")
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestQueryParamAs_MissingParam(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/?other=value", nil)
+
+	// Missing param should return zero value and no error
+	result, err := QueryParamAs[int](req, "page")
+	if err != nil {
+		t.Errorf("unexpected error for missing param: %v", err)
+	}
+	if result != 0 {
+		t.Errorf("expected 0 for missing param, got %d", result)
+	}
+}
+
+func TestQueryParamAs_InvalidValues(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/?num=abc&float=xyz&bool=maybe", nil)
+
+	tests := []struct {
+		name string
+		fn   func() (any, error)
+	}{
+		{
+			name: "invalid int",
+			fn: func() (any, error) {
+				return QueryParamAs[int](req, "num")
+			},
+		},
+		{
+			name: "invalid int8",
+			fn: func() (any, error) {
+				return QueryParamAs[int8](req, "num")
+			},
+		},
+		{
+			name: "invalid int16",
+			fn: func() (any, error) {
+				return QueryParamAs[int16](req, "num")
+			},
+		},
+		{
+			name: "invalid int32",
+			fn: func() (any, error) {
+				return QueryParamAs[int32](req, "num")
+			},
+		},
+		{
+			name: "invalid int64",
+			fn: func() (any, error) {
+				return QueryParamAs[int64](req, "num")
+			},
+		},
+		{
+			name: "invalid uint",
+			fn: func() (any, error) {
+				return QueryParamAs[uint](req, "num")
+			},
+		},
+		{
+			name: "invalid uint8",
+			fn: func() (any, error) {
+				return QueryParamAs[uint8](req, "num")
+			},
+		},
+		{
+			name: "invalid uint16",
+			fn: func() (any, error) {
+				return QueryParamAs[uint16](req, "num")
+			},
+		},
+		{
+			name: "invalid uint32",
+			fn: func() (any, error) {
+				return QueryParamAs[uint32](req, "num")
+			},
+		},
+		{
+			name: "invalid uint64",
+			fn: func() (any, error) {
+				return QueryParamAs[uint64](req, "num")
+			},
+		},
+		{
+			name: "invalid float32",
+			fn: func() (any, error) {
+				return QueryParamAs[float32](req, "float")
+			},
+		},
+		{
+			name: "invalid float64",
+			fn: func() (any, error) {
+				return QueryParamAs[float64](req, "float")
+			},
+		},
+		{
+			name: "invalid bool",
+			fn: func() (any, error) {
+				return QueryParamAs[bool](req, "bool")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.fn()
+			if err == nil {
+				t.Error("expected error but got none")
+			}
+		})
+	}
+}
+
+func TestQueryParamAsOrDefault(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/?page=10&limit=", nil)
+
+	tests := []struct {
+		name        string
+		paramName   string
+		defaultVal  int
+		expectedVal int
+	}{
+		{
+			name:        "existing value uses it",
+			paramName:   "page",
+			defaultVal:  1,
+			expectedVal: 10,
+		},
+		{
+			name:        "missing uses default",
+			paramName:   "offset",
+			defaultVal:  0,
+			expectedVal: 0,
+		},
+		{
+			name:        "empty value uses default",
+			paramName:   "limit",
+			defaultVal:  20,
+			expectedVal: 20,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := QueryParamAsOrDefault(req, tt.paramName, tt.defaultVal)
+			if result != tt.expectedVal {
+				t.Errorf("QueryParamAsOrDefault(%q, %d) = %d, want %d",
+					tt.paramName, tt.defaultVal, result, tt.expectedVal)
+			}
+		})
+	}
+}
+
+func TestQueryParamAsOrDefault_InvalidConversion(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/?page=abc", nil)
+
+	// Invalid conversion returns default
+	result := QueryParamAsOrDefault(req, "page", 1)
+	if result != 1 {
+		t.Errorf("expected default 1 for invalid conversion, got %d", result)
+	}
+}
+
+func TestQueryParamAsOrDefault_String(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/?sort=name", nil)
+
+	// Existing value
+	result := QueryParamAsOrDefault(req, "sort", "id")
+	if result != "name" {
+		t.Errorf("expected 'name', got %q", result)
+	}
+
+	// Missing value
+	result = QueryParamAsOrDefault(req, "order", "asc")
+	if result != "asc" {
+		t.Errorf("expected 'asc', got %q", result)
+	}
+}
+
+func TestQueryParamAsOrDefault_Bool(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/?active=true", nil)
+
+	// Existing true value
+	result := QueryParamAsOrDefault(req, "active", false)
+	if !result {
+		t.Error("expected true")
+	}
+
+	// Missing value uses default
+	result = QueryParamAsOrDefault(req, "enabled", true)
+	if !result {
+		t.Error("expected default true for missing param")
+	}
+}
+
+func TestQueryParam_CaseSensitivity(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/?Page=10&PAGE=20", nil)
+
+	// Query params are case-sensitive
+	page := Query.QueryParam(req, "Page")
+	if page != "10" {
+		t.Errorf("expected Page='10', got %q", page)
+	}
+
+	pageUpper := Query.QueryParam(req, "PAGE")
+	if pageUpper != "20" {
+		t.Errorf("expected PAGE='20', got %q", pageUpper)
+	}
+
+	pageLower := Query.QueryParam(req, "page")
+	if pageLower != "" {
+		t.Errorf("expected page='', got %q (query params are case-sensitive)", pageLower)
+	}
+}
+
+func TestQueryParam_MultipleValues(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/?tag=go&tag=web&tag=api", nil)
+
+	// Query().Get() returns the first value
+	tag := Query.QueryParam(req, "tag")
+	if tag != "go" {
+		t.Errorf("expected first value 'go', got %q", tag)
+	}
+
+	// Verify all values are accessible via URL.Query()
+	allTags := req.URL.Query()["tag"]
+	if len(allTags) != 3 {
+		t.Errorf("expected 3 values, got %d", len(allTags))
+	}
+}


### PR DESCRIPTION
Add Bind.Query() for struct-based binding using `query` tags and QueryParamAs[T]() for type-safe individual parameter extraction. Includes comprehensive tests and working example.