### PR TITLE
feat: add pprof profiling endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A lightweight HTTP framework for Go built on top of the standard `net/http` libr
   - [Extensible Interfaces](#extensible-interfaces)
   - [Pluggable Features](#pluggable-features)
 - [Testing Utilities](docs/TESTING.md)
+- [Profiling](#profiling)
 - [Configuration](#configuration)
   - [Server Configuration](#server-configuration)
   - [Middleware Configuration](#middleware-configuration)
@@ -579,6 +580,54 @@ Optional features that require external dependencies. See [PLUGGABLE.md](docs/PL
 ## Testing Utilities
 
 The `zhtest` package provides fluent, chainable helpers for testing HTTP handlers and middleware. See [TESTING.md](docs/TESTING.md) for details.
+
+## Profiling
+
+Built-in Go profiling endpoints via `net/http/pprof`, secured by default with auto-generated passwords:
+
+```go
+import (
+    "log"
+
+    zh "github.com/alexferl/zerohttp"
+    "github.com/alexferl/zerohttp/pprof"
+)
+
+func main() {
+    app := zh.New()
+
+    // Default: auto-generates secure password
+    pp := pprof.New(app, pprof.DefaultConfig)
+    log.Printf("pprof credentials - username: %s, password: %s", pp.Auth.Username, pp.Auth.Password)
+
+    // With custom credentials
+    cfg := pprof.DefaultConfig
+    cfg.Auth = &pprof.AuthConfig{
+        Username: "admin",
+        Password: "secret",
+    }
+    pp = pprof.New(app, cfg)
+
+    // Disable authentication (not recommended for production)
+    cfg = pprof.DefaultConfig
+    cfg.Auth = &pprof.AuthConfig{} // empty = disabled
+    pp = pprof.New(app, cfg)
+
+    log.Fatal(app.Start())
+}
+```
+
+Available endpoints at `/debug/pprof/`:
+
+- `/debug/pprof/` - Index page listing all profiles
+- `/debug/pprof/profile` - CPU profile (use `?seconds=30`)
+- `/debug/pprof/heap` - Memory heap profile
+- `/debug/pprof/goroutine` - Goroutine profile
+- `/debug/pprof/trace` - Execution trace (use `?seconds=5`)
+- `/debug/pprof/block` - Block profile
+- `/debug/pprof/mutex` - Mutex profile
+
+Access credentials via the returned `PProf` struct: `pp.Auth.Username`, `pp.Auth.Password`.
 
 ## Configuration
 

--- a/examples/pprof/main.go
+++ b/examples/pprof/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"log"
+
+	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/pprof"
+)
+
+func main() {
+	app := zh.New()
+
+	// Basic usage with defaults - auto-generates secure password
+	// Credentials are available via the returned PProf struct
+	pp := pprof.New(app, pprof.DefaultConfig)
+	log.Printf("pprof credentials - username: %s, password: %s", pp.Auth.Username, pp.Auth.Password)
+
+	// Or with custom configuration:
+
+	// Example 1: Custom prefix (auto-generates password)
+	// cfg := pprof.DefaultConfig
+	// cfg.Prefix = "/admin/pprof"
+	// pp := pprof.New(app, cfg)
+	// log.Printf("pprof credentials - username: %s, password: %s", pp.Auth.Username, pp.Auth.Password)
+
+	// Example 2: With specific basic auth credentials
+	// cfg := pprof.DefaultConfig
+	// cfg.Auth = &pprof.AuthConfig{
+	// 	Username: "admin",
+	// 	Password: "secret",
+	// }
+	// pp := pprof.New(app, cfg)
+
+	// Example 3: Disable authentication (not recommended for production)
+	// cfg := pprof.DefaultConfig
+	// cfg.Auth = &pprof.AuthConfig{} // empty = disabled
+	// pprof.New(app, cfg)
+
+	// Example 4: Selective endpoints (disable some profiles)
+	// cfg := pprof.DefaultConfig
+	// cfg.EnableBlock = false
+	// cfg.EnableMutex = false
+	// pp := pprof.New(app, cfg)
+
+	log.Printf("pprof endpoints available at http://localhost:8080%s/", pp.Config.Prefix)
+	log.Fatal(app.Start())
+}

--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -1,0 +1,245 @@
+package pprof
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"net/http"
+	stdpprof "net/http/pprof"
+
+	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/log"
+)
+
+// PProf holds the pprof configuration and runtime information
+type PProf struct {
+	// Config is the configuration used
+	Config Config
+	// Auth contains the actual authentication config used (auto-generated or provided)
+	Auth *AuthConfig
+}
+
+// Config holds the pprof configuration
+type Config struct {
+	// Prefix is the base path for all pprof endpoints
+	// Default: "/debug/pprof"
+	Prefix string
+
+	// EnableIndex enables the index page listing all profiles
+	// Default: true
+	EnableIndex bool
+
+	// EnableCmdline enables the cmdline endpoint
+	// Default: true
+	EnableCmdline bool
+
+	// EnableProfile enables the CPU profile endpoint
+	// Default: true
+	EnableProfile bool
+
+	// EnableSymbol enables the symbol endpoint
+	// Default: true
+	EnableSymbol bool
+
+	// EnableTrace enables the trace endpoint
+	// Default: true
+	EnableTrace bool
+
+	// EnableHeap enables the heap profile endpoint
+	// Default: true
+	EnableHeap bool
+
+	// EnableGoroutine enables the goroutine profile endpoint
+	// Default: true
+	EnableGoroutine bool
+
+	// EnableThreadCreate enables the threadcreate profile endpoint
+	// Default: true
+	EnableThreadCreate bool
+
+	// EnableBlock enables the block profile endpoint
+	// Default: true
+	EnableBlock bool
+
+	// EnableMutex enables the mutex profile endpoint
+	// Default: true
+	EnableMutex bool
+
+	// Auth is the basic auth configuration.
+	// If nil, a random password will be generated.
+	// Set to &AuthConfig{} with empty Username/Password to disable auth.
+	// Default: nil (auto-generates secure password)
+	Auth *AuthConfig
+}
+
+// AuthConfig holds basic authentication configuration
+type AuthConfig struct {
+	// Username for basic auth
+	// Default: "pprof"
+	Username string
+	// Password for basic auth
+	// Default: auto-generated secure random password
+	Password string
+}
+
+// DefaultConfig is the default pprof configuration.
+// Modify this to change system-wide defaults.
+var DefaultConfig = Config{
+	Prefix:             "/debug/pprof",
+	EnableIndex:        true,
+	EnableCmdline:      true,
+	EnableProfile:      true,
+	EnableSymbol:       true,
+	EnableTrace:        true,
+	EnableHeap:         true,
+	EnableGoroutine:    true,
+	EnableThreadCreate: true,
+	EnableBlock:        true,
+	EnableMutex:        true,
+	Auth:               nil,
+}
+
+// generateRandomPassword generates a secure random password
+func generateRandomPassword() string {
+	b := make([]byte, 24)
+	if _, err := rand.Read(b); err != nil {
+		// Fallback to a default if crypto/rand fails (extremely unlikely)
+		return "pprof-fallback-password-change-me"
+	}
+	return base64.URLEncoding.EncodeToString(b)
+}
+
+// New creates and registers all pprof endpoints with the provided configuration.
+// Returns a PProf struct containing the configuration and actual auth credentials used.
+//
+// Use DefaultConfig for default values:
+//
+//	pp := pprof.New(app, pprof.DefaultConfig)
+//	// Access auto-generated credentials:
+//	// pp.Auth.Username, pp.Auth.Password
+//
+// Or customize specific fields:
+//
+//	cfg := pprof.DefaultConfig
+//	cfg.Prefix = "/admin/pprof"
+//	pp := pprof.New(app, cfg)
+//
+// To disable authentication:
+//
+//	cfg := pprof.DefaultConfig
+//	cfg.Auth = &pprof.AuthConfig{}  // empty = no auth
+//	pp := pprof.New(app, cfg)
+func New(app *zh.Server, cfg Config) *PProf {
+	prefix := cfg.Prefix
+	auth := cfg.Auth
+	logger := app.Logger()
+
+	if auth == nil {
+		password := generateRandomPassword()
+		auth = &AuthConfig{
+			Username: "pprof",
+			Password: password,
+		}
+	} else if auth.Username == "" && auth.Password == "" {
+		auth = nil
+		logger.Warn("pprof endpoints enabled without authentication",
+			log.F("endpoint", prefix),
+		)
+	}
+
+	pp := &PProf{
+		Config: cfg,
+		Auth:   auth,
+	}
+
+	wrapFunc := func(fn http.HandlerFunc) zh.HandlerFunc {
+		if auth != nil {
+			return authHandlerFunc(auth, fn)
+		}
+		return adaptHandlerFunc(fn)
+	}
+
+	wrapHandler := func(h http.Handler) zh.HandlerFunc {
+		if auth != nil {
+			return authHandler(auth, h)
+		}
+		return adaptHandler(h)
+	}
+
+	if cfg.EnableIndex {
+		app.GET(prefix+"/", wrapFunc(stdpprof.Index))
+	}
+	if cfg.EnableCmdline {
+		app.GET(prefix+"/cmdline", wrapFunc(stdpprof.Cmdline))
+	}
+	if cfg.EnableProfile {
+		app.GET(prefix+"/profile", wrapFunc(stdpprof.Profile))
+	}
+	if cfg.EnableSymbol {
+		app.GET(prefix+"/symbol", wrapFunc(stdpprof.Symbol))
+		app.POST(prefix+"/symbol", wrapFunc(stdpprof.Symbol))
+	}
+	if cfg.EnableTrace {
+		app.GET(prefix+"/trace", wrapFunc(stdpprof.Trace))
+	}
+	if cfg.EnableHeap {
+		app.GET(prefix+"/heap", wrapHandler(stdpprof.Handler("heap")))
+	}
+	if cfg.EnableGoroutine {
+		app.GET(prefix+"/goroutine", wrapHandler(stdpprof.Handler("goroutine")))
+	}
+	if cfg.EnableThreadCreate {
+		app.GET(prefix+"/threadcreate", wrapHandler(stdpprof.Handler("threadcreate")))
+	}
+	if cfg.EnableBlock {
+		app.GET(prefix+"/block", wrapHandler(stdpprof.Handler("block")))
+	}
+	if cfg.EnableMutex {
+		app.GET(prefix+"/mutex", wrapHandler(stdpprof.Handler("mutex")))
+	}
+
+	return pp
+}
+
+// adaptHandler adapts a standard http.Handler to zerohttp's HandlerFunc
+func adaptHandler(h http.Handler) zh.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		h.ServeHTTP(w, r)
+		return nil
+	}
+}
+
+// adaptHandlerFunc adapts a standard http.HandlerFunc to zerohttp's HandlerFunc
+func adaptHandlerFunc(fn http.HandlerFunc) zh.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		fn(w, r)
+		return nil
+	}
+}
+
+// authHandler wraps a handler with basic authentication
+func authHandler(auth *AuthConfig, h http.Handler) zh.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != auth.Username || pass != auth.Password {
+			w.Header().Set("WWW-Authenticate", `Basic realm="pprof"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return nil
+		}
+		h.ServeHTTP(w, r)
+		return nil
+	}
+}
+
+// authHandlerFunc wraps a handler function with basic authentication
+func authHandlerFunc(auth *AuthConfig, fn http.HandlerFunc) zh.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != auth.Username || pass != auth.Password {
+			w.Header().Set("WWW-Authenticate", `Basic realm="pprof"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return nil
+		}
+		fn(w, r)
+		return nil
+	}
+}

