### PR TITLE
feat: add SSE support with replay and broadcast hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A lightweight HTTP framework for Go built on top of the standard `net/http` libr
 - [Pluggable Features](#pluggable-features)
     - [Auto-TLS](#auto-tls)
     - [HTTP/3 Support](#http3-support)
+    - [SSE Support](#sse-support)
     - [WebSocket Support](#websocket-support)
     - [WebTransport Support](#webtransport-support)
 - [Health Checks](#health-checks)
@@ -51,7 +52,8 @@ A lightweight HTTP framework for Go built on top of the standard `net/http` libr
 - **Middleware Support**: Comprehensive middleware system with built-in security, logging, and utility middlewares
 - **Built-in Security**: CORS, rate limiting, request body size limits, security headers, and more
 - **HTTP/2 & HTTP/3**: Automatic HTTP/2 support for TLS; optional HTTP/3 via pluggable interface
-- **Pluggable Architecture**: Extensible interfaces for Auto-TLS, HTTP/3, WebSocket, and WebTransport - bring your own implementations
+- **Pluggable Architecture**: Extensible interfaces for Auto-TLS, HTTP/3, WebSocket, WebTransport, and SSE - bring your own implementations
+- **Server-Sent Events**: Built-in SSE support with event replay and broadcast hub for real-time server-to-client streaming
 - **Request Tracing**: Built-in request ID generation and propagation
 - **Circuit Breaker**: Prevent cascading failures with configurable circuit breaker middleware
 - **Structured Logging**: Integrated structured logging with customizable fields
@@ -793,6 +795,38 @@ app.StartTLS("cert.pem", "key.pem")
 ```
 
 
+### SSE Support
+
+Server-Sent Events (SSE) provides real-time unidirectional server-to-client streaming over HTTP.
+zerohttp includes a built-in stdlib implementation with support for event replay and broadcast hubs.
+
+```go
+import (
+    "time"
+
+    zh "github.com/alexferl/zerohttp"
+    "github.com/alexferl/zerohttp/config"
+)
+
+func main() {
+    app := zh.New(config.WithSSEProvider(zh.NewDefaultProvider()))
+
+    app.GET("/events", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+        stream, err := app.SSEProvider().NewSSE(w, r)
+        if err != nil { return err }
+        defer stream.Close()
+
+        for i := 0; i < 10; i++ {
+            stream.Send(zh.SSEEvent{Name: "message", Data: []byte("hello")})
+            time.Sleep(1 * time.Second)
+        }
+        return nil
+    }))
+```
+
+See [`examples/sse/`](examples/sse/) for a complete example with event replay and broadcast hub.
+
+
 ### WebSocket Support
 
 WebSocket provides real-time bidirectional communication over TCP. zerohttp supports WebSocket
@@ -876,32 +910,35 @@ import (
     webtransport "github.com/quic-go/webtransport-go"
 )
 
-app := zh.New()
+func main() {
+    app := zh.New()
 
-// Create HTTP/3 server
-h3 := &http3.Server{Addr: ":8443", Handler: app}
+    // Create HTTP/3 server
+    h3 := &http3.Server{Addr: ":8443", Handler: app}
 
-// Create WebTransport server
-wtServer := &webtransport.Server{
-    H3:          h3,
-    CheckOrigin: func(r *http.Request) bool { return true },
-}
-webtransport.ConfigureHTTP3Server(h3)
-
-// Set WebTransport server - zerohttp starts it automatically
-app.SetWebTransportServer(wtServer)
-
-// Register WebTransport endpoint
-app.CONNECT("/wt", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-    sess, err := wtServer.Upgrade(w, r)
-    if err != nil {
-        w.WriteHeader(http.StatusInternalServerError)
-        return
+    // Create WebTransport server
+    wtServer := &webtransport.Server{
+        H3:          h3,
+        CheckOrigin: func(r *http.Request) bool { return true },
     }
-    go handleSession(sess) // Handle streams/datagrams
-}))
+    webtransport.ConfigureHTTP3Server(h3)
 
-app.ListenAndServeTLS("cert.pem", "key.pem")
+    // Set WebTransport server - zerohttp starts it automatically
+    app.SetWebTransportServer(wtServer)
+
+    // Register WebTransport endpoint
+    app.CONNECT("/wt", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        sess, err := wtServer.Upgrade(w, r)
+        if err != nil {
+            w.WriteHeader(http.StatusInternalServerError)
+            return
+        }
+        go handleSession(sess) // Handle streams/datagrams
+    }))
+
+    app.ListenAndServeTLS("cert.pem", "key.pem")
+}
+
 ```
 
 > **💡 Complete Example:** See [`examples/webtransport/`](examples/webtransport/) for a full working server with HTML client.
@@ -1040,6 +1077,7 @@ The functional options pattern provides structured configuration for all aspects
 - `config.WithPostShutdownHook()` - Hook to run after server shutdown
 - `config.WithAutocertManager()` - Let's Encrypt integration
 - `config.WithHTTP3Server()` - HTTP/3 server (e.g., quic-go)
+- `config.WithSSEProvider()` - SSE provider for server-sent events
 - `config.WithWebSocketUpgrader()` - WebSocket upgrader (e.g., gorilla/websocket)
 - `config.WithWebTransportServer()` - WebTransport server (e.g., webtransport-go)
 

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/alexferl/zerohttp/log"
 )
@@ -112,6 +113,12 @@ type Config struct {
 	// The server must implement the HTTP3Server interface.
 	// Default: nil (HTTP/3 not enabled unless set)
 	HTTP3Server HTTP3Server
+
+	// SSEProvider is an optional handler for Server-Sent Events connections.
+	// Users can set their own provider (e.g., wrapping a custom SSE library).
+	// If nil, SSE is not available but users can still handle SSE manually in their handlers.
+	// Default: nil
+	SSEProvider SSEProvider
 
 	// WebSocketUpgrader is an optional handler for WebSocket upgrades.
 	// Users can set their own upgrader (e.g., wrapping gorilla/websocket).
@@ -462,6 +469,77 @@ type HTTP3ServerWithAutocert interface {
 func WithHTTP3Server(server HTTP3Server) Option {
 	return func(c *Config) {
 		c.HTTP3Server = server
+	}
+}
+
+// ============================================================================
+// SSE Options
+// ============================================================================
+
+// SSEConnection represents an active Server-Sent Events connection.
+// Users can implement this interface with their own SSE library, or use
+// the built-in EventStream implementation.
+type SSEConnection interface {
+	// Send writes an event to the client.
+	// Returns error if the connection is closed or write fails.
+	Send(event SSEEvent) error
+
+	// SendComment sends a comment (heartbeat/keepalive).
+	// Comments are ignored by the client but keep connections alive through proxies.
+	SendComment(comment string) error
+
+	// Close signals the SSE connection is done.
+	// No further events should be sent after Close.
+	Close() error
+
+	// SetRetry sets the default reconnection time for this connection.
+	// Affects subsequent events without explicit Retry value.
+	SetRetry(d time.Duration) error
+}
+
+// SSEProvider creates SSE connections from HTTP requests.
+// Implement this to provide custom SSE implementations.
+type SSEProvider interface {
+	// NewSSE creates a new SSE connection from the request/response.
+	// Returns error if headers were already sent or SSE is not supported.
+	NewSSE(w http.ResponseWriter, r *http.Request) (SSEConnection, error)
+}
+
+// SSEEvent represents a single SSE event
+type SSEEvent struct {
+	ID    string
+	Name  string
+	Data  []byte
+	Retry time.Duration
+}
+
+// WithSSEProvider sets a custom SSE provider for Server-Sent Events connections.
+// Users bring their own SSE library and implement the SSEProvider interface,
+// or use a thin wrapper around their preferred library.
+//
+// Example with built-in stdlib provider:
+//
+//	app := zerohttp.New(
+//	    config.WithSSEProvider(zh.NewDefaultProvider()),
+//	)
+//
+//	app.GET("/events", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+//	    provider := app.SSEProvider()
+//	    if provider == nil {
+//	        return fmt.Errorf("SSE not configured")
+//	    }
+//
+//	    sse, err := provider.NewSSE(w, r)
+//	    if err != nil {
+//	        return err
+//	    }
+//	    defer sse.Close()
+//
+//	    // Stream events...
+//	}))
+func WithSSEProvider(provider SSEProvider) Option {
+	return func(c *Config) {
+		c.SSEProvider = provider
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/alexferl/zerohttp/log"
 )
@@ -617,6 +618,32 @@ func TestWithWebSocketUpgrader(t *testing.T) {
 
 	if cfg.WebSocketUpgrader == nil {
 		t.Error("expected WebSocketUpgrader to be set")
+	}
+}
+
+// mockSSEConnection is a mock implementation of SSEConnection for testing
+type mockSSEConnection struct{}
+
+func (m *mockSSEConnection) Send(event SSEEvent) error        { return nil }
+func (m *mockSSEConnection) SendComment(comment string) error { return nil }
+func (m *mockSSEConnection) Close() error                     { return nil }
+func (m *mockSSEConnection) SetRetry(d time.Duration) error   { return nil }
+
+// mockSSEProvider is a mock implementation of SSEProvider for testing
+type mockSSEProvider struct{}
+
+func (m *mockSSEProvider) NewSSE(w http.ResponseWriter, r *http.Request) (SSEConnection, error) {
+	return &mockSSEConnection{}, nil
+}
+
+func TestWithSSEProvider(t *testing.T) {
+	cfg := DefaultConfig
+	mockProvider := &mockSSEProvider{}
+
+	WithSSEProvider(mockProvider)(&cfg)
+
+	if cfg.SSEProvider == nil {
+		t.Error("expected SSEProvider to be set")
 	}
 }
 

--- a/examples/sse/main.go
+++ b/examples/sse/main.go
@@ -1,0 +1,548 @@
+// This example demonstrates how to use Server-Sent Events (SSE) with zerohttp.
+// It includes:
+//   - Basic SSE streaming (time, counter, notifications)
+//   - Event replay (reconnect and resume from last event ID)
+//   - Broadcast hub (fan-out messages to multiple clients)
+//
+// To run this example:
+//   1. go run examples/sse/main.go
+//   2. Open http://localhost:8080 in your browser
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
+)
+
+func main() {
+	// Create a custom HTTP server without write timeout for SSE support
+	customServer := &http.Server{
+		Addr:         ":8080",
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 0, // No write timeout for SSE
+		IdleTimeout:  120 * time.Second,
+	}
+
+	// Create replayer for event replay (keep last 100 events, 5 min TTL)
+	replayer := zh.NewInMemoryReplayer(100, 5*time.Minute)
+
+	// Create broadcast hub for fan-out
+	hub := zh.NewSSEHub()
+	broadcastCounter := int32(0)
+
+	// Create zerohttp server
+	app := zh.New(
+		config.WithServer(customServer),
+		config.WithDisableDefaultMiddlewares(),
+		config.WithSSEProvider(zh.NewDefaultProvider()),
+	)
+
+	// Serve HTML client
+	app.GET("/", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		w.Header().Set("Content-Type", "text/html")
+		_, err := w.Write([]byte(indexHTML))
+		return err
+	}))
+
+	// SSE endpoint - time stream (basic)
+	app.GET("/time", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		provider := app.SSEProvider()
+		if provider == nil {
+			return fmt.Errorf("SSE not configured")
+		}
+
+		stream, err := provider.NewSSE(w, r)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = stream.Close() }()
+
+		_ = stream.SetRetry(5 * time.Second)
+
+		ticker := time.NewTicker(1 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-r.Context().Done():
+				log.Println("Time stream: Client disconnected")
+				return nil
+			case t := <-ticker.C:
+				event := zh.SSEEvent{
+					Name: "time",
+					Data: []byte(t.Format(time.RFC3339)),
+					ID:   fmt.Sprintf("%d", t.Unix()),
+				}
+				if err := stream.Send(event); err != nil {
+					return nil
+				}
+			}
+		}
+	}))
+
+	// SSE endpoint - notifications with replay support
+	// Clients can reconnect and resume from their last event ID
+	app.GET("/notifications", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		// Get Last-Event-ID from header (browser auto-sends) or query param (manual reconnect)
+		lastEventID := r.Header.Get("Last-Event-ID")
+		if lastEventID == "" {
+			lastEventID = r.URL.Query().Get("last_id")
+		}
+
+		// Create SSE connection
+		stream, err := zh.NewSSE(w, r)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = stream.Close() }()
+
+		// Replay missed events if last_id is provided
+		if lastEventID != "" {
+			count, err := replayer.Replay(lastEventID, func(event zh.SSEEvent) error {
+				return stream.Send(event)
+			})
+			if err != nil {
+				log.Printf("Replay error: %v", err)
+			} else {
+				log.Printf("Replayed %d events", count)
+				_ = stream.Send(zh.SSEEvent{
+					Name: "info",
+					Data: []byte(fmt.Sprintf("Replayed %d missed events", count)),
+				})
+			}
+		}
+
+		// Subscribe to hub for real-time notifications
+		hub.Subscribe(stream, "notifications")
+		defer hub.Unsubscribe(stream, "notifications")
+
+		log.Printf("Notifications: Client connected (Last-Event-ID: %s)", lastEventID)
+
+		// Send a welcome message
+		_ = stream.Send(zh.SSEEvent{
+			Name: "info",
+			Data: []byte("Connected! Auto-generated events arrive every 10 seconds."),
+		})
+
+		// Keep connection alive and wait for context cancellation
+		<-r.Context().Done()
+		log.Println("Notifications: Client disconnected")
+		return nil
+	}))
+
+	// SSE endpoint - broadcast subscriber
+	app.GET("/broadcast", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		// Create SSE connection directly for hub compatibility
+		stream, err := zh.NewSSE(w, r)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = stream.Close() }()
+
+		// Register with hub for broadcast
+		hub.Register(stream)
+		defer hub.Unregister(stream)
+
+		log.Println("Broadcast: Client subscribed")
+
+		// Send initial welcome
+		_ = stream.Send(zh.SSEEvent{
+			Name: "info",
+			Data: []byte("Subscribed to broadcast channel"),
+		})
+
+		// Keep connection alive
+		<-r.Context().Done()
+		log.Println("Broadcast: Client unsubscribed")
+		return nil
+	}))
+
+	// API endpoint - publish a notification (stores for replay)
+	app.POST("/notify", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		msg := r.URL.Query().Get("msg")
+		if msg == "" {
+			msg = "System notification"
+		}
+
+		event := zh.SSEEvent{
+			Name: "notification",
+			Data: []byte(msg),
+		}
+
+		// Store for replay
+		replayer.Store(event)
+
+		_, err := w.Write([]byte("Notification stored for replay"))
+		return err
+	}))
+
+	// API endpoint - broadcast to all connected clients
+	app.POST("/broadcast", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		msg := r.URL.Query().Get("msg")
+		if msg == "" {
+			msg = fmt.Sprintf("Broadcast #%d", atomic.AddInt32(&broadcastCounter, 1))
+		}
+
+		event := zh.SSEEvent{
+			Name: "broadcast",
+			Data: []byte(msg),
+		}
+
+		// Broadcast to all connected clients
+		hub.Broadcast(event)
+
+		_, err := fmt.Fprintf(w, "Broadcast sent to %d clients", hub.ConnectionCount())
+		return err
+	}))
+
+	// Auto-generate notifications every 5 seconds for replay demo
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+
+		counter := 0
+		for range ticker.C {
+			counter++
+			event := zh.SSEEvent{
+				Name: "auto",
+				Data: []byte(fmt.Sprintf("Auto notification #%d at %s", counter, time.Now().Format("15:04:05"))),
+			}
+			// Store for replay and get event with assigned ID
+			event = replayer.Store(event)
+			// Broadcast to connected notification clients
+			hub.BroadcastTo("notifications", event)
+			log.Printf("Auto-generated notification #%d (stored + broadcast)", counter)
+		}
+	}()
+
+	log.Println("Starting server on http://localhost:8080")
+	log.Println("")
+	log.Println("Endpoints:")
+	log.Println("  GET  /time          - Basic time stream")
+	log.Println("  GET  /notifications - Stream with replay support (try reconnecting!)")
+	log.Println("  GET  /broadcast     - Subscribe to broadcasts")
+	log.Println("  POST /notify?msg=   - Store notification for replay")
+	log.Println("  POST /broadcast?msg= - Broadcast to all connected clients")
+	log.Println("")
+	log.Println("Open http://localhost:8080 in your browser to test")
+
+	if err := app.ListenAndServe(); err != nil && err != context.Canceled {
+		log.Fatal(err)
+	}
+}
+
+const indexHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>zerohttp SSE Example - Replay & Broadcast</title>
+    <style>
+        body {
+            font-family: system-ui, -apple-system, sans-serif;
+            max-width: 1000px;
+            margin: 0 auto;
+            padding: 20px;
+            background: #f5f5f5;
+        }
+        h1 { color: #333; }
+        h2 { margin-top: 0; }
+        .container {
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            margin-bottom: 20px;
+        }
+        .status {
+            display: inline-block;
+            padding: 4px 12px;
+            border-radius: 4px;
+            font-size: 14px;
+            font-weight: bold;
+        }
+        .status.connected { background: #4caf50; color: white; }
+        .status.disconnected { background: #f44336; color: white; }
+        .status.connecting { background: #ff9800; color: white; }
+        button {
+            padding: 10px 20px;
+            border: none;
+            border-radius: 4px;
+            background: #0066cc;
+            color: white;
+            cursor: pointer;
+            margin-right: 10px;
+            margin-bottom: 10px;
+        }
+        button:hover { background: #0052a3; }
+        button:disabled {
+            background: #ccc;
+            cursor: not-allowed;
+        }
+        input {
+            padding: 10px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            width: 250px;
+            margin-right: 10px;
+        }
+        .log {
+            background: #1a1a1a;
+            color: #00ff00;
+            padding: 15px;
+            border-radius: 4px;
+            font-family: monospace;
+            height: 150px;
+            overflow-y: auto;
+            white-space: pre-wrap;
+            font-size: 12px;
+        }
+        .grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+        }
+        @media (max-width: 768px) {
+            .grid { grid-template-columns: 1fr; }
+        }
+    </style>
+</head>
+<body>
+    <h1>zerohttp SSE Example - Replay & Broadcast</h1>
+
+    <div class="container">
+        <h2>Time Stream (Basic SSE)</h2>
+        <p>Status: <span id="timeStatus" class="status disconnected">Disconnected</span></p>
+        <button id="timeConnect" onclick="connectTime()">Connect</button>
+        <button id="timeDisconnect" onclick="disconnectTime()" disabled>Disconnect</button>
+        <div id="timeLog" class="log"></div>
+    </div>
+
+    <div class="grid">
+        <div class="container">
+            <h2>Notifications (with Replay)</h2>
+            <p>Connect, disconnect, then reconnect - missed events will be replayed!</p>
+            <p>Status: <span id="notifStatus" class="status disconnected">Disconnected</span></p>
+            <p>Last Event ID: <span id="notifLastID">-</span></p>
+            <button id="notifConnect" onclick="connectNotif()">Connect</button>
+            <button id="notifReconnect" onclick="reconnectNotif()" disabled>Reconnect with Replay</button>
+            <button id="notifDisconnect" onclick="disconnectNotif()" disabled>Disconnect</button>
+            <div id="notifLog" class="log"></div>
+        </div>
+
+        <div class="container">
+            <h2>Broadcast Hub</h2>
+            <p>Messages sent to all connected broadcast clients</p>
+            <p>Status: <span id="broadcastStatus" class="status disconnected">Disconnected</span></p>
+            <button id="broadcastConnect" onclick="connectBroadcast()">Connect</button>
+            <button id="broadcastDisconnect" onclick="disconnectBroadcast()" disabled>Disconnect</button>
+            <div id="broadcastLog" class="log"></div>
+        </div>
+    </div>
+
+    <div class="container">
+        <h2>Send Messages</h2>
+        <div>
+            <input type="text" id="notifyInput" placeholder="Notification message...">
+            <button onclick="sendNotification()">Store Notification</button>
+            <span id="notifyResult"></span>
+        </div>
+        <div style="margin-top: 10px;">
+            <input type="text" id="broadcastInput" placeholder="Broadcast message...">
+            <button onclick="sendBroadcast()">Broadcast to All</button>
+            <span id="broadcastResult"></span>
+        </div>
+    </div>
+
+    <script>
+        let timeSource = null;
+        let notifSource = null;
+        let broadcastSource = null;
+        let notifLastEventID = '';
+
+        function log(elementId, message) {
+            const logEl = document.getElementById(elementId);
+            const time = new Date().toLocaleTimeString();
+            const div = document.createElement('div');
+            div.textContent = '[' + time + '] ' + message;
+            logEl.appendChild(div);
+            logEl.scrollTop = logEl.scrollHeight;
+        }
+
+        function setStatus(elementId, status) {
+            const el = document.getElementById(elementId);
+            el.className = 'status ' + status;
+            el.textContent = status.charAt(0).toUpperCase() + status.slice(1);
+        }
+
+        function setButtons(connectId, disconnectId, connected) {
+            document.getElementById(connectId).disabled = connected;
+            document.getElementById(disconnectId).disabled = !connected;
+        }
+
+        // Time stream
+        function connectTime() {
+            if (timeSource) return;
+            setStatus('timeStatus', 'connecting');
+            log('timeLog', 'Connecting...');
+
+            timeSource = new EventSource('/time');
+
+            timeSource.addEventListener('time', (e) => {
+                log('timeLog', 'Time: ' + e.data);
+            });
+
+            timeSource.onopen = () => {
+                setStatus('timeStatus', 'connected');
+                setButtons('timeConnect', 'timeDisconnect', true);
+            };
+
+            timeSource.onerror = () => {
+                log('timeLog', 'Error/Disconnected');
+            };
+        }
+
+        function disconnectTime() {
+            if (timeSource) {
+                timeSource.close();
+                timeSource = null;
+                setStatus('timeStatus', 'disconnected');
+                setButtons('timeConnect', 'timeDisconnect', false);
+                log('timeLog', 'Disconnected');
+            }
+        }
+
+        // Notifications with replay
+        function connectNotif() {
+            if (notifSource) return;
+            doConnectNotif(null);
+        }
+
+        function doConnectNotif(lastID) {
+            setStatus('notifStatus', 'connecting');
+            log('notifLog', lastID ? 'Reconnecting with Last-Event-ID: ' + lastID + '...' : 'Connecting...');
+
+            // Create EventSource with optional last_id query parameter for replay
+            // (Browser EventSource doesn't allow setting headers manually)
+            const url = lastID ? '/notifications?last_id=' + encodeURIComponent(lastID) : '/notifications';
+            notifSource = new EventSource(url);
+
+            // Catch all message types
+            notifSource.onmessage = (e) => {
+                notifLastEventID = e.lastEventId;
+                document.getElementById('notifLastID').textContent = notifLastEventID;
+                log('notifLog', '📨 ' + e.data + ' (ID: ' + e.lastEventId + ')');
+            };
+
+            notifSource.addEventListener('notification', (e) => {
+                notifLastEventID = e.lastEventId;
+                document.getElementById('notifLastID').textContent = notifLastEventID;
+                log('notifLog', '📢 ' + e.data + ' (ID: ' + e.lastEventId + ')');
+            });
+
+            notifSource.addEventListener('auto', (e) => {
+                notifLastEventID = e.lastEventId;
+                document.getElementById('notifLastID').textContent = notifLastEventID;
+                log('notifLog', '⚡ ' + e.data + ' (ID: ' + e.lastEventId + ')');
+            });
+
+            notifSource.onopen = () => {
+                setStatus('notifStatus', 'connected');
+                document.getElementById('notifConnect').disabled = true;
+                document.getElementById('notifReconnect').disabled = true;
+                document.getElementById('notifDisconnect').disabled = false;
+                log('notifLog', 'Connected! Waiting for events... (auto-generated every 5s)');
+            };
+
+            notifSource.onerror = (e) => {
+                console.error('SSE Error:', e);
+                log('notifLog', 'Error/Disconnected (check console)');
+            };
+        }
+
+        function disconnectNotif() {
+            if (notifSource) {
+                notifSource.close();
+                notifSource = null;
+                setStatus('notifStatus', 'disconnected');
+                document.getElementById('notifConnect').disabled = false;
+                const hasLastID = notifLastEventID !== '';
+                document.getElementById('notifReconnect').disabled = !hasLastID;
+                document.getElementById('notifDisconnect').disabled = true;
+                log('notifLog', 'Disconnected. Last ID: ' + (notifLastEventID || 'none') + '. Reconnect button: ' + (hasLastID ? 'ENABLED' : 'disabled (need events first)'));
+            }
+        }
+
+        function reconnectNotif() {
+            if (notifSource || notifLastEventID === '') return;
+            // Pass last_id as query parameter since EventSource doesn't allow custom headers
+            doConnectNotif(notifLastEventID);
+        }
+
+        // Broadcast
+        function connectBroadcast() {
+            if (broadcastSource) return;
+            setStatus('broadcastStatus', 'connecting');
+            log('broadcastLog', 'Connecting...');
+
+            broadcastSource = new EventSource('/broadcast');
+
+            broadcastSource.addEventListener('info', (e) => {
+                log('broadcastLog', 'ℹ️ ' + e.data);
+            });
+
+            broadcastSource.addEventListener('broadcast', (e) => {
+                log('broadcastLog', '📡 ' + e.data);
+            });
+
+            broadcastSource.onopen = () => {
+                setStatus('broadcastStatus', 'connected');
+                setButtons('broadcastConnect', 'broadcastDisconnect', true);
+            };
+
+            broadcastSource.onerror = () => {
+                log('broadcastLog', 'Error/Disconnected');
+            };
+        }
+
+        function disconnectBroadcast() {
+            if (broadcastSource) {
+                broadcastSource.close();
+                broadcastSource = null;
+                setStatus('broadcastStatus', 'disconnected');
+                setButtons('broadcastConnect', 'broadcastDisconnect', false);
+                log('broadcastLog', 'Disconnected');
+            }
+        }
+
+        // Send messages
+        function sendNotification() {
+            const msg = document.getElementById('notifyInput').value;
+            fetch('/notify?msg=' + encodeURIComponent(msg), {method: 'POST'})
+                .then(r => r.text())
+                .then(text => {
+                    document.getElementById('notifyResult').textContent = text;
+                    setTimeout(() => document.getElementById('notifyResult').textContent = '', 3000);
+                });
+        }
+
+        function sendBroadcast() {
+            const msg = document.getElementById('broadcastInput').value;
+            fetch('/broadcast?msg=' + encodeURIComponent(msg), {method: 'POST'})
+                .then(r => r.text())
+                .then(text => {
+                    document.getElementById('broadcastResult').textContent = text;
+                    setTimeout(() => document.getElementById('broadcastResult').textContent = '', 3000);
+                });
+        }
+    </script>
+</body>
+</html>`

--- a/server.go
+++ b/server.go
@@ -73,6 +73,11 @@ type Server struct {
 	// If nil, HTTP/3 server will not be started.
 	http3Server config.HTTP3Server
 
+	// sseProvider is an optional SSE provider for handling Server-Sent Events connections.
+	// Users can inject their own implementation or use the built-in stdlib provider.
+	// If nil, SSE is not available but users can still handle SSE manually in their handlers.
+	sseProvider config.SSEProvider
+
 	// webSocketUpgrader is an optional WebSocket upgrader for handling WebSocket connections.
 	// Users provide their own implementation using their preferred WebSocket library.
 	// If nil, WebSocket is not available but users can still handle upgrades manually.
@@ -157,6 +162,7 @@ func New(opts ...config.Option) *Server {
 		http3Server:        cfg.HTTP3Server,
 		webTransportServer: cfg.WebTransportServer,
 		webSocketUpgrader:  cfg.WebSocketUpgrader,
+		sseProvider:        cfg.SSEProvider,
 		logger:             logger,
 		preShutdownHooks:   cfg.PreShutdownHooks,
 		shutdownHooks:      cfg.ShutdownHooks,
@@ -736,6 +742,40 @@ func (s *Server) SetHTTP3Server(server config.HTTP3Server) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.http3Server = server
+}
+
+// SetSSEProvider sets the SSE provider instance. This can be used to inject
+// an SSE implementation after creating the server.
+//
+// Users can implement their own SSE provider or use the built-in stdlib provider:
+//
+//	app := zerohttp.New()
+//	app.SetSSEProvider(zh.NewDefaultProvider())
+//
+//	app.GET("/events", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+//	    provider := app.SSEProvider()
+//	    sse, err := provider.NewSSE(w, r)
+//	    if err != nil {
+//	        return err
+//	    }
+//	    defer sse.Close()
+//	    // ... stream events ...
+//	}))
+//
+// Parameters:
+//   - provider: An SSE provider instance implementing the config.SSEProvider interface
+func (s *Server) SetSSEProvider(provider config.SSEProvider) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sseProvider = provider
+}
+
+// SSEProvider returns the configured SSE provider (if any).
+// Returns nil if no SSE provider has been configured.
+func (s *Server) SSEProvider() config.SSEProvider {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.sseProvider
 }
 
 // SetWebSocketUpgrader sets the WebSocket upgrader instance. This can be used to inject

--- a/server_test.go
+++ b/server_test.go
@@ -1939,3 +1939,31 @@ func TestServer_ConfigWithShutdownHooks(t *testing.T) {
 		t.Error("Expected post-shutdown hook to be called")
 	}
 }
+
+func TestServer_SSEProvider(t *testing.T) {
+	t.Run("SSEProvider returns nil by default", func(t *testing.T) {
+		s := New()
+		if s.SSEProvider() != nil {
+			t.Error("expected nil SSEProvider by default")
+		}
+	})
+
+	t.Run("SetSSEProvider stores provider", func(t *testing.T) {
+		s := New()
+		provider := NewDefaultProvider()
+		s.SetSSEProvider(provider)
+
+		if s.SSEProvider() != provider {
+			t.Error("expected SSEProvider to be set")
+		}
+	})
+
+	t.Run("SSEProvider works with config option", func(t *testing.T) {
+		provider := NewDefaultProvider()
+		s := New(config.WithSSEProvider(provider))
+
+		if s.SSEProvider() != provider {
+			t.Error("expected SSEProvider from config option")
+		}
+	})
+}

--- a/sse.go
+++ b/sse.go
@@ -1,0 +1,545 @@
+package zerohttp
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/alexferl/zerohttp/config"
+)
+
+// Re-export SSE types from config package for convenience.
+
+// SSEConnection is an alias for config.SSEConnection.
+type SSEConnection = config.SSEConnection
+
+// SSEProvider is an alias for config.SSEProvider.
+type SSEProvider = config.SSEProvider
+
+// SSEEvent is an alias for config.SSEEvent.
+type SSEEvent = config.SSEEvent
+
+// SSE is the built-in SSE implementation using Go's standard library.
+type SSE struct {
+	w       http.ResponseWriter
+	flusher http.Flusher
+	ctx     context.Context
+	cancel  context.CancelFunc
+	closed  chan struct{}
+	mu      sync.Mutex
+	retry   time.Duration
+}
+
+// NewSSE creates a new SSE connection using stdlib.
+// This sets the appropriate headers and prepares the connection for streaming.
+func NewSSE(w http.ResponseWriter, r *http.Request) (*SSE, error) {
+	if w.Header().Get("Content-Type") != "" {
+		return nil, fmt.Errorf("sse: response headers already sent")
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return nil, fmt.Errorf("sse: streaming not supported")
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	ctx, cancel := context.WithCancel(r.Context())
+
+	stream := &SSE{
+		w:       w,
+		flusher: flusher,
+		ctx:     ctx,
+		cancel:  cancel,
+		closed:  make(chan struct{}),
+	}
+
+	// Monitor context cancellation
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = stream.Close()
+		case <-stream.closed:
+		}
+	}()
+
+	return stream, nil
+}
+
+// Send writes an event to the client.
+func (s *SSE) Send(event SSEEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	select {
+	case <-s.closed:
+		return fmt.Errorf("sse: connection closed")
+	case <-s.ctx.Done():
+		return fmt.Errorf("sse: context cancelled")
+	default:
+	}
+
+	var buf strings.Builder
+
+	if event.ID != "" {
+		buf.WriteString("id: ")
+		buf.WriteString(event.ID)
+		buf.WriteByte('\n')
+	}
+
+	if event.Name != "" {
+		buf.WriteString("event: ")
+		buf.WriteString(event.Name)
+		buf.WriteByte('\n')
+	}
+
+	retry := event.Retry
+	if retry == 0 {
+		retry = s.retry
+	}
+	if retry > 0 {
+		buf.WriteString("retry: ")
+		buf.WriteString(strconv.FormatInt(retry.Milliseconds(), 10))
+		buf.WriteByte('\n')
+	}
+
+	if len(event.Data) > 0 {
+		lines := strings.Split(string(event.Data), "\n")
+		for _, line := range lines {
+			buf.WriteString("data: ")
+			buf.WriteString(line)
+			buf.WriteByte('\n')
+		}
+	} else {
+		buf.WriteString("data: \n")
+	}
+
+	// Empty line terminates the event
+	buf.WriteByte('\n')
+
+	_, err := s.w.Write([]byte(buf.String()))
+	if err != nil {
+		return fmt.Errorf("sse: write error: %w", err)
+	}
+
+	s.flusher.Flush()
+	return nil
+}
+
+// SendComment sends a comment (heartbeat/keepalive).
+func (s *SSE) SendComment(comment string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	select {
+	case <-s.closed:
+		return fmt.Errorf("sse: connection closed")
+	case <-s.ctx.Done():
+		return fmt.Errorf("sse: context cancelled")
+	default:
+	}
+
+	// Comments start with colon
+	lines := strings.Split(comment, "\n")
+	var buf strings.Builder
+	for _, line := range lines {
+		buf.WriteString(": ")
+		buf.WriteString(line)
+		buf.WriteByte('\n')
+	}
+
+	_, err := s.w.Write([]byte(buf.String()))
+	if err != nil {
+		return fmt.Errorf("sse: write error: %w", err)
+	}
+
+	s.flusher.Flush()
+	return nil
+}
+
+// Close signals the SSE connection is done.
+func (s *SSE) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	select {
+	case <-s.closed:
+		return nil
+	default:
+		close(s.closed)
+		s.cancel()
+		return nil
+	}
+}
+
+// SetRetry sets the default reconnection time for this connection.
+func (s *SSE) SetRetry(d time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.retry = d
+	return nil
+}
+
+// DefaultProvider implements SSEProvider using the stdlib
+type DefaultProvider struct{}
+
+// NewDefaultProvider creates a new stdlib-based SSE provider.
+func NewDefaultProvider() *DefaultProvider {
+	return &DefaultProvider{}
+}
+
+// NewSSE creates a new SSE connection using the stdlib implementation.
+func (p *DefaultProvider) NewSSE(w http.ResponseWriter, r *http.Request) (SSEConnection, error) {
+	return NewSSE(w, r)
+}
+
+// SSEWriter wraps an http.ResponseWriter to provide SSE capabilities.
+// This is a lower-level helper for users who want to write SSE directly.
+type SSEWriter struct {
+	w       http.ResponseWriter
+	flusher http.Flusher
+	mu      sync.Mutex
+}
+
+// NewSSEWriter creates a new SSEWriter from an http.ResponseWriter.
+// This sets SSE headers and prepares the connection.
+func NewSSEWriter(w http.ResponseWriter, r *http.Request) (*SSEWriter, error) {
+	if w.Header().Get("Content-Type") != "" {
+		return nil, fmt.Errorf("sse: response headers already sent")
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return nil, fmt.Errorf("sse: streaming not supported")
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	return &SSEWriter{
+		w:       w,
+		flusher: flusher,
+	}, nil
+}
+
+// WriteEvent writes an SSE event.
+func (s *SSEWriter) WriteEvent(event SSEEvent) error {
+	return s.writeEvent(event)
+}
+
+// WriteComment writes an SSE comment.
+func (s *SSEWriter) WriteComment(comment string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	lines := strings.Split(comment, "\n")
+	var buf strings.Builder
+	for _, line := range lines {
+		buf.WriteString(": ")
+		buf.WriteString(line)
+		buf.WriteByte('\n')
+	}
+
+	_, err := s.w.Write([]byte(buf.String()))
+	if err != nil {
+		return err
+	}
+	s.flusher.Flush()
+	return nil
+}
+
+// Flush flushes the underlying writer.
+func (s *SSEWriter) Flush() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.flusher.Flush()
+}
+
+func (s *SSEWriter) writeEvent(event SSEEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var buf strings.Builder
+
+	if event.ID != "" {
+		buf.WriteString("id: ")
+		buf.WriteString(event.ID)
+		buf.WriteByte('\n')
+	}
+
+	if event.Name != "" {
+		buf.WriteString("event: ")
+		buf.WriteString(event.Name)
+		buf.WriteByte('\n')
+	}
+
+	if event.Retry > 0 {
+		buf.WriteString("retry: ")
+		buf.WriteString(strconv.FormatInt(event.Retry.Milliseconds(), 10))
+		buf.WriteByte('\n')
+	}
+
+	if len(event.Data) > 0 {
+		lines := strings.Split(string(event.Data), "\n")
+		for _, line := range lines {
+			buf.WriteString("data: ")
+			buf.WriteString(line)
+			buf.WriteByte('\n')
+		}
+	} else {
+		buf.WriteString("data: \n")
+	}
+
+	buf.WriteByte('\n')
+
+	_, err := s.w.Write([]byte(buf.String()))
+	if err != nil {
+		return err
+	}
+	s.flusher.Flush()
+	return nil
+}
+
+// IsClientDisconnected checks if the client has disconnected.
+// This checks if the request context is done.
+func IsClientDisconnected(r *http.Request) bool {
+	select {
+	case <-r.Context().Done():
+		return true
+	default:
+		return false
+	}
+}
+
+// SSEReplayer defines the interface for event replay storage.
+// Implementations can use in-memory storage, Redis, databases, etc.
+type SSEReplayer interface {
+	// Store saves an event to the replay buffer and returns the event with assigned ID.
+	Store(event SSEEvent) SSEEvent
+	// Replay sends all events after the given ID to the provided send function.
+	// Returns the number of events replayed and any error.
+	Replay(afterID string, send func(SSEEvent) error) (int, error)
+}
+
+// InMemoryReplayer stores events in memory with a circular buffer.
+// Events can be limited by max count and/or TTL.
+type InMemoryReplayer struct {
+	events    []storedEvent
+	maxEvents int
+	ttl       time.Duration
+	mu        sync.RWMutex
+	lastID    int64
+}
+
+type storedEvent struct {
+	id        int64
+	event     SSEEvent
+	timestamp time.Time
+}
+
+// NewInMemoryReplayer creates a new in-memory event replayer.
+// maxEvents is the maximum number of events to keep (0 = unlimited).
+// ttl is how long to keep events (0 = no expiration).
+func NewInMemoryReplayer(maxEvents int, ttl time.Duration) *InMemoryReplayer {
+	if maxEvents < 0 {
+		maxEvents = 0
+	}
+	return &InMemoryReplayer{
+		events:    make([]storedEvent, 0),
+		maxEvents: maxEvents,
+		ttl:       ttl,
+	}
+}
+
+// Store saves an event to the replay buffer with an auto-generated ID.
+// Returns the event with the assigned ID so it can be used for broadcasting.
+func (r *InMemoryReplayer) Store(event SSEEvent) SSEEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.ttl > 0 {
+		now := time.Now()
+		valid := make([]storedEvent, 0, len(r.events))
+		for _, e := range r.events {
+			if now.Sub(e.timestamp) < r.ttl {
+				valid = append(valid, e)
+			}
+		}
+		r.events = valid
+	}
+
+	r.lastID++
+	event.ID = strconv.FormatInt(r.lastID, 10)
+
+	r.events = append(r.events, storedEvent{
+		id:        r.lastID,
+		event:     event,
+		timestamp: time.Now(),
+	})
+
+	if r.maxEvents > 0 && len(r.events) > r.maxEvents {
+		r.events = r.events[len(r.events)-r.maxEvents:]
+	}
+
+	return event
+}
+
+// Replay sends all events after the given ID to the provided send function.
+func (r *InMemoryReplayer) Replay(afterID string, send func(SSEEvent) error) (int, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	startID := int64(0)
+	if afterID != "" {
+		var err error
+		startID, err = strconv.ParseInt(afterID, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("sse: invalid Last-Event-ID: %w", err)
+		}
+	}
+
+	count := 0
+	for _, se := range r.events {
+		if se.id > startID {
+			if err := send(se.event); err != nil {
+				return count, err
+			}
+			count++
+		}
+	}
+	return count, nil
+}
+
+// SSEWithReplay creates a new SSE connection and replays missed events if Last-Event-ID header is present.
+// After replay completes, the connection is ready for new events.
+func SSEWithReplay(w http.ResponseWriter, r *http.Request, replayer SSEReplayer) (*SSE, error) {
+	stream, err := NewSSE(w, r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check for Last-Event-ID header for replay
+	lastEventID := r.Header.Get("Last-Event-ID")
+	if lastEventID != "" && replayer != nil {
+		_, err := replayer.Replay(lastEventID, func(event SSEEvent) error {
+			return stream.Send(event)
+		})
+		if err != nil {
+			_ = stream.Close()
+			return nil, fmt.Errorf("sse: replay failed: %w", err)
+		}
+	}
+
+	return stream, nil
+}
+
+// SSEHub manages multiple SSE connections for broadcasting.
+type SSEHub struct {
+	connections map[*SSE]struct{}
+	topics      map[string]map[*SSE]struct{}
+	mu          sync.RWMutex
+}
+
+// NewSSEHub creates a new SSE broadcast hub.
+func NewSSEHub() *SSEHub {
+	return &SSEHub{
+		connections: make(map[*SSE]struct{}),
+		topics:      make(map[string]map[*SSE]struct{}),
+	}
+}
+
+// Register adds an SSE connection to the hub.
+func (h *SSEHub) Register(s *SSE) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.connections[s] = struct{}{}
+}
+
+// Unregister removes an SSE connection from the hub.
+func (h *SSEHub) Unregister(s *SSE) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.connections, s)
+	for topic, subs := range h.topics {
+		delete(subs, s)
+		if len(subs) == 0 {
+			delete(h.topics, topic)
+		}
+	}
+}
+
+// Subscribe adds an SSE connection to a topic.
+func (h *SSEHub) Subscribe(s *SSE, topic string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.topics[topic] == nil {
+		h.topics[topic] = make(map[*SSE]struct{})
+	}
+	h.topics[topic][s] = struct{}{}
+}
+
+// Unsubscribe removes an SSE connection from a topic.
+func (h *SSEHub) Unsubscribe(s *SSE, topic string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if subs, ok := h.topics[topic]; ok {
+		delete(subs, s)
+		if len(subs) == 0 {
+			delete(h.topics, topic)
+		}
+	}
+}
+
+// Broadcast sends an event to all registered connections.
+func (h *SSEHub) Broadcast(event SSEEvent) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	for conn := range h.connections {
+		_ = conn.Send(event)
+	}
+}
+
+// BroadcastTo sends an event to all connections subscribed to a topic.
+func (h *SSEHub) BroadcastTo(topic string, event SSEEvent) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	if subs, ok := h.topics[topic]; ok {
+		for conn := range subs {
+			_ = conn.Send(event)
+		}
+	}
+}
+
+// ConnectionCount returns the number of registered connections.
+func (h *SSEHub) ConnectionCount() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.connections)
+}
+
+// TopicCount returns the number of connections subscribed to a topic.
+func (h *SSEHub) TopicCount(topic string) int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.topics[topic])
+}
+
+var (
+	_ SSEConnection = (*SSE)(nil)
+	_ SSEProvider   = (*DefaultProvider)(nil)
+	_ SSEReplayer   = (*InMemoryReplayer)(nil)
+)

--- a/sse_test.go
+++ b/sse_test.go
@@ -1,0 +1,713 @@
+package zerohttp
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewEventStream(t *testing.T) {
+	t.Run("successfully creates SSE", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		stream, err := NewSSE(w, r)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		defer func() { _ = stream.Close() }()
+
+		// Check headers
+		resp := w.Result()
+		if resp.Header.Get("Content-Type") != "text/event-stream" {
+			t.Errorf("expected Content-Type text/event-stream, got %s", resp.Header.Get("Content-Type"))
+		}
+		if resp.Header.Get("Cache-Control") != "no-cache" {
+			t.Errorf("expected Cache-Control no-cache, got %s", resp.Header.Get("Cache-Control"))
+		}
+	})
+
+	t.Run("returns error if headers already sent", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		// Set Content-Type header to simulate headers already sent
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+
+		_, err := NewSSE(w, r)
+		if err == nil {
+			t.Error("expected error when headers already sent")
+		}
+	})
+}
+
+func TestEventStream_Send(t *testing.T) {
+	t.Run("sends simple event", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		stream, err := NewSSE(w, r)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		event := SSEEvent{
+			Data: []byte("hello world"),
+		}
+
+		err = stream.Send(event)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Check body
+		body := w.Body.String()
+		if !strings.Contains(body, "data: hello world\n") {
+			t.Errorf("expected event data in body, got %s", body)
+		}
+	})
+
+	t.Run("sends event with all fields", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		stream, err := NewSSE(w, r)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		event := SSEEvent{
+			ID:    "123",
+			Name:  "update",
+			Data:  []byte("test data"),
+			Retry: 5000 * time.Millisecond,
+		}
+
+		err = stream.Send(event)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		body := w.Body.String()
+		if !strings.Contains(body, "id: 123\n") {
+			t.Errorf("expected id in body, got %s", body)
+		}
+		if !strings.Contains(body, "event: update\n") {
+			t.Errorf("expected event name in body, got %s", body)
+		}
+		if !strings.Contains(body, "retry: 5000\n") {
+			t.Errorf("expected retry in body, got %s", body)
+		}
+		if !strings.Contains(body, "data: test data\n") {
+			t.Errorf("expected data in body, got %s", body)
+		}
+	})
+
+	t.Run("handles multi-line data", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		stream, err := NewSSE(w, r)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		event := SSEEvent{
+			Data: []byte("line1\nline2\nline3"),
+		}
+
+		err = stream.Send(event)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		body := w.Body.String()
+		expected := "data: line1\ndata: line2\ndata: line3\n"
+		if !strings.Contains(body, expected) {
+			t.Errorf("expected multi-line data format, got %s", body)
+		}
+	})
+
+	t.Run("returns error after close", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		stream, err := NewSSE(w, r)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		_ = stream.Close()
+
+		event := SSEEvent{Data: []byte("test")}
+		err = stream.Send(event)
+		if err == nil {
+			t.Error("expected error after close")
+		}
+	})
+}
+
+func TestEventStream_SendComment(t *testing.T) {
+	t.Run("sends comment", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		stream, err := NewSSE(w, r)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		err = stream.SendComment("keepalive")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		body := w.Body.String()
+		if !strings.Contains(body, ": keepalive\n") {
+			t.Errorf("expected comment in body, got %s", body)
+		}
+	})
+}
+
+func TestEventStream_SetRetry(t *testing.T) {
+	t.Run("sets default retry", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		stream, err := NewSSE(w, r)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		defer func() { _ = stream.Close() }()
+
+		err = stream.SetRetry(10 * time.Second)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Send event without retry - should use default
+		event := SSEEvent{Data: []byte("test")}
+		err = stream.Send(event)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		body := w.Body.String()
+		if !strings.Contains(body, "retry: 10000\n") {
+			t.Errorf("expected default retry in body, got %s", body)
+		}
+	})
+}
+
+func TestDefaultProvider(t *testing.T) {
+	provider := NewDefaultProvider()
+	if provider == nil {
+		t.Fatal("expected provider to not be nil")
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+	conn, err := provider.NewSSE(w, r)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if conn == nil {
+		t.Error("expected connection to not be nil")
+	}
+}
+
+func TestIsClientDisconnected(t *testing.T) {
+	t.Run("returns false for active request", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+		if IsClientDisconnected(r) {
+			t.Error("expected false for active request")
+		}
+	})
+
+	t.Run("returns true for cancelled context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil).WithContext(ctx)
+
+		cancel()
+		time.Sleep(10 * time.Millisecond) // Let cancellation propagate
+
+		if !IsClientDisconnected(r) {
+			t.Error("expected true for cancelled context")
+		}
+	})
+}
+
+func TestEventStream_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/sse", nil).WithContext(ctx)
+
+	stream, err := NewSSE(w, r)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Cancel context
+	cancel()
+	time.Sleep(50 * time.Millisecond) // Let cancellation propagate
+
+	// Send should fail after context cancellation
+	event := SSEEvent{Data: []byte("test")}
+	err = stream.Send(event)
+	if err == nil {
+		t.Error("expected error after context cancellation")
+	}
+}
+
+// errorWriter is a ResponseWriter that fails on write
+type errorWriter struct {
+	http.ResponseWriter
+	header http.Header
+}
+
+func (e *errorWriter) Header() http.Header {
+	return e.header
+}
+
+func (e *errorWriter) Write([]byte) (int, error) {
+	return 0, fmt.Errorf("write error")
+}
+
+func (e *errorWriter) WriteHeader(code int) {}
+
+func TestEventStream_Send_WriteError(t *testing.T) {
+	t.Run("returns error on write failure", func(t *testing.T) {
+		header := make(http.Header)
+		hew := &errorWriter{header: header}
+		// Create a flusher that works
+		f := &flusherWriter{ResponseWriter: hew, header: header}
+
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		stream := &SSE{
+			w:       f,
+			flusher: f,
+			ctx:     r.Context(),
+			closed:  make(chan struct{}),
+		}
+
+		event := SSEEvent{Data: []byte("test")}
+		err := stream.Send(event)
+		if err == nil {
+			t.Error("expected error on write failure")
+		}
+	})
+}
+
+func TestEventStream_SendComment_WriteError(t *testing.T) {
+	t.Run("returns error on write failure", func(t *testing.T) {
+		header := make(http.Header)
+		hew := &errorWriter{header: header}
+		f := &flusherWriter{ResponseWriter: hew, header: header}
+
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		stream := &SSE{
+			w:       f,
+			flusher: f,
+			ctx:     r.Context(),
+			closed:  make(chan struct{}),
+		}
+
+		err := stream.SendComment("test")
+		if err == nil {
+			t.Error("expected error on write failure")
+		}
+	})
+}
+
+func TestEventStream_SendComment_ContextCancelled(t *testing.T) {
+	t.Run("returns error when context cancelled", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		ctx, cancel := context.WithCancel(context.Background())
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil).WithContext(ctx)
+
+		stream, err := NewSSE(w, r)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		cancel()
+		time.Sleep(10 * time.Millisecond)
+
+		err = stream.SendComment("test")
+		if err == nil {
+			t.Error("expected error when context cancelled")
+		}
+	})
+}
+
+// flusherWriter wraps a ResponseWriter and adds Flush
+type flusherWriter struct {
+	http.ResponseWriter
+	header http.Header
+}
+
+func (f *flusherWriter) Flush() {}
+
+// SSEWriter tests
+
+func TestNewSSEWriter(t *testing.T) {
+	t.Run("successfully creates SSEWriter", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		writer, err := NewSSEWriter(w, r)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Check headers
+		resp := w.Result()
+		if resp.Header.Get("Content-Type") != "text/event-stream" {
+			t.Errorf("expected Content-Type text/event-stream, got %s", resp.Header.Get("Content-Type"))
+		}
+
+		_ = writer
+	})
+
+	t.Run("returns error if headers already sent", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+
+		_, err := NewSSEWriter(w, r)
+		if err == nil {
+			t.Error("expected error when headers already sent")
+		}
+	})
+}
+
+func TestSSEWriter_WriteEvent(t *testing.T) {
+	t.Run("writes event with all fields", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		writer, err := NewSSEWriter(w, r)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		event := SSEEvent{
+			ID:    "456",
+			Name:  "message",
+			Data:  []byte("hello"),
+			Retry: 3000 * time.Millisecond,
+		}
+
+		err = writer.WriteEvent(event)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		body := w.Body.String()
+		if !strings.Contains(body, "id: 456") {
+			t.Errorf("expected id in body, got %s", body)
+		}
+		if !strings.Contains(body, "event: message") {
+			t.Errorf("expected event name in body, got %s", body)
+		}
+		if !strings.Contains(body, "retry: 3000") {
+			t.Errorf("expected retry in body, got %s", body)
+		}
+		if !strings.Contains(body, "data: hello") {
+			t.Errorf("expected data in body, got %s", body)
+		}
+	})
+}
+
+func TestSSEWriter_WriteComment(t *testing.T) {
+	t.Run("writes comment", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		writer, err := NewSSEWriter(w, r)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		err = writer.WriteComment("keepalive")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		body := w.Body.String()
+		if !strings.Contains(body, ": keepalive") {
+			t.Errorf("expected comment in body, got %s", body)
+		}
+	})
+}
+
+func TestSSEWriter_Flush(t *testing.T) {
+	t.Run("flushes without error", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		writer, err := NewSSEWriter(w, r)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Flush should not panic
+		writer.Flush()
+	})
+}
+
+// InMemoryReplayer tests
+
+func TestInMemoryReplayer(t *testing.T) {
+	t.Run("stores and replays events", func(t *testing.T) {
+		replay := NewInMemoryReplayer(100, 0)
+
+		// Store some events
+		replay.Store(SSEEvent{Name: "test1", Data: []byte("data1")})
+		replay.Store(SSEEvent{Name: "test2", Data: []byte("data2")})
+		replay.Store(SSEEvent{Name: "test3", Data: []byte("data3")})
+
+		// Replay from event 1
+		var replayed []SSEEvent
+		count, err := replay.Replay("1", func(e SSEEvent) error {
+			replayed = append(replayed, e)
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if count != 2 {
+			t.Errorf("expected 2 events replayed, got %d", count)
+		}
+		if len(replayed) != 2 {
+			t.Errorf("expected 2 events in slice, got %d", len(replayed))
+		}
+	})
+
+	t.Run("respects max events limit", func(t *testing.T) {
+		replay := NewInMemoryReplayer(2, 0)
+
+		replay.Store(SSEEvent{Data: []byte("data1")})
+		replay.Store(SSEEvent{Data: []byte("data2")})
+		replay.Store(SSEEvent{Data: []byte("data3")}) // Should evict data1
+
+		count, _ := replay.Replay("", func(e SSEEvent) error {
+			return nil
+		})
+		if count != 2 {
+			t.Errorf("expected 2 events (max), got %d", count)
+		}
+	})
+
+	t.Run("respects TTL", func(t *testing.T) {
+		replay := NewInMemoryReplayer(100, 50*time.Millisecond)
+
+		replay.Store(SSEEvent{Data: []byte("old")})
+		time.Sleep(100 * time.Millisecond)
+		replay.Store(SSEEvent{Data: []byte("new")})
+
+		count, _ := replay.Replay("", func(e SSEEvent) error {
+			return nil
+		})
+		if count != 1 {
+			t.Errorf("expected 1 event (old expired), got %d", count)
+		}
+	})
+
+	t.Run("auto-assigns IDs", func(t *testing.T) {
+		replay := NewInMemoryReplayer(100, 0)
+
+		event := SSEEvent{Data: []byte("test")}
+		returnedEvent := replay.Store(event)
+
+		// Check that returned event has ID assigned
+		if returnedEvent.ID == "" {
+			t.Error("expected returned event to have ID auto-assigned")
+		}
+
+		// Check that ID is accessible immediately without replay
+		if returnedEvent.ID != "1" {
+			t.Errorf("expected ID to be 1, got %s", returnedEvent.ID)
+		}
+
+		// Also verify it's stored correctly
+		var replayed SSEEvent
+		_, _ = replay.Replay("", func(e SSEEvent) error {
+			replayed = e
+			return nil
+		})
+		if replayed.ID == "" {
+			t.Error("expected ID to be auto-assigned in storage")
+		}
+		if replayed.ID != returnedEvent.ID {
+			t.Errorf("replay ID %s doesn't match returned ID %s", replayed.ID, returnedEvent.ID)
+		}
+	})
+}
+
+func TestSSEWithReplay(t *testing.T) {
+	t.Run("creates stream without replay when no header", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+		replay := NewInMemoryReplayer(100, 0)
+
+		stream, err := SSEWithReplay(w, r, replay)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer func() { _ = stream.Close() }()
+
+		// Should not replay anything
+	})
+
+	t.Run("replays events when Last-Event-ID present", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+		r.Header.Set("Last-Event-ID", "0")
+		replay := NewInMemoryReplayer(100, 0)
+
+		replay.Store(SSEEvent{Data: []byte("event1")})
+		replay.Store(SSEEvent{Data: []byte("event2")})
+
+		stream, err := SSEWithReplay(w, r, replay)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer func() { _ = stream.Close() }()
+
+		body := w.Body.String()
+		if !strings.Contains(body, "event1") || !strings.Contains(body, "event2") {
+			t.Errorf("expected replayed events in body, got %s", body)
+		}
+	})
+
+	t.Run("returns error for invalid Last-Event-ID", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+		r.Header.Set("Last-Event-ID", "not-a-number")
+		replay := NewInMemoryReplayer(100, 0)
+
+		_, err := SSEWithReplay(w, r, replay)
+		if err == nil {
+			t.Error("expected error for invalid Last-Event-ID")
+		}
+	})
+}
+
+// SSEHub tests
+
+func TestSSEHub(t *testing.T) {
+	t.Run("registers and unregisters connections", func(t *testing.T) {
+		hub := NewSSEHub()
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		stream, _ := NewSSE(w, r)
+		hub.Register(stream)
+
+		if hub.ConnectionCount() != 1 {
+			t.Errorf("expected 1 connection, got %d", hub.ConnectionCount())
+		}
+
+		hub.Unregister(stream)
+		if hub.ConnectionCount() != 0 {
+			t.Errorf("expected 0 connections, got %d", hub.ConnectionCount())
+		}
+	})
+
+	t.Run("subscribes to topics", func(t *testing.T) {
+		hub := NewSSEHub()
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		stream, _ := NewSSE(w, r)
+		hub.Subscribe(stream, "notifications")
+
+		if hub.TopicCount("notifications") != 1 {
+			t.Errorf("expected 1 subscriber, got %d", hub.TopicCount("notifications"))
+		}
+
+		hub.Unsubscribe(stream, "notifications")
+		if hub.TopicCount("notifications") != 0 {
+			t.Errorf("expected 0 subscribers, got %d", hub.TopicCount("notifications"))
+		}
+	})
+
+	t.Run("broadcasts to all connections", func(t *testing.T) {
+		hub := NewSSEHub()
+
+		// Create two streams
+		w1 := httptest.NewRecorder()
+		w2 := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		stream1, _ := NewSSE(w1, r)
+		stream2, _ := NewSSE(w2, r)
+
+		hub.Register(stream1)
+		hub.Register(stream2)
+
+		hub.Broadcast(SSEEvent{Data: []byte("hello all")})
+
+		if !strings.Contains(w1.Body.String(), "hello all") {
+			t.Error("expected stream1 to receive broadcast")
+		}
+		if !strings.Contains(w2.Body.String(), "hello all") {
+			t.Error("expected stream2 to receive broadcast")
+		}
+	})
+
+	t.Run("broadcasts to topic subscribers only", func(t *testing.T) {
+		hub := NewSSEHub()
+
+		w1 := httptest.NewRecorder()
+		w2 := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		stream1, _ := NewSSE(w1, r)
+		stream2, _ := NewSSE(w2, r)
+
+		hub.Subscribe(stream1, "topic1")
+		hub.Subscribe(stream2, "topic2")
+
+		hub.BroadcastTo("topic1", SSEEvent{Data: []byte("topic1 message")})
+
+		if !strings.Contains(w1.Body.String(), "topic1 message") {
+			t.Error("expected stream1 to receive topic1 message")
+		}
+		if strings.Contains(w2.Body.String(), "topic1 message") {
+			t.Error("expected stream2 NOT to receive topic1 message")
+		}
+	})
+
+	t.Run("unsubscribe removes from all topics", func(t *testing.T) {
+		hub := NewSSEHub()
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		stream, _ := NewSSE(w, r)
+		hub.Subscribe(stream, "topic1")
+		hub.Subscribe(stream, "topic2")
+
+		hub.Unregister(stream)
+
+		if hub.TopicCount("topic1") != 0 {
+			t.Error("expected stream to be removed from topic1")
+		}
+		if hub.TopicCount("topic2") != 0 {
+			t.Error("expected stream to be removed from topic2")
+		}
+	})
+}


### PR DESCRIPTION
Add Server-Sent Events (SSE) implementation with:
- Core SSE connection and provider interfaces
- InMemoryReplayer for event replay with Last-Event-ID support
- SSEHub for fan-out broadcasting to multiple clients
- Built-in stdlib provider (zero dependencies)
- Complete working example with HTML client
- Documentation in README