### PR TITLE
feat: add graceful shutdown hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A lightweight HTTP framework for Go built on top of the standard `net/http` libr
     - [WebTransport Support](#webtransport-support)
 - [Health Checks](#health-checks)
 - [Circuit Breaker](#circuit-breaker)
+- [Graceful Shutdown](#graceful-shutdown)
 - [Configuration Reference](#configuration-reference)
     - [Server Configuration](#server-configuration)
     - [Middleware Configuration](#middleware-configuration)
@@ -895,6 +896,57 @@ app.Use(middleware.CircuitBreaker(
 The circuit breaker operates in three states: **Closed** (normal), **Open** (blocked), and **Half-Open** (testing recovery). It prevents cascading failures when downstream services are unavailable.
 
 
+## Graceful Shutdown
+
+zerohttp provides graceful shutdown hooks for cleanup tasks during server shutdown. Hooks are called during `Shutdown()` and allow you to perform cleanup like closing database connections, flushing logs, and notifying external systems.
+
+**⚠️ Important:** Hooks **must** respect context cancellation by checking `ctx.Done()`. If a hook blocks without respecting the context, shutdown will hang.
+
+```go
+app := zh.New(
+    // Pre-shutdown: run before servers start shutting down (sequential)
+    config.WithPreShutdownHook("health", func(ctx context.Context) error {
+        // Mark service as unhealthy to stop receiving traffic
+        health.SetUnhealthy()
+        return nil
+    }),
+
+    // Shutdown: run concurrently with server shutdown
+    config.WithShutdownHook("flush-logs", func(ctx context.Context) error {
+        return logger.Flush()
+    }),
+    config.WithShutdownHook("close-db", func(ctx context.Context) error {
+        // Always check context cancellation for long operations
+        select {
+        case <-ctx.Done():
+            return ctx.Err()
+        default:
+            return db.Close()
+        }
+    }),
+
+    // Post-shutdown: run after all servers are stopped (sequential)
+    config.WithPostShutdownHook("cleanup", func(ctx context.Context) error {
+        return os.RemoveAll("/tmp/app-*")
+    }),
+)
+
+// Hooks can also be registered programmatically
+app.RegisterShutdownHook("metrics", func(ctx context.Context) error {
+    return metrics.Push(ctx, gateway)
+})
+```
+
+### Hook Execution Order
+
+1. **Pre-shutdown hooks** - Execute sequentially in registration order
+2. **Server shutdown** - HTTP/HTTPS/HTTP3 servers shut down concurrently
+3. **Shutdown hooks** - Execute concurrently alongside server shutdown
+4. **Post-shutdown hooks** - Execute sequentially in registration order
+
+Hook errors are logged but do not stop the shutdown process. Context errors (`context.Canceled` or `context.DeadlineExceeded`) from pre-shutdown hooks will abort shutdown early.
+
+
 ## Configuration Reference
 
 The functional options pattern provides structured configuration for all aspects of the server:
@@ -912,6 +964,9 @@ The functional options pattern provides structured configuration for all aspects
 - `config.WithAutocertManager()` - Let's Encrypt integration
 - `config.WithHTTP3Server()` - HTTP/3 server (e.g., quic-go)
 - `config.WithWebTransportServer()` - WebTransport server (e.g., webtransport-go)
+- `config.WithPreShutdownHook()` - Hook to run before server shutdown
+- `config.WithShutdownHook()` - Hook to run concurrently with server shutdown
+- `config.WithPostShutdownHook()` - Hook to run after server shutdown
 
 
 ### Middleware Configuration

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,20 @@ import (
 	"github.com/alexferl/zerohttp/log"
 )
 
+// ShutdownHook is a function called during server shutdown.
+// The context passed to the hook will be cancelled when the shutdown
+// timeout is reached or if the parent context is cancelled.
+//
+// Hooks must respect context cancellation by checking ctx.Done().
+// If a hook blocks without respecting the context, shutdown will hang.
+type ShutdownHook func(ctx context.Context) error
+
+// ShutdownHookConfig configures a shutdown hook.
+type ShutdownHookConfig struct {
+	Name string
+	Hook ShutdownHook
+}
+
 // Config holds server and middleware configuration options for zerohttp.
 type Config struct {
 	// Addr is the address for the HTTP server to listen on.
@@ -104,6 +118,21 @@ type Config struct {
 	// The server will be started automatically when ListenAndServeTLS or Start is called.
 	// Default: nil
 	WebTransportServer WebTransportServer
+
+	// PreShutdownHooks are hooks that execute sequentially before server shutdown begins.
+	// These run before any servers start shutting down.
+	// Default: nil
+	PreShutdownHooks []ShutdownHookConfig
+
+	// ShutdownHooks are hooks that execute concurrently with server shutdown.
+	// These run alongside the HTTP/HTTPS/HTTP3 server shutdown.
+	// Default: nil
+	ShutdownHooks []ShutdownHookConfig
+
+	// PostShutdownHooks are hooks that execute sequentially after all servers are shut down.
+	// These run after all servers have completed shutdown.
+	// Default: nil
+	PostShutdownHooks []ShutdownHookConfig
 }
 
 // DefaultConfig contains all default values used by Config.
@@ -405,5 +434,57 @@ func WithHTTP3Server(server HTTP3Server) Option {
 func WithWebTransportServer(server WebTransportServer) Option {
 	return func(c *Config) {
 		c.WebTransportServer = server
+	}
+}
+
+// WithPreShutdownHook registers a hook to run before server shutdown begins.
+// Pre-shutdown hooks execute sequentially in registration order.
+//
+// Hooks must respect context cancellation by checking ctx.Done().
+// If a hook blocks without respecting the context, shutdown will hang.
+//
+// Example:
+//
+//	zerohttp.New(zerohttp.WithPreShutdownHook("health", func(ctx context.Context) error {
+//	    health.SetUnhealthy()
+//	    return nil
+//	}))
+func WithPreShutdownHook(name string, hook ShutdownHook) Option {
+	return func(c *Config) {
+		c.PreShutdownHooks = append(c.PreShutdownHooks, ShutdownHookConfig{Name: name, Hook: hook})
+	}
+}
+
+// WithShutdownHook registers a hook to run concurrently with server shutdown.
+// Shutdown hooks execute concurrently alongside server shutdown.
+//
+// Hooks must respect context cancellation by checking ctx.Done().
+// If a hook blocks without respecting the context, shutdown will hang.
+//
+// Example:
+//
+//	zerohttp.New(zerohttp.WithShutdownHook("close-db", func(ctx context.Context) error {
+//	    return db.Close()
+//	}))
+func WithShutdownHook(name string, hook ShutdownHook) Option {
+	return func(c *Config) {
+		c.ShutdownHooks = append(c.ShutdownHooks, ShutdownHookConfig{Name: name, Hook: hook})
+	}
+}
+
+// WithPostShutdownHook registers a hook to run after servers are shut down.
+// Post-shutdown hooks execute sequentially in registration order.
+//
+// Hooks must respect context cancellation by checking ctx.Done().
+// If a hook blocks without respecting the context, shutdown will hang.
+//
+// Example:
+//
+//	zerohttp.New(zerohttp.WithPostShutdownHook("cleanup", func(ctx context.Context) error {
+//	    return os.RemoveAll("/tmp/app-*")
+//	}))
+func WithPostShutdownHook(name string, hook ShutdownHook) Option {
+	return func(c *Config) {
+		c.PostShutdownHooks = append(c.PostShutdownHooks, ShutdownHookConfig{Name: name, Hook: hook})
 	}
 }

--- a/config/config_shutdown_hooks_test.go
+++ b/config/config_shutdown_hooks_test.go
@@ -1,0 +1,161 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestWithPreShutdownHook(t *testing.T) {
+	called := false
+	hook := func(ctx context.Context) error {
+		called = true
+		return nil
+	}
+
+	cfg := DefaultConfig
+	opt := WithPreShutdownHook("test-hook", hook)
+	opt(&cfg)
+
+	if len(cfg.PreShutdownHooks) != 1 {
+		t.Errorf("Expected 1 pre-shutdown hook, got %d", len(cfg.PreShutdownHooks))
+	}
+
+	if cfg.PreShutdownHooks[0].Name != "test-hook" {
+		t.Errorf("Expected hook name 'test-hook', got '%s'", cfg.PreShutdownHooks[0].Name)
+	}
+
+	// Verify the hook works
+	err := cfg.PreShutdownHooks[0].Hook(context.Background())
+	if err != nil {
+		t.Errorf("Expected no error from hook, got %v", err)
+	}
+
+	if !called {
+		t.Error("Expected hook to be called")
+	}
+}
+
+func TestWithShutdownHook(t *testing.T) {
+	called := false
+	hook := func(ctx context.Context) error {
+		called = true
+		return nil
+	}
+
+	cfg := DefaultConfig
+	opt := WithShutdownHook("test-hook", hook)
+	opt(&cfg)
+
+	if len(cfg.ShutdownHooks) != 1 {
+		t.Errorf("Expected 1 shutdown hook, got %d", len(cfg.ShutdownHooks))
+	}
+
+	if cfg.ShutdownHooks[0].Name != "test-hook" {
+		t.Errorf("Expected hook name 'test-hook', got '%s'", cfg.ShutdownHooks[0].Name)
+	}
+
+	err := cfg.ShutdownHooks[0].Hook(context.Background())
+	if err != nil {
+		t.Errorf("Expected no error from hook, got %v", err)
+	}
+
+	if !called {
+		t.Error("Expected hook to be called")
+	}
+}
+
+func TestWithPostShutdownHook(t *testing.T) {
+	called := false
+	hook := func(ctx context.Context) error {
+		called = true
+		return nil
+	}
+
+	cfg := DefaultConfig
+	opt := WithPostShutdownHook("test-hook", hook)
+	opt(&cfg)
+
+	if len(cfg.PostShutdownHooks) != 1 {
+		t.Errorf("Expected 1 post-shutdown hook, got %d", len(cfg.PostShutdownHooks))
+	}
+
+	if cfg.PostShutdownHooks[0].Name != "test-hook" {
+		t.Errorf("Expected hook name 'test-hook', got '%s'", cfg.PostShutdownHooks[0].Name)
+	}
+
+	err := cfg.PostShutdownHooks[0].Hook(context.Background())
+	if err != nil {
+		t.Errorf("Expected no error from hook, got %v", err)
+	}
+
+	if !called {
+		t.Error("Expected hook to be called")
+	}
+}
+
+func TestWithMultipleHooks(t *testing.T) {
+	cfg := DefaultConfig
+
+	opt1 := WithPreShutdownHook("hook-1", func(ctx context.Context) error {
+		return nil
+	})
+	opt2 := WithPreShutdownHook("hook-2", func(ctx context.Context) error {
+		return nil
+	})
+
+	opt1(&cfg)
+	opt2(&cfg)
+
+	if len(cfg.PreShutdownHooks) != 2 {
+		t.Errorf("Expected 2 pre-shutdown hooks, got %d", len(cfg.PreShutdownHooks))
+	}
+
+	if cfg.PreShutdownHooks[0].Name != "hook-1" {
+		t.Errorf("Expected first hook name 'hook-1', got '%s'", cfg.PreShutdownHooks[0].Name)
+	}
+
+	if cfg.PreShutdownHooks[1].Name != "hook-2" {
+		t.Errorf("Expected second hook name 'hook-2', got '%s'", cfg.PreShutdownHooks[1].Name)
+	}
+}
+
+func TestShutdownHookWithError(t *testing.T) {
+	expectedErr := errors.New("hook error")
+	hook := func(ctx context.Context) error {
+		return expectedErr
+	}
+
+	cfg := DefaultConfig
+	opt := WithShutdownHook("error-hook", hook)
+	opt(&cfg)
+
+	err := cfg.ShutdownHooks[0].Hook(context.Background())
+	if !errors.Is(err, expectedErr) {
+		t.Errorf("Expected error '%v', got '%v'", expectedErr, err)
+	}
+}
+
+func TestShutdownHookContextCancellation(t *testing.T) {
+	hook := func(ctx context.Context) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return nil
+		}
+	}
+
+	cfg := DefaultConfig
+	opt := WithShutdownHook("ctx-hook", hook)
+	opt(&cfg)
+
+	// Test with cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := cfg.ShutdownHooks[0].Hook(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Expected context.Canceled error, got %v", err)
+	}
+}

--- a/examples/graceful/main.go
+++ b/examples/graceful/main.go
@@ -10,11 +10,43 @@ import (
 	"time"
 
 	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
 	"github.com/alexferl/zerohttp/log"
 )
 
 func main() {
-	app := zh.New()
+	app := zh.New(
+		// Pre-shutdown: mark service as unhealthy first
+		config.WithPreShutdownHook("health", func(ctx context.Context) error {
+			// In a real app, this would update a health check endpoint
+			return nil
+		}),
+
+		// During shutdown: close resources concurrently with server shutdown
+		config.WithShutdownHook("flush-logs", func(ctx context.Context) error {
+			// Simulate log flush
+			time.Sleep(100 * time.Millisecond)
+			return nil
+		}),
+
+		config.WithShutdownHook("close-connections", func(ctx context.Context) error {
+			// Simulate DB connection close
+			time.Sleep(100 * time.Millisecond)
+			return nil
+		}),
+
+		// Post-shutdown: final cleanup after servers are stopped
+		config.WithPostShutdownHook("cleanup", func(ctx context.Context) error {
+			// Cleanup temporary files
+			return nil
+		}),
+	)
+
+	// Hooks can also be registered programmatically
+	app.RegisterShutdownHook("metrics-flush", func(ctx context.Context) error {
+		// Flush metrics to external system
+		return nil
+	})
 
 	app.GET("/", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 		return zh.R.JSON(w, 200, zh.M{"message": "Hello, World!"})
@@ -30,10 +62,14 @@ func main() {
 	signal.Notify(quit, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	<-quit
 
+	app.Logger().Info("Shutting down server...")
+
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	if err := app.Shutdown(ctx); err != nil {
 		app.Logger().Fatal("Server forced to shutdown", log.E(err))
 	}
+
+	app.Logger().Info("Server shutdown complete")
 }

--- a/server.go
+++ b/server.go
@@ -70,6 +70,15 @@ type Server struct {
 	// for recording HTTP requests, errors, and server lifecycle events.
 	logger log.Logger
 
+	// preShutdownHooks execute sequentially before server shutdown begins.
+	preShutdownHooks []config.ShutdownHookConfig
+
+	// shutdownHooks execute concurrently with server shutdown.
+	shutdownHooks []config.ShutdownHookConfig
+
+	// postShutdownHooks execute sequentially after all servers are shut down.
+	postShutdownHooks []config.ShutdownHookConfig
+
 	// mu protects concurrent access to server fields during startup,
 	// shutdown, and configuration operations.
 	mu sync.RWMutex
@@ -143,6 +152,9 @@ func New(opts ...config.Option) *Server {
 		http3Server:        cfg.HTTP3Server,
 		webTransportServer: cfg.WebTransportServer,
 		logger:             logger,
+		preShutdownHooks:   cfg.PreShutdownHooks,
+		shutdownHooks:      cfg.ShutdownHooks,
+		postShutdownHooks:  cfg.PostShutdownHooks,
 	}
 
 	if s.server != nil {
@@ -659,12 +671,29 @@ func (s *Server) SetWebTransportServer(server config.WebTransportServer) {
 //
 // The shutdown process runs concurrently for both servers. If any server
 // encounters an error during shutdown, that error is returned.
+// Shutdown hooks are executed during the shutdown process:
+//   - Pre-shutdown hooks run sequentially before server shutdown begins
+//   - Shutdown hooks run concurrently with server shutdown
+//   - Post-shutdown hooks run sequentially after all servers are shut down
+//
 // Returns the first error encountered during shutdown, or nil if successful.
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.logger.Info("Shutting down server...")
 
+	// Execute pre-shutdown hooks sequentially
+	if err := s.runPreShutdownHooks(ctx); err != nil {
+		s.logger.Error("Pre-shutdown hook error", log.E(err))
+		// Return context errors as they indicate shutdown was cancelled
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+	}
+
+	// Start shutdown hooks concurrently and wait for them
+	hookWg, hookErrCh := s.startShutdownHooks(ctx)
+
 	var wg sync.WaitGroup
-	errCh := make(chan error, 3)
+	errCh := make(chan error, 4)
 
 	if s.server != nil && s.listener != nil {
 		wg.Add(1)
@@ -726,6 +755,15 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	wg.Wait()
 	close(errCh)
 
+	// Wait for shutdown hooks to complete
+	hookWg.Wait()
+	close(hookErrCh)
+
+	// Execute post-shutdown hooks sequentially
+	if err := s.runPostShutdownHooks(ctx); err != nil {
+		s.logger.Error("Post-shutdown hook error", log.E(err))
+	}
+
 	for err := range errCh {
 		if err != nil {
 			return err
@@ -733,6 +771,98 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	}
 
 	s.logger.Info("Server shutdown complete")
+	return nil
+}
+
+// runPreShutdownHooks executes pre-shutdown hooks sequentially in registration order.
+func (s *Server) runPreShutdownHooks(ctx context.Context) error {
+	s.mu.RLock()
+	hooks := s.preShutdownHooks
+	s.mu.RUnlock()
+
+	if len(hooks) == 0 {
+		return nil
+	}
+
+	s.logger.Debug("Running pre-shutdown hooks", log.F("count", len(hooks)))
+
+	for _, hook := range hooks {
+		select {
+		case <-ctx.Done():
+			s.logger.Warn("Pre-shutdown hook aborted due to context cancellation", log.F("hook", hook.Name))
+			return ctx.Err()
+		default:
+		}
+
+		s.logger.Debug("Running pre-shutdown hook", log.F("hook", hook.Name))
+		if err := hook.Hook(ctx); err != nil {
+			s.logger.Error("Pre-shutdown hook failed", log.F("hook", hook.Name), log.E(err))
+			// Continue with other hooks despite error
+		}
+	}
+
+	return nil
+}
+
+// startShutdownHooks starts shutdown hooks concurrently and returns a WaitGroup and error channel.
+// The caller must wait on the returned WaitGroup and then close the error channel.
+func (s *Server) startShutdownHooks(ctx context.Context) (*sync.WaitGroup, chan error) {
+	s.mu.RLock()
+	hooks := s.shutdownHooks
+	s.mu.RUnlock()
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(hooks))
+
+	if len(hooks) == 0 {
+		return &wg, errCh
+	}
+
+	s.logger.Debug("Starting shutdown hooks", log.F("count", len(hooks)))
+
+	for _, hook := range hooks {
+		wg.Add(1)
+		go func(h config.ShutdownHookConfig) {
+			defer wg.Done()
+
+			s.logger.Debug("Running shutdown hook", log.F("hook", h.Name))
+			if err := h.Hook(ctx); err != nil {
+				s.logger.Error("Shutdown hook failed", log.F("hook", h.Name), log.E(err))
+				errCh <- err
+			}
+		}(hook)
+	}
+
+	return &wg, errCh
+}
+
+// runPostShutdownHooks executes post-shutdown hooks sequentially in registration order.
+func (s *Server) runPostShutdownHooks(ctx context.Context) error {
+	s.mu.RLock()
+	hooks := s.postShutdownHooks
+	s.mu.RUnlock()
+
+	if len(hooks) == 0 {
+		return nil
+	}
+
+	s.logger.Debug("Running post-shutdown hooks", log.F("count", len(hooks)))
+
+	for _, hook := range hooks {
+		select {
+		case <-ctx.Done():
+			s.logger.Warn("Post-shutdown hook aborted due to context cancellation", log.F("hook", hook.Name))
+			return ctx.Err()
+		default:
+		}
+
+		s.logger.Debug("Running post-shutdown hook", log.F("hook", hook.Name))
+		if err := hook.Hook(ctx); err != nil {
+			s.logger.Error("Post-shutdown hook failed", log.F("hook", hook.Name), log.E(err))
+			// Continue with other hooks despite error
+		}
+	}
+
 	return nil
 }
 
@@ -840,6 +970,58 @@ func (s *Server) ListenerTLSAddr() string {
 // structured logging capabilities with fields and different log levels.
 func (s *Server) Logger() log.Logger {
 	return s.logger
+}
+
+// RegisterPreShutdownHook registers a hook to run before server shutdown begins.
+// Pre-shutdown hooks execute sequentially in registration order.
+//
+// Hooks must respect context cancellation by checking ctx.Done().
+// If a hook blocks without respecting the context, shutdown will hang.
+//
+// Example:
+//
+//	app.RegisterPreShutdownHook("health", func(ctx context.Context) error {
+//	    health.SetUnhealthy()
+//	    return nil
+//	})
+func (s *Server) RegisterPreShutdownHook(name string, hook config.ShutdownHook) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.preShutdownHooks = append(s.preShutdownHooks, config.ShutdownHookConfig{Name: name, Hook: hook})
+}
+
+// RegisterShutdownHook registers a hook to run concurrently with server shutdown.
+// Shutdown hooks execute concurrently alongside server shutdown.
+//
+// Hooks must respect context cancellation by checking ctx.Done().
+// If a hook blocks without respecting the context, shutdown will hang.
+//
+// Example:
+//
+//	app.RegisterShutdownHook("close-db", func(ctx context.Context) error {
+//	    return db.Close()
+//	})
+func (s *Server) RegisterShutdownHook(name string, hook config.ShutdownHook) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.shutdownHooks = append(s.shutdownHooks, config.ShutdownHookConfig{Name: name, Hook: hook})
+}
+
+// RegisterPostShutdownHook registers a hook to run after servers are shut down.
+// Post-shutdown hooks execute sequentially in registration order.
+//
+// Hooks must respect context cancellation by checking ctx.Done().
+// If a hook blocks without respecting the context, shutdown will hang.
+//
+// Example:
+//
+//	app.RegisterPostShutdownHook("cleanup", func(ctx context.Context) error {
+//	    return os.RemoveAll("/tmp/app-*")
+//	})
+func (s *Server) RegisterPostShutdownHook(name string, hook config.ShutdownHook) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.postShutdownHooks = append(s.postShutdownHooks, config.ShutdownHookConfig{Name: name, Hook: hook})
 }
 
 func fmtHTTPAddr(addr string) string {

--- a/server_test.go
+++ b/server_test.go
@@ -1650,3 +1650,292 @@ func TestServer_ListenerTLSAddr_Empty(t *testing.T) {
 		t.Errorf("Expected empty TLS address, got '%s'", addr)
 	}
 }
+
+// Shutdown Hooks Tests
+
+func TestServer_RegisterPreShutdownHook(t *testing.T) {
+	server := New()
+
+	called := false
+	server.RegisterPreShutdownHook("test-hook", func(ctx context.Context) error {
+		called = true
+		return nil
+	})
+
+	if len(server.preShutdownHooks) != 1 {
+		t.Errorf("Expected 1 pre-shutdown hook, got %d", len(server.preShutdownHooks))
+	}
+
+	if server.preShutdownHooks[0].Name != "test-hook" {
+		t.Errorf("Expected hook name 'test-hook', got '%s'", server.preShutdownHooks[0].Name)
+	}
+
+	// Verify hook works
+	err := server.preShutdownHooks[0].Hook(context.Background())
+	if err != nil {
+		t.Errorf("Expected no error from hook, got %v", err)
+	}
+
+	if !called {
+		t.Error("Expected hook to be called")
+	}
+}
+
+func TestServer_RegisterShutdownHook(t *testing.T) {
+	server := New()
+
+	called := false
+	server.RegisterShutdownHook("test-hook", func(ctx context.Context) error {
+		called = true
+		return nil
+	})
+
+	if len(server.shutdownHooks) != 1 {
+		t.Errorf("Expected 1 shutdown hook, got %d", len(server.shutdownHooks))
+	}
+
+	if server.shutdownHooks[0].Name != "test-hook" {
+		t.Errorf("Expected hook name 'test-hook', got '%s'", server.shutdownHooks[0].Name)
+	}
+
+	err := server.shutdownHooks[0].Hook(context.Background())
+	if err != nil {
+		t.Errorf("Expected no error from hook, got %v", err)
+	}
+
+	if !called {
+		t.Error("Expected hook to be called")
+	}
+}
+
+func TestServer_RegisterPostShutdownHook(t *testing.T) {
+	server := New()
+
+	called := false
+	server.RegisterPostShutdownHook("test-hook", func(ctx context.Context) error {
+		called = true
+		return nil
+	})
+
+	if len(server.postShutdownHooks) != 1 {
+		t.Errorf("Expected 1 post-shutdown hook, got %d", len(server.postShutdownHooks))
+	}
+
+	if server.postShutdownHooks[0].Name != "test-hook" {
+		t.Errorf("Expected hook name 'test-hook', got '%s'", server.postShutdownHooks[0].Name)
+	}
+
+	err := server.postShutdownHooks[0].Hook(context.Background())
+	if err != nil {
+		t.Errorf("Expected no error from hook, got %v", err)
+	}
+
+	if !called {
+		t.Error("Expected hook to be called")
+	}
+}
+
+func TestServer_Shutdown_WithPreShutdownHooks(t *testing.T) {
+	listener, _ := net.Listen("tcp", "127.0.0.1:0")
+	server := New()
+	server.listener = listener
+	server.server = &http.Server{Addr: listener.Addr().String()}
+
+	var order []string
+	server.RegisterPreShutdownHook("hook-1", func(ctx context.Context) error {
+		order = append(order, "hook-1")
+		return nil
+	})
+	server.RegisterPreShutdownHook("hook-2", func(ctx context.Context) error {
+		order = append(order, "hook-2")
+		return nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := server.Shutdown(ctx)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	if len(order) != 2 {
+		t.Errorf("Expected 2 hooks to run, got %d", len(order))
+	}
+
+	if order[0] != "hook-1" || order[1] != "hook-2" {
+		t.Errorf("Expected hooks to run in registration order, got %v", order)
+	}
+}
+
+func TestServer_Shutdown_WithPostShutdownHooks(t *testing.T) {
+	listener, _ := net.Listen("tcp", "127.0.0.1:0")
+	server := New()
+	server.listener = listener
+	server.server = &http.Server{Addr: listener.Addr().String()}
+
+	var order []string
+	server.RegisterPostShutdownHook("hook-1", func(ctx context.Context) error {
+		order = append(order, "hook-1")
+		return nil
+	})
+	server.RegisterPostShutdownHook("hook-2", func(ctx context.Context) error {
+		order = append(order, "hook-2")
+		return nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := server.Shutdown(ctx)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	if len(order) != 2 {
+		t.Errorf("Expected 2 hooks to run, got %d", len(order))
+	}
+
+	if order[0] != "hook-1" || order[1] != "hook-2" {
+		t.Errorf("Expected hooks to run in registration order, got %v", order)
+	}
+}
+
+func TestServer_Shutdown_WithShutdownHooks(t *testing.T) {
+	listener, _ := net.Listen("tcp", "127.0.0.1:0")
+	server := New()
+	server.listener = listener
+	server.server = &http.Server{Addr: listener.Addr().String()}
+
+	var mu sync.Mutex
+	var calls []string
+	server.RegisterShutdownHook("hook-1", func(ctx context.Context) error {
+		mu.Lock()
+		calls = append(calls, "hook-1")
+		mu.Unlock()
+		return nil
+	})
+	server.RegisterShutdownHook("hook-2", func(ctx context.Context) error {
+		mu.Lock()
+		calls = append(calls, "hook-2")
+		mu.Unlock()
+		return nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := server.Shutdown(ctx)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	mu.Lock()
+	if len(calls) != 2 {
+		t.Errorf("Expected 2 shutdown hooks to run, got %d", len(calls))
+	}
+	mu.Unlock()
+}
+
+func TestServer_Shutdown_HooksContinueOnError(t *testing.T) {
+	listener, _ := net.Listen("tcp", "127.0.0.1:0")
+	server := New()
+	server.listener = listener
+	server.server = &http.Server{Addr: listener.Addr().String()}
+
+	var calls []string
+	server.RegisterPreShutdownHook("failing-hook", func(ctx context.Context) error {
+		calls = append(calls, "failing")
+		return errors.New("hook error")
+	})
+	server.RegisterPreShutdownHook("success-hook", func(ctx context.Context) error {
+		calls = append(calls, "success")
+		return nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	// Shutdown should complete without returning the hook error
+	err := server.Shutdown(ctx)
+	if err != nil {
+		t.Errorf("Expected no error from server shutdown, got %v", err)
+	}
+
+	// Both hooks should have been called
+	if len(calls) != 2 {
+		t.Errorf("Expected both hooks to run, got %v", calls)
+	}
+
+	if calls[0] != "failing" || calls[1] != "success" {
+		t.Errorf("Expected hooks to run in order despite first failing, got %v", calls)
+	}
+}
+
+func TestServer_Shutdown_HooksRespectContextCancellation(t *testing.T) {
+	listener, _ := net.Listen("tcp", "127.0.0.1:0")
+	server := New()
+	server.listener = listener
+	server.server = &http.Server{Addr: listener.Addr().String()}
+
+	// Create a context that's already cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	called := false
+	server.RegisterPreShutdownHook("should-not-run", func(ctx context.Context) error {
+		called = true
+		return nil
+	})
+
+	err := server.Shutdown(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Expected context.Canceled error, got %v", err)
+	}
+
+	// Hook should not have been called due to cancelled context
+	if called {
+		t.Error("Expected hook not to be called due to cancelled context")
+	}
+}
+
+func TestServer_ConfigWithShutdownHooks(t *testing.T) {
+	var preCalled, shutdownCalled, postCalled bool
+
+	server := New(
+		config.WithPreShutdownHook("pre", func(ctx context.Context) error {
+			preCalled = true
+			return nil
+		}),
+		config.WithShutdownHook("shutdown", func(ctx context.Context) error {
+			shutdownCalled = true
+			return nil
+		}),
+		config.WithPostShutdownHook("post", func(ctx context.Context) error {
+			postCalled = true
+			return nil
+		}),
+	)
+
+	listener, _ := net.Listen("tcp", "127.0.0.1:0")
+	server.listener = listener
+	server.server = &http.Server{Addr: listener.Addr().String()}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := server.Shutdown(ctx)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	if !preCalled {
+		t.Error("Expected pre-shutdown hook to be called")
+	}
+	if !shutdownCalled {
+		t.Error("Expected shutdown hook to be called")
+	}
+	if !postCalled {
+		t.Error("Expected post-shutdown hook to be called")
+	}
+}


### PR DESCRIPTION
Add user-defined callback functions for cleanup tasks during server shutdown. Supports three hook types:
- Pre-shutdown: run sequentially before servers stop
- Shutdown: run concurrently with server shutdown
- Post-shutdown: run sequentially after servers stop

API:
- config.WithPreShutdownHook/WithShutdownHook/WithPostShutdownHook
- server.RegisterPreShutdownHook/RegisterShutdownHook/RegisterPostShutdownHook

Hooks receive a context that is cancelled when shutdown timeout is reached. Hooks must respect ctx.Done() to avoid blocking shutdown indefinitely.