--- a/pprof/pprof_test.go
+++ b/pprof/pprof_test.go
@@ -1,0 +1,312 @@
+package pprof
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	zh "github.com/alexferl/zerohttp"
+)
+
+// setupPProf creates a test server with pprof endpoints and returns the server and pprof instance.
+// By default, auth is disabled for tests. Use setupPProfWithAuth to test auth scenarios.
+func setupPProf(t *testing.T, cfg *Config) (*zh.Server, *PProf) {
+	t.Helper()
+	app := zh.New()
+
+	var c Config
+	if cfg != nil {
+		c = *cfg
+		// Disable auth for tests unless explicitly set
+		if cfg.Auth == nil {
+			c.Auth = &AuthConfig{}
+		}
+	} else {
+		c = DefaultConfig
+		c.Auth = &AuthConfig{} // disable auth by default for tests
+	}
+
+	pp := New(app, c)
+	return app, pp
+}
+
+// setupPProfWithAuth creates a test server with pprof endpoints and specific auth credentials.
+func setupPProfWithAuth(t *testing.T, username, password string) (*zh.Server, *PProf) {
+	t.Helper()
+	app := zh.New()
+	cfg := DefaultConfig
+	cfg.Auth = &AuthConfig{
+		Username: username,
+		Password: password,
+	}
+	pp := New(app, cfg)
+	return app, pp
+}
+
+// makeRequest makes an HTTP request to the test server and returns the response.
+func makeRequest(t *testing.T, app *zh.Server, method, path string, username, password string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	if username != "" || password != "" {
+		req.SetBasicAuth(username, password)
+	}
+	rec := httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestDefaultConfig(t *testing.T) {
+	if DefaultConfig.Prefix != "/debug/pprof" {
+		t.Errorf("expected prefix '/debug/pprof', got '%s'", DefaultConfig.Prefix)
+	}
+	if !DefaultConfig.EnableIndex {
+		t.Error("expected EnableIndex to be true")
+	}
+	if !DefaultConfig.EnableCmdline {
+		t.Error("expected EnableCmdline to be true")
+	}
+	if !DefaultConfig.EnableProfile {
+		t.Error("expected EnableProfile to be true")
+	}
+	if !DefaultConfig.EnableSymbol {
+		t.Error("expected EnableSymbol to be true")
+	}
+	if !DefaultConfig.EnableTrace {
+		t.Error("expected EnableTrace to be true")
+	}
+	if !DefaultConfig.EnableHeap {
+		t.Error("expected EnableHeap to be true")
+	}
+	if !DefaultConfig.EnableGoroutine {
+		t.Error("expected EnableGoroutine to be true")
+	}
+	if !DefaultConfig.EnableThreadCreate {
+		t.Error("expected EnableThreadCreate to be true")
+	}
+	if !DefaultConfig.EnableBlock {
+		t.Error("expected EnableBlock to be true")
+	}
+	if !DefaultConfig.EnableMutex {
+		t.Error("expected EnableMutex to be true")
+	}
+	if DefaultConfig.Auth != nil {
+		t.Error("expected Auth to be nil")
+	}
+}
+
+func TestNewWithDefaultConfig(t *testing.T) {
+	app, _ := setupPProf(t, nil)
+
+	rec := makeRequest(t, app, http.MethodGet, "/debug/pprof/", "", "")
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+}
+
+func TestNewWithCustomPrefix(t *testing.T) {
+	cfg := DefaultConfig
+	cfg.Prefix = "/admin/pprof"
+	app, _ := setupPProf(t, &cfg)
+
+	// Test index endpoint at custom prefix
+	rec := makeRequest(t, app, http.MethodGet, "/admin/pprof/", "", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	// Test that default prefix doesn't work
+	rec = makeRequest(t, app, http.MethodGet, "/debug/pprof/", "", "")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected status %d for unknown path, got %d", http.StatusNotFound, rec.Code)
+	}
+}
+
+func TestNewWithAuth(t *testing.T) {
+	app, _ := setupPProfWithAuth(t, "admin", "secret")
+
+	// Test without auth
+	rec := makeRequest(t, app, http.MethodGet, "/debug/pprof/", "", "")
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d without auth, got %d", http.StatusUnauthorized, rec.Code)
+	}
+
+	// Test with wrong credentials
+	rec = makeRequest(t, app, http.MethodGet, "/debug/pprof/", "wrong", "wrong")
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d with wrong credentials, got %d", http.StatusUnauthorized, rec.Code)
+	}
+
+	// Test with correct credentials
+	rec = makeRequest(t, app, http.MethodGet, "/debug/pprof/", "admin", "secret")
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d with correct credentials, got %d", http.StatusOK, rec.Code)
+	}
+}
+
+func TestNewWithDisabledEndpoints(t *testing.T) {
+	cfg := DefaultConfig
+	cfg.EnableIndex = false
+	cfg.EnableCmdline = false
+	app, _ := setupPProf(t, &cfg)
+
+	// Test disabled index endpoint
+	rec := makeRequest(t, app, http.MethodGet, "/debug/pprof/", "", "")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected status %d for disabled endpoint, got %d", http.StatusNotFound, rec.Code)
+	}
+}
+
+func TestCmdlineEndpoint(t *testing.T) {
+	app, _ := setupPProf(t, nil)
+
+	rec := makeRequest(t, app, http.MethodGet, "/debug/pprof/cmdline", "", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+}
+
+func TestSymbolEndpoint(t *testing.T) {
+	app, _ := setupPProf(t, nil)
+
+	// Test GET
+	rec := makeRequest(t, app, http.MethodGet, "/debug/pprof/symbol", "", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d for GET, got %d", http.StatusOK, rec.Code)
+	}
+
+	// Test POST
+	rec = makeRequest(t, app, http.MethodPost, "/debug/pprof/symbol", "", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d for POST, got %d", http.StatusOK, rec.Code)
+	}
+}
+
+func TestHeapEndpoint(t *testing.T) {
+	app, _ := setupPProf(t, nil)
+
+	rec := makeRequest(t, app, http.MethodGet, "/debug/pprof/heap", "", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+}
+
+func TestGoroutineEndpoint(t *testing.T) {
+	app, _ := setupPProf(t, nil)
+
+	rec := makeRequest(t, app, http.MethodGet, "/debug/pprof/goroutine", "", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+}
+
+func TestThreadCreateEndpoint(t *testing.T) {
+	app, _ := setupPProf(t, nil)
+
+	rec := makeRequest(t, app, http.MethodGet, "/debug/pprof/threadcreate", "", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+}
+
+func TestBlockEndpoint(t *testing.T) {
+	app, _ := setupPProf(t, nil)
+
+	rec := makeRequest(t, app, http.MethodGet, "/debug/pprof/block", "", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+}
+
+func TestMutexEndpoint(t *testing.T) {
+	app, _ := setupPProf(t, nil)
+
+	rec := makeRequest(t, app, http.MethodGet, "/debug/pprof/mutex", "", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+}
+
+func TestAllEndpointsWithAuth(t *testing.T) {
+	app, pp := setupPProfWithAuth(t, "test", "test")
+
+	if pp.Auth == nil {
+		t.Fatal("expected Auth to be set")
+	}
+	if pp.Auth.Username != "test" {
+		t.Errorf("expected username 'test', got '%s'", pp.Auth.Username)
+	}
+	if pp.Auth.Password != "test" {
+		t.Errorf("expected password 'test', got '%s'", pp.Auth.Password)
+	}
+
+	endpoints := []string{
+		"/debug/pprof/",
+		"/debug/pprof/cmdline",
+		"/debug/pprof/symbol",
+		"/debug/pprof/heap",
+		"/debug/pprof/goroutine",
+		"/debug/pprof/threadcreate",
+		"/debug/pprof/block",
+		"/debug/pprof/mutex",
+	}
+
+	for _, endpoint := range endpoints {
+		// Without auth
+		rec := makeRequest(t, app, http.MethodGet, endpoint, "", "")
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("endpoint %s: expected status %d without auth, got %d", endpoint, http.StatusUnauthorized, rec.Code)
+		}
+
+		// With auth
+		rec = makeRequest(t, app, http.MethodGet, endpoint, "test", "test")
+		if rec.Code != http.StatusOK {
+			t.Errorf("endpoint %s: expected status %d with auth, got %d", endpoint, http.StatusOK, rec.Code)
+		}
+	}
+}
+
+func TestAutoGeneratedAuth(t *testing.T) {
+	app := zh.New()
+	cfg := DefaultConfig // Auth is nil, so auto-generate
+	pp := New(app, cfg)
+
+	if pp.Auth == nil {
+		t.Fatal("expected Auth to be auto-generated")
+	}
+	if pp.Auth.Username != "pprof" {
+		t.Errorf("expected default username 'pprof', got '%s'", pp.Auth.Username)
+	}
+	if pp.Auth.Password == "" {
+		t.Error("expected auto-generated password to not be empty")
+	}
+
+	// Test that auth is required
+	rec := makeRequest(t, app, http.MethodGet, "/debug/pprof/", "", "")
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d without auth, got %d", http.StatusUnauthorized, rec.Code)
+	}
+
+	// Test with auto-generated credentials
+	rec = makeRequest(t, app, http.MethodGet, "/debug/pprof/", pp.Auth.Username, pp.Auth.Password)
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d with correct credentials, got %d", http.StatusOK, rec.Code)
+	}
+}
+
+func TestDisabledAuth(t *testing.T) {
+	app := zh.New()
+	cfg := DefaultConfig
+	cfg.Auth = &AuthConfig{} // empty = disabled
+	pp := New(app, cfg)
+
+	if pp.Auth != nil {
+		t.Error("expected Auth to be nil when disabled")
+	}
+
+	// Test without auth - should succeed
+	rec := makeRequest(t, app, http.MethodGet, "/debug/pprof/", "", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d with auth disabled, got %d", http.StatusOK, rec.Code)
+	}
+}


### PR DESCRIPTION
Add pprof package with secure-by-default profiling endpoints wrapping net/http/pprof. Features include:

- Auto-generated secure passwords when auth is not specified
- PProf struct returned with Config and Auth for credential access
- Optional basic auth protection with customizable credentials
- All standard pprof endpoints: cpu, heap, goroutine, trace, block, mutex
- Configurable endpoint prefix and selective endpoint enable/disable