### PR TITLE
feat: add JWT authentication middleware

### DIFF
--- a/config/jwt_auth.go
+++ b/config/jwt_auth.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"net/http"
+	"strings"
+	"time"
+)
+
+// TokenType indicates the type of token being generated
+type TokenType int
+
+const (
+	AccessToken TokenType = iota
+	RefreshToken
+)
+
+const (
+	TokenTypeRefresh = "refresh"
+)
+
+// TokenStore is the interface for JWT token operations.
+// Users implement this interface to integrate their preferred JWT library
+// and handle token persistence (generation, validation, revocation).
+type TokenStore interface {
+	// Validate parses and validates a JWT token, returning the claims.
+	// Returns (claims, nil) on valid token, (nil, error) on invalid.
+	Validate(token string) (JWTClaims, error)
+
+	// Generate creates a new signed JWT token for the given claims.
+	// Used for access tokens and refresh tokens.
+	Generate(claims JWTClaims, tokenType TokenType) (string, error)
+
+	// Revoke invalidates a refresh token (called during logout).
+	// Implement this to store revoked token identifiers (e.g., jti) in database/Redis.
+	// Return nil if revocation succeeds or if token doesn't need revocation.
+	Revoke(claims JWTClaims) error
+
+	// IsRevoked checks if a refresh token has been revoked.
+	// Return true if token was revoked, false otherwise.
+	// Called during token refresh to prevent use of revoked tokens.
+	IsRevoked(claims JWTClaims) bool
+}
+
+// JWTAuthConfig configures JWT authentication middleware
+type JWTAuthConfig struct {
+	// TokenExtractor extracts the JWT token from the request.
+	// Default: extracts from "Authorization: Bearer <token>" header
+	TokenExtractor func(r *http.Request) string
+
+	// TokenStore handles all token operations (validate, generate, revoke).
+	// This is the PLUGGABLE INTERFACE - users implement this with their JWT library.
+	// REQUIRED for authentication to work.
+	TokenStore TokenStore
+
+	// RequiredClaims are claims that MUST be present in the token.
+	// Validation fails if any are missing.
+	// Default: none
+	RequiredClaims []string
+
+	// ExemptPaths are paths that skip JWT validation.
+	// Default: []
+	ExemptPaths []string
+
+	// ExemptMethods are HTTP methods that skip JWT validation.
+	// Default: [] (OPTIONS is always exempt)
+	ExemptMethods []string
+
+	// ErrorHandler is called when JWT validation fails.
+	// Default: Returns 401/403 with RFC 9457 Problem Details
+	ErrorHandler http.HandlerFunc
+
+	// OnSuccess is called after successful validation (optional).
+	// Use for audit logging, metrics, etc.
+	OnSuccess func(r *http.Request, claims JWTClaims)
+
+	// AccessTokenTTL is the time-to-live for access tokens.
+	// Default: 15 minutes
+	AccessTokenTTL time.Duration
+
+	// RefreshTokenTTL is the time-to-live for refresh tokens.
+	// Default: 7 days
+	RefreshTokenTTL time.Duration
+}
+
+// DefaultJWTAuthConfig provides sensible defaults
+var DefaultJWTAuthConfig = JWTAuthConfig{
+	TokenExtractor:  extractBearerToken,
+	ExemptPaths:     []string{},
+	ExemptMethods:   []string{},
+	RequiredClaims:  []string{},
+	AccessTokenTTL:  15 * time.Minute,
+	RefreshTokenTTL: 7 * 24 * time.Hour,
+}
+
+// JWTClaims represents validated JWT claims.
+// This is intentionally an interface{} to allow any JWT library's claims type.
+// Users type-assert to their library's claims type in handlers.
+type JWTClaims any
+
+// Standard JWT claim keys (RFC 7519)
+const (
+	JWTClaimSubject    = "sub"
+	JWTClaimIssuer     = "iss"
+	JWTClaimAudience   = "aud"
+	JWTClaimExpiration = "exp"
+	JWTClaimNotBefore  = "nbf"
+	JWTClaimIssuedAt   = "iat"
+	JWTClaimJWTID      = "jti"
+	JWTClaimScope      = "scope"
+	JWTClaimType       = "type"
+)
+
+// extractBearerToken extracts the JWT token from the Authorization header
+func extractBearerToken(r *http.Request) string {
+	auth := r.Header.Get("Authorization")
+	if auth == "" {
+		return ""
+	}
+
+	const prefix = "Bearer "
+	if !strings.HasPrefix(auth, prefix) {
+		return ""
+	}
+
+	return strings.TrimSpace(auth[len(prefix):])
+}

--- a/config/jwt_auth_test.go
+++ b/config/jwt_auth_test.go
@@ -1,0 +1,149 @@
+package config
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestDefaultJWTAuthConfig(t *testing.T) {
+	cfg := DefaultJWTAuthConfig
+
+	if cfg.AccessTokenTTL != 15*time.Minute {
+		t.Errorf("expected AccessTokenTTL to be 15m, got %v", cfg.AccessTokenTTL)
+	}
+
+	if cfg.RefreshTokenTTL != 7*24*time.Hour {
+		t.Errorf("expected RefreshTokenTTL to be 7d, got %v", cfg.RefreshTokenTTL)
+	}
+
+	if cfg.TokenExtractor == nil {
+		t.Error("expected TokenExtractor to be set")
+	}
+}
+
+func TestExtractBearerToken(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{
+			name:   "valid bearer token",
+			header: "Bearer abc123",
+			want:   "abc123",
+		},
+		{
+			name:   "valid bearer token with extra spaces",
+			header: "Bearer  abc123  ",
+			want:   "abc123",
+		},
+		{
+			name:   "missing bearer prefix",
+			header: "abc123",
+			want:   "",
+		},
+		{
+			name:   "empty header",
+			header: "",
+			want:   "",
+		},
+		{
+			name:   "wrong prefix",
+			header: "Basic abc123",
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tt.header != "" {
+				req.Header.Set("Authorization", tt.header)
+			}
+
+			got := extractBearerToken(req)
+			if got != tt.want {
+				t.Errorf("extractBearerToken() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTokenType(t *testing.T) {
+	if AccessToken != 0 {
+		t.Errorf("expected AccessToken to be 0, got %d", AccessToken)
+	}
+	if RefreshToken != 1 {
+		t.Errorf("expected RefreshToken to be 1, got %d", RefreshToken)
+	}
+}
+
+func TestJWTAuthConfig_Customization(t *testing.T) {
+	customExtractor := func(r *http.Request) string {
+		return r.Header.Get("X-Custom-Token")
+	}
+
+	cfg := JWTAuthConfig{
+		TokenExtractor:  customExtractor,
+		RequiredClaims:  []string{"sub", "iss"},
+		ExemptPaths:     []string{"/health", "/metrics"},
+		ExemptMethods:   []string{http.MethodHead},
+		AccessTokenTTL:  30 * time.Minute,
+		RefreshTokenTTL: 30 * 24 * time.Hour,
+	}
+
+	// Test custom extractor
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Custom-Token", "my-token")
+	if got := cfg.TokenExtractor(req); got != "my-token" {
+		t.Errorf("expected token 'my-token', got %q", got)
+	}
+
+	if len(cfg.RequiredClaims) != 2 || cfg.RequiredClaims[0] != "sub" || cfg.RequiredClaims[1] != "iss" {
+		t.Errorf("expected RequiredClaims [sub iss], got %v", cfg.RequiredClaims)
+	}
+
+	if len(cfg.ExemptPaths) != 2 || cfg.ExemptPaths[0] != "/health" || cfg.ExemptPaths[1] != "/metrics" {
+		t.Errorf("expected ExemptPaths [/health /metrics], got %v", cfg.ExemptPaths)
+	}
+
+	if len(cfg.ExemptMethods) != 1 || cfg.ExemptMethods[0] != http.MethodHead {
+		t.Errorf("expected ExemptMethods [HEAD], got %v", cfg.ExemptMethods)
+	}
+
+	if cfg.AccessTokenTTL != 30*time.Minute {
+		t.Errorf("expected AccessTokenTTL to be 30m, got %v", cfg.AccessTokenTTL)
+	}
+}
+
+func TestJWTClaimConstants(t *testing.T) {
+	if JWTClaimSubject != "sub" {
+		t.Errorf("expected JWTClaimSubject = sub, got %s", JWTClaimSubject)
+	}
+	if JWTClaimIssuer != "iss" {
+		t.Errorf("expected JWTClaimIssuer = iss, got %s", JWTClaimIssuer)
+	}
+	if JWTClaimAudience != "aud" {
+		t.Errorf("expected JWTClaimAudience = aud, got %s", JWTClaimAudience)
+	}
+	if JWTClaimExpiration != "exp" {
+		t.Errorf("expected JWTClaimExpiration = exp, got %s", JWTClaimExpiration)
+	}
+	if JWTClaimNotBefore != "nbf" {
+		t.Errorf("expected JWTClaimNotBefore = nbf, got %s", JWTClaimNotBefore)
+	}
+	if JWTClaimIssuedAt != "iat" {
+		t.Errorf("expected JWTClaimIssuedAt = iat, got %s", JWTClaimIssuedAt)
+	}
+	if JWTClaimJWTID != "jti" {
+		t.Errorf("expected JWTClaimJWTID = jti, got %s", JWTClaimJWTID)
+	}
+	if JWTClaimScope != "scope" {
+		t.Errorf("expected JWTClaimScope = scope, got %s", JWTClaimScope)
+	}
+	if JWTClaimType != "type" {
+		t.Errorf("expected JWTClaimType = type, got %s", JWTClaimType)
+	}
+}

--- a/docs/MIDDLEWARES.md
+++ b/docs/MIDDLEWARES.md
@@ -9,6 +9,7 @@ zerohttp provides a comprehensive set of middleware for security, authentication
 - [Available Middlewares](#available-middlewares)
   - [Authentication](#authentication)
     - [Basic Auth](#basic-auth)
+    - [JWT Authentication](#jwt-authentication)
     - [HMAC Request Signing](#hmac-request-signing)
   - [Security](#security)
   - [Rate Limiting](#rate-limiting)
@@ -58,6 +59,178 @@ middleware.BasicAuth(config.BasicAuthConfig{
     Realm: "Restricted Area",
     ExemptPaths: []string{"/health", "/metrics"},
 })
+```
+
+#### JWT Authentication
+
+JSON Web Token (JWT) authentication with pluggable `TokenStore` interface. Includes a built-in HS256 implementation (zero dependencies) or bring your own JWT library.
+
+```go
+// Using built-in HS256 (zero dependencies)
+hp := middleware.HS256Options{
+    Secret: []byte("your-secret-key"),
+    Issuer: "my-app",
+}
+
+jwtCfg := config.JWTAuthConfig{
+    TokenStore:     middleware.NewHS256TokenStore(hp.Secret, hp),
+    RequiredClaims: []string{"sub"},
+    ExemptPaths:    []string{"/login", "/register"},
+}
+
+app.Use(middleware.JWTAuth(jwtCfg))
+```
+
+**TokenStore Interface:**
+
+Users implement the `TokenStore` interface to integrate their preferred JWT library:
+
+```go
+type TokenStore interface {
+    // Validate parses and validates a JWT token
+    Validate(token string) (JWTClaims, error)
+
+    // Generate creates a new signed JWT token
+    Generate(claims JWTClaims, tokenType TokenType) (string, error)
+
+    // Revoke invalidates a refresh token (called during logout)
+    Revoke(claims JWTClaims) error
+
+    // IsRevoked checks if a refresh token has been revoked
+    IsRevoked(claims JWTClaims) bool
+}
+```
+
+**Token Generation:**
+
+```go
+// In your login handler
+claims := middleware.HS256Claims{
+    "sub":   userID,
+    "scope": "read write",
+}
+
+accessToken, _ := middleware.GenerateAccessToken(r, claims, cfg)
+refreshToken, _ := middleware.GenerateRefreshToken(r, claims, cfg)
+```
+
+**Refresh Token Endpoint:**
+
+```go
+// Built-in refresh handler (calls TokenStore.IsRevoked to check revocation)
+app.POST("/auth/refresh", middleware.RefreshTokenHandler(jwtCfg))
+```
+
+**Logout Endpoint:**
+
+Use the built-in logout handler to revoke refresh tokens:
+
+```go
+// TokenStore.Revoke is called during logout
+app.POST("/auth/logout", middleware.LogoutTokenHandler(jwtCfg))
+```
+
+**Security Features:**
+
+- Revoked tokens are blocked immediately on all requests (not just at refresh)
+- Refresh tokens cannot be used as access tokens for protected endpoints
+- Constant-time signature verification to prevent timing attacks
+
+**Accessing Claims in Handlers:**
+
+```go
+func profileHandler(w http.ResponseWriter, r *http.Request) error {
+    jwt := middleware.GetJWTClaims(r)
+    subject := jwt.Subject()     // Get 'sub' claim
+    scopes := jwt.Scopes()       // Get 'scope' claim as []string
+
+    if !jwt.HasScope("admin") {
+        return zh.R.JSON(w, http.StatusForbidden, zh.M{"error": "admin required"})
+    }
+
+    return zh.R.JSON(w, http.StatusOK, zh.M{
+        "subject": subject,
+        "scopes":  scopes,
+    })
+}
+```
+
+**With External JWT Library:**
+
+```go
+// Using golang-jwt/jwt (bring your own)
+type MyTokenStore struct {
+    secret []byte
+}
+
+func (s *MyTokenStore) Validate(token string) (config.JWTClaims, error) {
+    return jwt.Parse(token, func(t *jwt.Token) (interface{}, error) {
+        return s.secret, nil
+    })
+}
+
+func (s *MyTokenStore) Generate(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+    // Your signing logic
+}
+
+func (s *MyTokenStore) Revoke(claims config.JWTClaims) error {
+    // Store jti in Redis/DB
+    return nil
+}
+
+func (s *MyTokenStore) IsRevoked(claims config.JWTClaims) bool {
+    // Check jti in Redis/DB
+    return false
+}
+
+jwtCfg := config.JWTAuthConfig{
+    TokenStore:     &MyTokenStore{secret: secret},
+    RequiredClaims: []string{"sub"},
+}
+
+app.Use(middleware.JWTAuth(jwtCfg))
+```
+
+**Custom Token Extraction:**
+
+By default, tokens are extracted from the `Authorization: Bearer <token>` header. You can customize this with a `TokenExtractor` function:
+
+```go
+// Extract from cookie
+jwtCfg := config.JWTAuthConfig{
+    TokenStore: store,
+    TokenExtractor: func(r *http.Request) string {
+        if cookie, err := r.Cookie("jwt"); err == nil {
+            return cookie.Value
+        }
+        return ""
+    },
+}
+
+// Extract from custom header
+jwtCfg := config.JWTAuthConfig{
+    TokenStore: store,
+    TokenExtractor: func(r *http.Request) string {
+        return r.Header.Get("X-API-Token")
+    },
+}
+
+// Try cookie first, then fallback to Authorization header
+// Useful for supporting both browser (cookie) and API (Bearer) clients
+jwtCfg := config.JWTAuthConfig{
+    TokenStore: store,
+    TokenExtractor: func(r *http.Request) string {
+        if cookie, err := r.Cookie("jwt"); err == nil && cookie.Value != "" {
+            return cookie.Value
+        }
+        // Fallback to Authorization header
+        auth := r.Header.Get("Authorization")
+        if strings.HasPrefix(auth, "Bearer ") {
+            return strings.TrimPrefix(auth, "Bearer ")
+        }
+        return ""
+    },
+}
 ```
 
 #### HMAC Request Signing

--- a/examples/jwt/golang_jwt.go
+++ b/examples/jwt/golang_jwt.go
@@ -1,0 +1,212 @@
+//go:build ignore
+// +build ignore
+
+// This example demonstrates JWT authentication using github.com/golang-jwt/jwt
+//
+// To run this example:
+//   go get github.com/golang-jwt/jwt/v5
+//   go run golang_jwt.go
+//
+// Test commands:
+//   # 1. Login to get tokens
+//   curl -X POST http://localhost:8080/login \
+//     -H "Content-Type: application/json" \
+//     -d '{"username":"alice","password":"secret"}'
+//
+//   # 2. Access protected endpoint (replace <token> with access_token from step 1)
+//   curl -H "Authorization: Bearer <token>" http://localhost:8080/api/profile
+//
+//   # 3. Refresh tokens (replace <refresh_token> from step 1)
+//   curl -X POST http://localhost:8080/auth/refresh \
+//     -H "Content-Type: application/json" \
+//     -d '{"refresh_token":"<refresh_token>"}'
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/middleware"
+)
+
+var jwtSecret = []byte("your-secret-key-change-in-production")
+
+// GolangJWTTokenStore implements config.TokenStore using github.com/golang-jwt/jwt
+type GolangJWTTokenStore struct {
+	secret []byte
+}
+
+// NewGolangJWTTokenStore creates a new TokenStore using golang-jwt/jwt
+func NewGolangJWTTokenStore(secret []byte) *GolangJWTTokenStore {
+	return &GolangJWTTokenStore{secret: secret}
+}
+
+// Validate parses and validates a JWT token
+func (s *GolangJWTTokenStore) Validate(tokenString string) (config.JWTClaims, error) {
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		// Validate signing method
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, jwt.ErrSignatureInvalid
+		}
+		return s.secret, nil
+	})
+
+	if err != nil || !token.Valid {
+		return nil, err
+	}
+
+	return token.Claims, nil
+}
+
+// Generate creates a new JWT token for the given claims
+func (s *GolangJWTTokenStore) Generate(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+	mapClaims, ok := claims.(jwt.MapClaims)
+	if !ok {
+		// Convert map[string]any to jwt.MapClaims
+		if m, ok := claims.(map[string]any); ok {
+			mapClaims = jwt.MapClaims(m)
+		} else {
+			return "", fmt.Errorf("unsupported claims type")
+		}
+	}
+
+	// Set expiration based on token type
+	ttl := config.DefaultJWTAuthConfig.AccessTokenTTL
+	if tokenType == config.RefreshToken {
+		ttl = config.DefaultJWTAuthConfig.RefreshTokenTTL
+		mapClaims["type"] = config.TokenTypeRefresh
+	}
+	mapClaims["exp"] = time.Now().Add(ttl).Unix()
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, mapClaims)
+	return token.SignedString(s.secret)
+}
+
+// Revoke is a no-op in this example. In production, store revoked jti in Redis/DB.
+func (s *GolangJWTTokenStore) Revoke(claims config.JWTClaims) error {
+	// No-op for this example
+	return nil
+}
+
+// IsRevoked always returns false in this example. In production, check Redis/DB.
+func (s *GolangJWTTokenStore) IsRevoked(claims config.JWTClaims) bool {
+	// Always returns false for this example
+	return false
+}
+
+func main() {
+	app := zh.New()
+
+	// Create TokenStore using golang-jwt/jwt
+	tokenStore := NewGolangJWTTokenStore(jwtSecret)
+
+	jwtCfg := config.JWTAuthConfig{
+		TokenStore:      tokenStore,
+		RequiredClaims:  []string{"sub"},
+		ExemptPaths:     []string{"/login"},
+		AccessTokenTTL:  15 * time.Minute,
+		RefreshTokenTTL: 7 * 24 * time.Hour,
+	}
+
+	// Public login endpoint
+	app.POST("/login", loginHandlerGolangJWT(jwtCfg))
+
+	// Refresh token endpoint
+	app.POST("/auth/refresh", middleware.RefreshTokenHandler(jwtCfg))
+
+	// Protected endpoints
+	app.Use(middleware.JWTAuth(jwtCfg))
+
+	app.GET("/api/profile", zh.HandlerFunc(profileHandlerGolangJWT))
+
+	fmt.Println("Server starting on http://localhost:8080")
+	fmt.Println()
+	fmt.Println("This example uses github.com/golang-jwt/jwt v5")
+	fmt.Println()
+	fmt.Println("Endpoints:")
+	fmt.Println("  POST /login        - Get tokens")
+	fmt.Println("  POST /auth/refresh - Refresh tokens")
+	fmt.Println("  GET  /api/profile  - Get profile (requires auth)")
+	fmt.Println()
+	fmt.Println("Try these commands:")
+	fmt.Println("  # 1. Login to get tokens")
+	fmt.Println(`  curl -X POST http://localhost:8080/login -H "Content-Type: application/json" -d '{"username":"alice","password":"secret"}'`)
+	fmt.Println()
+	fmt.Println("  # 2. Access protected endpoint (replace <token> with access_token)")
+	fmt.Println(`  curl -H "Authorization: Bearer <token>" http://localhost:8080/api/profile`)
+	fmt.Println()
+	fmt.Println("  # 3. Refresh tokens (replace <refresh_token>)")
+	fmt.Println(`  curl -X POST http://localhost:8080/auth/refresh -H "Content-Type: application/json" -d '{"refresh_token":"<refresh_token>"}'`)
+	fmt.Println()
+	log.Fatal(app.Start())
+}
+
+func loginHandlerGolangJWT(cfg config.JWTAuthConfig) zh.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		var req struct {
+			Username string `json:"username"`
+			Password string `json:"password"`
+		}
+
+		if err := zh.B.JSON(r.Body, &req); err != nil {
+			return zh.R.JSON(w, http.StatusBadRequest, zh.M{"error": "invalid request"})
+		}
+
+		// Demo credentials
+		if req.Username != "alice" || req.Password != "secret" {
+			return zh.R.JSON(w, http.StatusUnauthorized, zh.M{"error": "invalid credentials"})
+		}
+
+		claims := map[string]any{
+			"sub":   req.Username,
+			"scope": "read write",
+		}
+
+		accessToken, err := middleware.GenerateAccessToken(r, claims, cfg)
+		if err != nil {
+			return zh.R.JSON(w, http.StatusInternalServerError, zh.M{"error": "failed to generate token"})
+		}
+
+		refreshToken, err := middleware.GenerateRefreshToken(r, claims, cfg)
+		if err != nil {
+			return zh.R.JSON(w, http.StatusInternalServerError, zh.M{"error": "failed to generate token"})
+		}
+
+		return zh.R.JSON(w, http.StatusOK, zh.M{
+			"access_token":  accessToken,
+			"refresh_token": refreshToken,
+			"token_type":    "Bearer",
+			"expires_in":    int(cfg.AccessTokenTTL.Seconds()),
+		})
+	}
+}
+
+func profileHandlerGolangJWT(w http.ResponseWriter, r *http.Request) error {
+	jwtWrapper := middleware.GetJWTClaims(r)
+
+	// Type assert to jwt.Claims
+	claims := jwtWrapper.Raw()
+	if claims == nil {
+		return zh.R.JSON(w, http.StatusUnauthorized, zh.M{"error": "no claims found"})
+	}
+
+	jwtClaims, ok := claims.(jwt.Claims)
+	if !ok {
+		return zh.R.JSON(w, http.StatusInternalServerError, zh.M{"error": "invalid claims type"})
+	}
+
+	subject, _ := jwtClaims.GetSubject()
+
+	return zh.R.JSON(w, http.StatusOK, zh.M{
+		"subject": subject,
+		"message": "Hello from golang-jwt/jwt example",
+		"scopes":  jwtWrapper.Scopes(),
+	})
+}

--- a/examples/jwt/lestrrat_jwx.go
+++ b/examples/jwt/lestrrat_jwx.go
@@ -1,0 +1,228 @@
+//go:build ignore
+// +build ignore
+
+// This example demonstrates JWT authentication using github.com/lestrrat-go/jwx v3
+//
+// To run this example:
+//   go get github.com/lestrrat-go/jwx/v3/jwt
+//   go get github.com/lestrrat-go/jwx/v3/jwk
+//   go run lestrrat_jwx.go
+//
+// Test commands:
+//   # 1. Login to get tokens
+//   curl -X POST http://localhost:8080/login \
+//     -H "Content-Type: application/json" \
+//     -d '{"username":"alice","password":"secret"}'
+//
+//   # 2. Access protected endpoint (replace <token> with access_token from step 1)
+//   curl -H "Authorization: Bearer <token>" http://localhost:8080/api/profile
+//
+//   # 3. Refresh tokens (replace <refresh_token> from step 1)
+//   curl -X POST http://localhost:8080/auth/refresh \
+//     -H "Content-Type: application/json" \
+//     -d '{"refresh_token":"<refresh_token>"}'
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwk"
+	"github.com/lestrrat-go/jwx/v3/jwt"
+
+	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/middleware"
+)
+
+// LestrratTokenStore implements config.TokenStore using github.com/lestrrat-go/jwx
+type LestrratTokenStore struct {
+	keySet jwk.Set
+}
+
+// NewLestrratTokenStore creates a new TokenStore using lestrrat-go/jwx
+func NewLestrratTokenStore(keySet jwk.Set) *LestrratTokenStore {
+	return &LestrratTokenStore{keySet: keySet}
+}
+
+// Validate parses and validates a JWT token
+func (s *LestrratTokenStore) Validate(tokenString string) (config.JWTClaims, error) {
+	token, err := jwt.ParseString(tokenString,
+		jwt.WithKeySet(s.keySet),
+		jwt.WithValidate(true),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return token, nil
+}
+
+// Generate creates a new JWT token for the given claims
+func (s *LestrratTokenStore) Generate(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+	// Build JWT token
+	builder := jwt.NewBuilder()
+
+	// Add claims from map
+	if m, ok := claims.(map[string]any); ok {
+		for k, v := range m {
+			builder.Claim(k, v)
+		}
+	}
+
+	// Set expiration based on token type
+	ttl := config.DefaultJWTAuthConfig.AccessTokenTTL
+	if tokenType == config.RefreshToken {
+		ttl = config.DefaultJWTAuthConfig.RefreshTokenTTL
+		builder.Claim("type", config.TokenTypeRefresh)
+	}
+	builder.Expiration(time.Now().Add(ttl))
+
+	token, err := builder.Build()
+	if err != nil {
+		return "", err
+	}
+
+	// Get the signing key from the keyset
+	key, _ := s.keySet.Key(0)
+
+	// Sign the token
+	signed, err := jwt.Sign(token, jwt.WithKey(jwa.HS256, key))
+	if err != nil {
+		return "", err
+	}
+
+	return string(signed), nil
+}
+
+// Revoke is a no-op in this example. In production, store revoked jti in Redis/DB.
+func (s *LestrratTokenStore) Revoke(claims config.JWTClaims) error {
+	// No-op for this example
+	return nil
+}
+
+// IsRevoked always returns false in this example. In production, check Redis/DB.
+func (s *LestrratTokenStore) IsRevoked(claims config.JWTClaims) bool {
+	// Always returns false for this example
+	return false
+}
+
+func main() {
+	app := zh.New()
+
+	// Create a symmetric key for HS256
+	// In production, load this from a secure location
+	key, err := jwk.GenerateKey(jwa.HS256)
+	if err != nil {
+		log.Fatalf("failed to generate key: %s", err)
+	}
+	keySet := jwk.NewSet()
+	keySet.AddKey(key)
+
+	// Create TokenStore using lestrrat-go/jwx
+	tokenStore := NewLestrratTokenStore(keySet)
+
+	jwtCfg := config.JWTAuthConfig{
+		TokenStore:      tokenStore,
+		RequiredClaims:  []string{"sub"},
+		ExemptPaths:     []string{"/login"},
+		AccessTokenTTL:  15 * time.Minute,
+		RefreshTokenTTL: 7 * 24 * time.Hour,
+	}
+
+	// Public login endpoint
+	app.POST("/login", loginHandlerLestrrat(jwtCfg, key))
+
+	// Refresh token endpoint
+	app.POST("/auth/refresh", middleware.RefreshTokenHandler(jwtCfg))
+
+	// Protected endpoints
+	app.Use(middleware.JWTAuth(jwtCfg))
+
+	app.GET("/api/profile", zh.HandlerFunc(profileHandlerLestrrat))
+
+	fmt.Println("Server starting on http://localhost:8080")
+	fmt.Println()
+	fmt.Println("This example uses github.com/lestrrat-go/jwx v3")
+	fmt.Println()
+	fmt.Println("Endpoints:")
+	fmt.Println("  POST /login        - Get tokens")
+	fmt.Println("  POST /auth/refresh - Refresh tokens")
+	fmt.Println("  GET  /api/profile  - Get profile (requires auth)")
+	fmt.Println()
+	fmt.Println("Try these commands:")
+	fmt.Println("  # 1. Login to get tokens")
+	fmt.Println(`  curl -X POST http://localhost:8080/login -H "Content-Type: application/json" -d '{"username":"alice","password":"secret"}'`)
+	fmt.Println()
+	fmt.Println("  # 2. Access protected endpoint (replace <token> with access_token)")
+	fmt.Println(`  curl -H "Authorization: Bearer <token>" http://localhost:8080/api/profile`)
+	fmt.Println()
+	fmt.Println("  # 3. Refresh tokens (replace <refresh_token>)")
+	fmt.Println(`  curl -X POST http://localhost:8080/auth/refresh -H "Content-Type: application/json" -d '{"refresh_token":"<refresh_token>"}'`)
+	fmt.Println()
+	log.Fatal(app.Start())
+}
+
+func loginHandlerLestrrat(cfg config.JWTAuthConfig, key jwk.Key) zh.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		var req struct {
+			Username string `json:"username"`
+			Password string `json:"password"`
+		}
+
+		if err := zh.B.JSON(r.Body, &req); err != nil {
+			return zh.R.JSON(w, http.StatusBadRequest, zh.M{"error": "invalid request"})
+		}
+
+		// Demo credentials
+		if req.Username != "alice" || req.Password != "secret" {
+			return zh.R.JSON(w, http.StatusUnauthorized, zh.M{"error": "invalid credentials"})
+		}
+
+		claims := map[string]any{
+			"sub":   req.Username,
+			"scope": "read write",
+		}
+
+		accessToken, err := middleware.GenerateAccessToken(r, claims, cfg)
+		if err != nil {
+			return zh.R.JSON(w, http.StatusInternalServerError, zh.M{"error": "failed to generate token"})
+		}
+
+		refreshToken, err := middleware.GenerateRefreshToken(r, claims, cfg)
+		if err != nil {
+			return zh.R.JSON(w, http.StatusInternalServerError, zh.M{"error": "failed to generate token"})
+		}
+
+		return zh.R.JSON(w, http.StatusOK, zh.M{
+			"access_token":  accessToken,
+			"refresh_token": refreshToken,
+			"token_type":    "Bearer",
+			"expires_in":    int(cfg.AccessTokenTTL.Seconds()),
+		})
+	}
+}
+
+func profileHandlerLestrrat(w http.ResponseWriter, r *http.Request) error {
+	jwtWrapper := middleware.GetJWTClaims(r)
+
+	// Type assert to jwt.Token
+	claims := jwtWrapper.Raw()
+	if claims == nil {
+		return zh.R.JSON(w, http.StatusUnauthorized, zh.M{"error": "no claims found"})
+	}
+
+	token, ok := claims.(jwt.Token)
+	if !ok {
+		return zh.R.JSON(w, http.StatusInternalServerError, zh.M{"error": "invalid claims type"})
+	}
+
+	return zh.R.JSON(w, http.StatusOK, zh.M{
+		"subject": token.Subject(),
+		"message": "Hello from lestrrat-go/jwx v3 example",
+		"scopes":  jwtWrapper.Scopes(),
+	})
+}

--- a/examples/jwt/main.go
+++ b/examples/jwt/main.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/middleware"
+)
+
+var jwtSecret = []byte("your-secret-key-change-in-production")
+
+func main() {
+	app := zh.New()
+
+	// Simple HS256 token store (no refresh tokens, just access tokens)
+	hp := middleware.HS256Options{
+		Secret: jwtSecret,
+		Issuer: "zerohttp-example",
+	}
+
+	jwtCfg := config.JWTAuthConfig{
+		TokenStore:     middleware.NewHS256TokenStore(jwtSecret, hp),
+		RequiredClaims: []string{"sub"},
+		ExemptPaths:    []string{"/login", "/register"},
+		// Long expiry - 30 days (or use 0 for no expiry)
+		AccessTokenTTL: 30 * 24 * time.Hour,
+	}
+
+	// Public endpoints (no auth required)
+	app.POST("/login", loginHandler(jwtCfg))
+	app.POST("/register", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return zh.R.JSON(w, http.StatusOK, zh.M{
+			"message": "registration endpoint - implement your logic here",
+		})
+	}))
+
+	// Protected endpoints (JWT required)
+	app.Use(middleware.JWTAuth(jwtCfg))
+
+	app.GET("/api/profile", zh.HandlerFunc(profileHandler))
+	app.GET("/api/admin", zh.HandlerFunc(adminHandler))
+
+	fmt.Println("Server starting on http://localhost:8080")
+	fmt.Println()
+	fmt.Println("Simple JWT Example (no refresh tokens)")
+	fmt.Println()
+	fmt.Println("Endpoints:")
+	fmt.Println("  POST /login           - Get access token (30 day expiry)")
+	fmt.Println("  POST /register        - Register a new user (stub)")
+	fmt.Println("  GET  /api/profile     - Get user profile (requires auth)")
+	fmt.Println("  GET  /api/admin       - Admin endpoint (requires auth + admin scope)")
+	fmt.Println()
+	fmt.Println("Try:")
+	fmt.Println("  # Login and get token")
+	fmt.Println("  curl -X POST http://localhost:8080/login -d '{\"username\":\"alice\",\"password\":\"secret\"}'")
+	fmt.Println()
+	fmt.Println("  # Access protected endpoint")
+	fmt.Println("  curl -H 'Authorization: Bearer <token>' http://localhost:8080/api/profile")
+	fmt.Println()
+	log.Fatal(app.Start())
+}
+
+// loginHandler authenticates users and returns a JWT token
+func loginHandler(cfg config.JWTAuthConfig) zh.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		var req struct {
+			Username string `json:"username"`
+			Password string `json:"password"`
+		}
+
+		if err := zh.B.JSON(r.Body, &req); err != nil {
+			return zh.R.JSON(w, http.StatusBadRequest, zh.M{"error": "invalid request"})
+		}
+
+		// In production, verify against database
+		if req.Username != "alice" || req.Password != "secret" {
+			return zh.R.JSON(w, http.StatusUnauthorized, zh.M{"error": "invalid credentials"})
+		}
+
+		// Create claims
+		claims := middleware.HS256Claims{
+			"sub":   req.Username,
+			"scope": "read write",
+		}
+
+		// Generate token
+		token, err := middleware.GenerateAccessToken(r, claims, cfg)
+		if err != nil {
+			return zh.R.JSON(w, http.StatusInternalServerError, zh.M{"error": "failed to generate token"})
+		}
+
+		return zh.R.JSON(w, http.StatusOK, zh.M{
+			"access_token": token,
+			"token_type":   "Bearer",
+			"expires_in":   int(cfg.AccessTokenTTL.Seconds()),
+		})
+	}
+}
+
+func profileHandler(w http.ResponseWriter, r *http.Request) error {
+	jwt := middleware.GetJWTClaims(r)
+
+	return zh.R.JSON(w, http.StatusOK, zh.M{
+		"subject": jwt.Subject(),
+		"scopes":  jwt.Scopes(),
+		"message": "This is your profile",
+	})
+}
+
+func adminHandler(w http.ResponseWriter, r *http.Request) error {
+	// Check for admin scope
+	if !middleware.GetJWTClaims(r).HasScope("admin") {
+		return zh.R.JSON(w, http.StatusForbidden, zh.M{"error": "admin scope required"})
+	}
+
+	return zh.R.JSON(w, http.StatusOK, zh.M{
+		"message": "Admin access granted",
+	})
+}

--- a/examples/jwt/refresh.go
+++ b/examples/jwt/refresh.go
@@ -1,0 +1,211 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/middleware"
+)
+
+var refreshJWTSecret = []byte("your-secret-key-change-in-production")
+
+// JWTTokenStore implements config.TokenStore with HS256 and in-memory revocation.
+// In production, use Redis or database for revocation storage.
+type JWTTokenStore struct {
+	mu      sync.RWMutex
+	revoked map[string]bool // map of jti -> revoked
+	hs256   *middleware.HS256TokenStore
+	opts    middleware.HS256Options
+}
+
+// NewJWTTokenStore creates a new TokenStore with HS256 and revocation support
+func NewJWTTokenStore(secret []byte, opts middleware.HS256Options) *JWTTokenStore {
+	return &JWTTokenStore{
+		revoked: make(map[string]bool),
+		hs256:   middleware.NewHS256TokenStore(secret, opts),
+		opts:    opts,
+	}
+}
+
+// Validate parses and validates a JWT token
+func (s *JWTTokenStore) Validate(token string) (config.JWTClaims, error) {
+	return s.hs256.Validate(token)
+}
+
+// Generate creates a new JWT token
+func (s *JWTTokenStore) Generate(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+	return s.hs256.Generate(claims, tokenType)
+}
+
+// Revoke invalidates a refresh token by its jti claim
+func (s *JWTTokenStore) Revoke(claims config.JWTClaims) error {
+	jti := getJTI(claims)
+	if jti != "" {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.revoked[jti] = true
+	}
+	return nil
+}
+
+// IsRevoked checks if a refresh token has been revoked
+func (s *JWTTokenStore) IsRevoked(claims config.JWTClaims) bool {
+	jti := getJTI(claims)
+	if jti == "" {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.revoked[jti]
+}
+
+// getJTI extracts the jti claim from claims
+func getJTI(claims config.JWTClaims) string {
+	switch c := claims.(type) {
+	case map[string]any:
+		if jti, ok := c["jti"].(string); ok {
+			return jti
+		}
+	case middleware.HS256Claims:
+		if jti, ok := c["jti"].(string); ok {
+			return jti
+		}
+	}
+	return ""
+}
+
+func main() {
+	app := zh.New()
+
+	// HS256 configuration using zero-dependency built-in implementation
+	hp := middleware.HS256Options{
+		Secret: refreshJWTSecret,
+		Issuer: "zerohttp-example",
+	}
+
+	// Create TokenStore with HS256 and revocation support
+	tokenStore := NewJWTTokenStore(refreshJWTSecret, hp)
+
+	jwtCfg := config.JWTAuthConfig{
+		TokenStore:      tokenStore,
+		RequiredClaims:  []string{"sub"},
+		ExemptPaths:     []string{"/login", "/register"},
+		AccessTokenTTL:  15 * time.Minute,
+		RefreshTokenTTL: 7 * 24 * time.Hour,
+	}
+
+	// Public endpoints (no auth required)
+	app.POST("/login", refreshLoginHandler(jwtCfg))
+	app.POST("/logout", middleware.LogoutTokenHandler(jwtCfg)) // Revokes refresh token
+	app.POST("/register", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return zh.R.JSON(w, http.StatusOK, zh.M{
+			"message": "registration endpoint - implement your logic here",
+		})
+	}))
+
+	// Refresh token endpoint
+	app.POST("/auth/refresh", middleware.RefreshTokenHandler(jwtCfg))
+
+	// Protected endpoints (JWT required)
+	app.Use(middleware.JWTAuth(jwtCfg))
+
+	app.GET("/api/profile", zh.HandlerFunc(refreshProfileHandler))
+	app.GET("/api/admin", zh.HandlerFunc(refreshAdminHandler))
+
+	fmt.Println("Server starting on http://localhost:8080")
+	fmt.Println()
+	fmt.Println("Endpoints:")
+	fmt.Println("  POST /login           - Get access and refresh tokens")
+	fmt.Println("  POST /logout          - Revoke refresh token")
+	fmt.Println("  POST /register        - Register a new user (stub)")
+	fmt.Println("  POST /auth/refresh    - Refresh tokens (checks revocation)")
+	fmt.Println("  GET  /api/profile     - Get user profile (requires auth)")
+	fmt.Println("  GET  /api/admin       - Admin endpoint (requires auth + admin scope)")
+	fmt.Println()
+	fmt.Println("Try:")
+	fmt.Println("  # Login and get tokens")
+	fmt.Println("  curl -X POST http://localhost:8080/login -d '{\"username\":\"alice\",\"password\":\"secret\"}'")
+	fmt.Println()
+	fmt.Println("  # Access protected endpoint")
+	fmt.Println("  curl -H 'Authorization: Bearer <token>' http://localhost:8080/api/profile")
+	fmt.Println()
+	fmt.Println("  # Refresh tokens (will fail if revoked)")
+	fmt.Println("  curl -X POST http://localhost:8080/auth/refresh -d '{\"refresh_token\":\"<refresh_token>\"}'")
+	fmt.Println()
+	fmt.Println("  # Logout (revokes refresh token)")
+	fmt.Println("  curl -X POST http://localhost:8080/logout -d '{\"refresh_token\":\"<refresh_token>\"}'")
+	fmt.Println()
+	log.Fatal(app.Start())
+}
+
+// refreshLoginHandler authenticates users and returns JWT tokens
+func refreshLoginHandler(cfg config.JWTAuthConfig) zh.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		var req struct {
+			Username string `json:"username"`
+			Password string `json:"password"`
+		}
+
+		if err := zh.B.JSON(r.Body, &req); err != nil {
+			return zh.R.JSON(w, http.StatusBadRequest, zh.M{"error": "invalid request"})
+		}
+
+		// In production, verify against database
+		if req.Username != "alice" || req.Password != "secret" {
+			return zh.R.JSON(w, http.StatusUnauthorized, zh.M{"error": "invalid credentials"})
+		}
+
+		// Create claims with jti for revocation tracking
+		claims := middleware.HS256Claims{
+			"sub": req.Username,
+			"jti": fmt.Sprintf("%s-%d", req.Username, time.Now().Unix()),
+		}
+
+		// Generate tokens
+		accessToken, err := middleware.GenerateAccessToken(r, claims, cfg)
+		if err != nil {
+			return zh.R.JSON(w, http.StatusInternalServerError, zh.M{"error": "failed to generate token"})
+		}
+
+		refreshToken, err := middleware.GenerateRefreshToken(r, claims, cfg)
+		if err != nil {
+			return zh.R.JSON(w, http.StatusInternalServerError, zh.M{"error": "failed to generate token"})
+		}
+
+		return zh.R.JSON(w, http.StatusOK, zh.M{
+			"access_token":  accessToken,
+			"refresh_token": refreshToken,
+			"token_type":    "Bearer",
+			"expires_in":    int(cfg.AccessTokenTTL.Seconds()),
+		})
+	}
+}
+
+func refreshProfileHandler(w http.ResponseWriter, r *http.Request) error {
+	jwt := middleware.GetJWTClaims(r)
+
+	return zh.R.JSON(w, http.StatusOK, zh.M{
+		"subject": jwt.Subject(),
+		"scopes":  jwt.Scopes(),
+		"message": "This is your profile",
+	})
+}
+
+func refreshAdminHandler(w http.ResponseWriter, r *http.Request) error {
+	// Check for admin scope
+	if !middleware.GetJWTClaims(r).HasScope("admin") {
+		return zh.R.JSON(w, http.StatusForbidden, zh.M{"error": "admin scope required"})
+	}
+
+	return zh.R.JSON(w, http.StatusOK, zh.M{
+		"message": "Admin access granted",
+	})
+}

--- a/middleware/jwt_auth.go
+++ b/middleware/jwt_auth.go
@@ -1,0 +1,744 @@
+// Package middleware provides HTTP middleware for zerohttp.
+//
+// # JWT Authentication Middleware
+//
+// The JWTAuth middleware provides pluggable JWT authentication. Users bring their own
+// JWT library by implementing the TokenStore interface.
+//
+// Basic usage:
+//
+//	app.Use(middleware.JWTAuth(config.JWTAuthConfig{
+//	    TokenStore: myTokenStore,
+//	    RequiredClaims: []string{"sub"},
+//	}))
+//
+// The middleware supports:
+//   - Custom token extraction (Bearer header, cookies, custom headers)
+//   - Required claims validation
+//   - Exempt paths and methods
+//   - Custom error handling
+//   - Token refresh handling
+//
+// For a zero-dependency option, use the built-in HS256 implementation:
+//
+//	cfg := config.JWTAuthConfig{
+//	    TokenStore: middleware.NewHS256TokenStore(secret, opts),
+//	}
+//
+// Security Note: The built-in HS256 implementation uses HMAC-SHA256 symmetric signing.
+// For production systems requiring asymmetric keys (RS256, ES256, EdDSA), use a
+// proper JWT library like golang-jwt/jwt or lestrrat-go/jwx.
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/alexferl/zerohttp/config"
+)
+
+// JWTAuthContextKey is the context key type for JWT auth
+type JWTAuthContextKey string
+
+const (
+	// JWTClaimsContextKey holds the validated JWT claims
+	JWTClaimsContextKey JWTAuthContextKey = "jwt_claims"
+	// JWTErrorContextKey holds the JWT validation error
+	JWTErrorContextKey JWTAuthContextKey = "jwt_error"
+	// JWTTokenContextKey holds the raw token string
+	JWTTokenContextKey JWTAuthContextKey = "jwt_token"
+)
+
+// JWTAuthError represents a JWT authentication error with RFC 9457 Problem Details
+type JWTAuthError struct {
+	Type   string `json:"type"`
+	Title  string `json:"title"`
+	Status int    `json:"status"`
+	Detail string `json:"detail"`
+}
+
+// Error implements the error interface
+func (e *JWTAuthError) Error() string {
+	return e.Detail
+}
+
+// Common JWT auth errors
+var (
+	errMissingToken = &JWTAuthError{
+		Type:   "urn:ietf:rfc:9457:jwt-auth:missing-token",
+		Title:  "Missing Authorization Token",
+		Status: http.StatusUnauthorized,
+		Detail: "Request is missing the Authorization header with Bearer token",
+	}
+	errInvalidToken = &JWTAuthError{
+		Type:   "urn:ietf:rfc:9457:jwt-auth:invalid-token",
+		Title:  "Invalid Token",
+		Status: http.StatusUnauthorized,
+		Detail: "The provided token is invalid or has expired",
+	}
+	errMissingRequiredClaim = &JWTAuthError{
+		Type:   "urn:ietf:rfc:9457:jwt-auth:missing-claim",
+		Title:  "Missing Required Claim",
+		Status: http.StatusForbidden,
+		Detail: "Token is missing a required claim",
+	}
+	errTokenGeneratorNotConfigured = &JWTAuthError{
+		Type:   "urn:ietf:rfc:9457:jwt-auth:generator-not-configured",
+		Title:  "Token Generator Not Configured",
+		Status: http.StatusInternalServerError,
+		Detail: "Token generation is not configured",
+	}
+)
+
+// JWTAuth creates JWT authentication middleware
+func JWTAuth(cfg ...config.JWTAuthConfig) func(http.Handler) http.Handler {
+	c := config.DefaultJWTAuthConfig
+	if len(cfg) > 0 {
+		c = cfg[0]
+	}
+
+	if c.TokenExtractor == nil {
+		c.TokenExtractor = extractBearerToken
+	}
+	if c.ExemptPaths == nil {
+		c.ExemptPaths = config.DefaultJWTAuthConfig.ExemptPaths
+	}
+	if c.ExemptMethods == nil {
+		c.ExemptMethods = config.DefaultJWTAuthConfig.ExemptMethods
+	}
+	if c.RequiredClaims == nil {
+		c.RequiredClaims = config.DefaultJWTAuthConfig.RequiredClaims
+	}
+	if c.AccessTokenTTL == 0 {
+		c.AccessTokenTTL = config.DefaultJWTAuthConfig.AccessTokenTTL
+	}
+	if c.RefreshTokenTTL == 0 {
+		c.RefreshTokenTTL = config.DefaultJWTAuthConfig.RefreshTokenTTL
+	}
+
+	errorHandler := c.ErrorHandler
+	if errorHandler == nil {
+		errorHandler = defaultJWTErrorHandler
+	}
+
+	onSuccess := c.OnSuccess
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Skip OPTIONS requests (CORS preflight)
+			if r.Method == http.MethodOptions {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if slices.Contains(c.ExemptMethods, r.Method) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			for _, exemptPath := range c.ExemptPaths {
+				if pathMatches(r.URL.Path, exemptPath) {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+
+			if c.TokenStore == nil {
+				handleJWTError(w, r, errInvalidToken, errorHandler)
+				return
+			}
+
+			tokenString := c.TokenExtractor(r)
+			if tokenString == "" {
+				handleJWTError(w, r, errMissingToken, errorHandler)
+				return
+			}
+
+			claims, err := c.TokenStore.Validate(tokenString)
+			if err != nil {
+				handleJWTError(w, r, errInvalidToken, errorHandler)
+				return
+			}
+
+			// Check if token is revoked
+			if c.TokenStore.IsRevoked(claims) {
+				handleJWTError(w, r, &JWTAuthError{
+					Type:   "urn:ietf:rfc:9457:jwt-auth:token-revoked",
+					Title:  "Token Revoked",
+					Status: http.StatusUnauthorized,
+					Detail: "token has been revoked",
+				}, errorHandler)
+				return
+			}
+
+			// Prevent refresh tokens from being used as access tokens
+			if tokenType := getStringClaim(claims, config.JWTClaimType); tokenType == config.TokenTypeRefresh {
+				handleJWTError(w, r, &JWTAuthError{
+					Type:   "urn:ietf:rfc:9457:jwt-auth:invalid-token-type",
+					Title:  "Invalid Token Type",
+					Status: http.StatusUnauthorized,
+					Detail: "refresh token cannot be used for authentication",
+				}, errorHandler)
+				return
+			}
+
+			for _, claim := range c.RequiredClaims {
+				if !hasClaim(claims, claim) {
+					handleJWTError(w, r, &JWTAuthError{
+						Type:   errMissingRequiredClaim.Type,
+						Title:  errMissingRequiredClaim.Title,
+						Status: errMissingRequiredClaim.Status,
+						Detail: "Token is missing required claim: " + claim,
+					}, errorHandler)
+					return
+				}
+			}
+
+			if onSuccess != nil {
+				onSuccess(r, claims)
+			}
+
+			ctx := r.Context()
+			ctx = context.WithValue(ctx, JWTClaimsContextKey, claims)
+			ctx = context.WithValue(ctx, JWTTokenContextKey, tokenString)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// GetJWTToken retrieves the raw JWT token string from the request context.
+func GetJWTToken(r *http.Request) string {
+	if token, ok := r.Context().Value(JWTTokenContextKey).(string); ok {
+		return token
+	}
+	return ""
+}
+
+// GetJWTError retrieves the JWT authentication error from the request context.
+func GetJWTError(r *http.Request) *JWTAuthError {
+	if err, ok := r.Context().Value(JWTErrorContextKey).(error); ok {
+		var jwtErr *JWTAuthError
+		if errors.As(err, &jwtErr) {
+			return jwtErr
+		}
+	}
+	return nil
+}
+
+// JWTClaims wraps JWTClaims to provide convenient accessor methods.
+// Use GetJWTClaims(r) to get claims from a request.
+//
+// Example:
+//
+//	jwt := middleware.GetJWTClaims(r)
+//	subject := jwt.Subject()
+//	scopes := jwt.Scopes()
+type JWTClaims struct {
+	claims config.JWTClaims
+}
+
+// GetJWTClaims retrieves JWT claims from the request and returns a JWTClaims wrapper.
+// This is the primary way to access JWT claims in handlers.
+//
+// Example:
+//
+//	jwt := middleware.GetJWTClaims(r)
+//	subject := jwt.Subject()
+//	if jwt.HasScope("admin") { ... }
+func GetJWTClaims(r *http.Request) JWTClaims {
+	if claims, ok := r.Context().Value(JWTClaimsContextKey).(config.JWTClaims); ok {
+		return JWTClaims{claims: claims}
+	}
+	return JWTClaims{}
+}
+
+// Subject returns the 'sub' claim.
+func (j JWTClaims) Subject() string {
+	return getStringClaim(j.claims, config.JWTClaimSubject)
+}
+
+// Issuer returns the 'iss' claim.
+func (j JWTClaims) Issuer() string {
+	return getStringClaim(j.claims, config.JWTClaimIssuer)
+}
+
+// Audience returns the 'aud' claim.
+func (j JWTClaims) Audience() string {
+	return getStringClaim(j.claims, config.JWTClaimAudience)
+}
+
+// JTI returns the 'jti' claim (JWT ID).
+func (j JWTClaims) JTI() string {
+	return getStringClaim(j.claims, config.JWTClaimJWTID)
+}
+
+// Expiration returns the 'exp' claim as time.Time.
+func (j JWTClaims) Expiration() time.Time {
+	if j.claims == nil {
+		return time.Time{}
+	}
+
+	extractExp := func(m map[string]any) time.Time {
+		if exp, ok := m[config.JWTClaimExpiration]; ok {
+			switch v := exp.(type) {
+			case float64:
+				return time.Unix(int64(v), 0)
+			case int64:
+				return time.Unix(v, 0)
+			}
+		}
+		return time.Time{}
+	}
+
+	switch c := j.claims.(type) {
+	case map[string]any:
+		return extractExp(c)
+	case HS256Claims:
+		return extractExp(c)
+	}
+	return time.Time{}
+}
+
+// Scopes returns the 'scope' claim as a string slice.
+func (j JWTClaims) Scopes() []string {
+	if j.claims == nil {
+		return nil
+	}
+
+	extractScopes := func(m map[string]any) []string {
+		if scope, ok := m[config.JWTClaimScope]; ok {
+			switch v := scope.(type) {
+			case string:
+				return strings.Fields(v)
+			case []string:
+				return v
+			case []any:
+				scopes := make([]string, 0, len(v))
+				for _, s := range v {
+					if str, ok := s.(string); ok {
+						scopes = append(scopes, str)
+					}
+				}
+				return scopes
+			}
+		}
+		return nil
+	}
+
+	switch c := j.claims.(type) {
+	case map[string]any:
+		return extractScopes(c)
+	case HS256Claims:
+		return extractScopes(c)
+	}
+	return nil
+}
+
+// HasScope checks if the token has a specific scope.
+func (j JWTClaims) HasScope(scope string) bool {
+	return slices.Contains(j.Scopes(), scope)
+}
+
+// Raw returns the underlying claims.
+// Use this for type assertion with third-party JWT libraries.
+//
+// Example with lestrrat-go/jwx:
+//
+//	token := middleware.GetJWTClaims(r).Raw().(jwt.Token)
+//	subject := token.Subject()
+func (j JWTClaims) Raw() config.JWTClaims {
+	return j.claims
+}
+
+// GenerateAccessToken generates a new access token for the given claims.
+// Automatically sets 'exp' claim based on AccessTokenTTL.
+// Requires TokenStore to be configured.
+func GenerateAccessToken(r *http.Request, claims config.JWTClaims, cfg config.JWTAuthConfig) (string, error) {
+	if cfg.TokenStore == nil {
+		return "", errTokenGeneratorNotConfigured
+	}
+
+	ttl := cfg.AccessTokenTTL
+	if ttl == 0 {
+		ttl = config.DefaultJWTAuthConfig.AccessTokenTTL
+	}
+
+	claims = addExpirationToClaims(claims, ttl)
+
+	return cfg.TokenStore.Generate(claims, config.AccessToken)
+}
+
+// GenerateRefreshToken generates a new refresh token for the given claims.
+// Automatically sets 'exp' claim based on RefreshTokenTTL and 'type': 'refresh'.
+// Requires TokenStore to be configured.
+func GenerateRefreshToken(r *http.Request, claims config.JWTClaims, cfg config.JWTAuthConfig) (string, error) {
+	if cfg.TokenStore == nil {
+		return "", errTokenGeneratorNotConfigured
+	}
+
+	ttl := cfg.RefreshTokenTTL
+	if ttl == 0 {
+		ttl = config.DefaultJWTAuthConfig.RefreshTokenTTL
+	}
+
+	// Add expiration and type if claims is a map
+	claims = addExpirationToClaims(claims, ttl)
+	claims = addTypeToClaims(claims, config.TokenTypeRefresh)
+
+	return cfg.TokenStore.Generate(claims, config.RefreshToken)
+}
+
+// writeJWTError writes a JWTAuthError response
+func writeJWTError(w http.ResponseWriter, jwtErr *JWTAuthError) {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(jwtErr.Status)
+	_ = json.NewEncoder(w).Encode(jwtErr)
+}
+
+// tokenHandlerRequest parses and validates the refresh token from the request body.
+// Returns the claims if validation succeeds, or an error response if it fails.
+func tokenHandlerRequest(w http.ResponseWriter, r *http.Request, cfg config.JWTAuthConfig) (config.JWTClaims, bool) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return nil, false
+	}
+
+	if cfg.TokenStore == nil {
+		writeJWTError(w, errInvalidToken)
+		return nil, false
+	}
+
+	var req struct {
+		RefreshToken string `json:"refresh_token"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJWTError(w, &JWTAuthError{
+			Type:   "urn:ietf:rfc:9457:jwt-auth:invalid-request",
+			Title:  "Invalid Request",
+			Status: http.StatusBadRequest,
+			Detail: "Request body must contain refresh_token",
+		})
+		return nil, false
+	}
+
+	if req.RefreshToken == "" {
+		writeJWTError(w, &JWTAuthError{
+			Type:   "urn:ietf:rfc:9457:jwt-auth:missing-refresh-token",
+			Title:  "Missing Refresh Token",
+			Status: http.StatusUnprocessableEntity,
+			Detail: "refresh_token is required",
+		})
+		return nil, false
+	}
+
+	claims, err := cfg.TokenStore.Validate(req.RefreshToken)
+	if err != nil {
+		writeJWTError(w, errInvalidToken)
+		return nil, false
+	}
+
+	if tokenType := getStringClaim(claims, config.JWTClaimType); tokenType != config.TokenTypeRefresh {
+		writeJWTError(w, &JWTAuthError{
+			Type:   "urn:ietf:rfc:9457:jwt-auth:invalid-token-type",
+			Title:  "Invalid Token Type",
+			Status: http.StatusUnprocessableEntity,
+			Detail: "Provided token is not a refresh token",
+		})
+		return nil, false
+	}
+
+	if cfg.TokenStore.IsRevoked(claims) {
+		writeJWTError(w, &JWTAuthError{
+			Type:   "urn:ietf:rfc:9457:jwt-auth:token-revoked",
+			Title:  "Token Revoked",
+			Status: http.StatusUnauthorized,
+			Detail: "token has been revoked",
+		})
+		return nil, false
+	}
+
+	if err := cfg.TokenStore.Revoke(claims); err != nil {
+		writeJWTError(w, &JWTAuthError{
+			Type:   "urn:ietf:rfc:9457:jwt-auth:revocation-failed",
+			Title:  "Token Revocation Failed",
+			Status: http.StatusInternalServerError,
+			Detail: err.Error(),
+		})
+		return nil, false
+	}
+
+	return claims, true
+}
+
+// RefreshTokenHandler returns an http.HandlerFunc that handles token refresh.
+// Accepts: { "refresh_token": "..." }
+// Returns: { "access_token": "...", "refresh_token": "...", "token_type": "Bearer", "expires_in": 900 }
+// Users mount this at their chosen path: app.Post("/auth/refresh", middleware.RefreshTokenHandler(cfg))
+func RefreshTokenHandler(cfg config.JWTAuthConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		claims, ok := tokenHandlerRequest(w, r, cfg)
+		if !ok {
+			return
+		}
+
+		accessToken, err := GenerateAccessToken(r, claims, cfg)
+		if err != nil {
+			writeJWTError(w, errTokenGeneratorNotConfigured)
+			return
+		}
+
+		refreshToken, err := GenerateRefreshToken(r, claims, cfg)
+		if err != nil {
+			writeJWTError(w, errTokenGeneratorNotConfigured)
+			return
+		}
+
+		expiresIn := cfg.AccessTokenTTL
+		if expiresIn == 0 {
+			expiresIn = config.DefaultJWTAuthConfig.AccessTokenTTL
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  accessToken,
+			"refresh_token": refreshToken,
+			"token_type":    "Bearer",
+			"expires_in":    int(expiresIn.Seconds()),
+		})
+	}
+}
+
+// LogoutTokenHandler returns an http.HandlerFunc that handles token revocation (logout).
+// Accepts: { "refresh_token": "..." }
+// Returns: { "message": "logged out successfully" }
+// Users mount this at their chosen path: app.Post("/auth/logout", middleware.LogoutTokenHandler(cfg))
+// Requires TokenStore to be configured in JWTAuthConfig.
+func LogoutTokenHandler(cfg config.JWTAuthConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, ok := tokenHandlerRequest(w, r, cfg)
+		if !ok {
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"message": "logged out successfully",
+		})
+	}
+}
+
+// extractBearerToken extracts the JWT token from the Authorization header
+func extractBearerToken(r *http.Request) string {
+	auth := r.Header.Get("Authorization")
+	if auth == "" {
+		return ""
+	}
+
+	const prefix = "Bearer "
+	if !strings.HasPrefix(auth, prefix) {
+		return ""
+	}
+
+	return strings.TrimSpace(auth[len(prefix):])
+}
+
+// handleJWTError sends an error response
+func handleJWTError(w http.ResponseWriter, r *http.Request, jwtErr *JWTAuthError, handler http.HandlerFunc) {
+	// Add error to context so custom handlers can access it
+	ctx := context.WithValue(r.Context(), JWTErrorContextKey, jwtErr)
+	r = r.WithContext(ctx)
+
+	if handler != nil {
+		handler(w, r)
+		return
+	}
+	defaultJWTErrorHandler(w, r)
+}
+
+// defaultJWTErrorHandler is the default error handler
+func defaultJWTErrorHandler(w http.ResponseWriter, r *http.Request) {
+	jwtErr := GetJWTError(r)
+	if jwtErr == nil {
+		jwtErr = errInvalidToken
+	}
+
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(jwtErr.Status)
+
+	response := fmt.Sprintf(`{"type":"%s","title":"%s","status":%d,"detail":"%s"}`,
+		jwtErr.Type, jwtErr.Title, jwtErr.Status, jwtErr.Detail)
+	_, _ = w.Write([]byte(response))
+}
+
+// hasClaim checks if a claim exists in the claims
+func hasClaim(claims config.JWTClaims, key string) bool {
+	switch c := claims.(type) {
+	case map[string]any:
+		_, ok := c[key]
+		return ok
+	case HS256Claims:
+		_, ok := c[key]
+		return ok
+	default:
+		// Handle other map types (e.g., jwt.MapClaims from golang-jwt)
+		return getMapClaim(c, key) != nil
+	}
+}
+
+// getStringClaim extracts a string claim from claims
+func getStringClaim(claims config.JWTClaims, key string) string {
+	extractFromMap := func(m map[string]any) string {
+		if v, ok := m[key]; ok {
+			switch s := v.(type) {
+			case string:
+				return s
+			case []string:
+				if len(s) > 0 {
+					return s[0]
+				}
+			case []any:
+				if len(s) > 0 {
+					if str, ok := s[0].(string); ok {
+						return str
+					}
+				}
+			}
+		}
+		return ""
+	}
+
+	switch c := claims.(type) {
+	case map[string]any:
+		return extractFromMap(c)
+	case HS256Claims:
+		return extractFromMap(c)
+	default:
+		// Handle other map types (e.g., jwt.MapClaims from golang-jwt)
+		if v := getMapClaim(claims, key); v != nil {
+			return extractStringValue(v)
+		}
+	}
+	return ""
+}
+
+// getMapClaim extracts a value from any map-like type using reflection
+func getMapClaim(claims config.JWTClaims, key string) any {
+	if claims == nil {
+		return nil
+	}
+	switch m := claims.(type) {
+	case map[string]any:
+		return m[key]
+	default:
+		v := reflect.ValueOf(claims)
+		if v.Kind() == reflect.Map && v.Type().Key().Kind() == reflect.String {
+			val := v.MapIndex(reflect.ValueOf(key))
+			if val.IsValid() {
+				return val.Interface()
+			}
+		}
+		return nil
+	}
+}
+
+// extractStringValue converts a value to string
+func extractStringValue(v any) string {
+	if v == nil {
+		return ""
+	}
+	switch s := v.(type) {
+	case string:
+		return s
+	case []string:
+		if len(s) > 0 {
+			return s[0]
+		}
+	case []any:
+		if len(s) > 0 {
+			if str, ok := s[0].(string); ok {
+				return str
+			}
+		}
+	}
+	return ""
+}
+
+// deepCopyMap creates a deep copy of a map[string]any
+func deepCopyMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	newMap := make(map[string]any, len(m))
+	for k, v := range m {
+		switch val := v.(type) {
+		case map[string]any:
+			newMap[k] = deepCopyMap(val)
+		case []any:
+			newMap[k] = deepCopySlice(val)
+		default:
+			newMap[k] = v
+		}
+	}
+	return newMap
+}
+
+// deepCopySlice creates a deep copy of a []any
+func deepCopySlice(s []any) []any {
+	if s == nil {
+		return nil
+	}
+	newSlice := make([]any, len(s))
+	for i, v := range s {
+		switch val := v.(type) {
+		case map[string]any:
+			newSlice[i] = deepCopyMap(val)
+		case []any:
+			newSlice[i] = deepCopySlice(val)
+		default:
+			newSlice[i] = v
+		}
+	}
+	return newSlice
+}
+
+// addExpirationToClaims adds exp claim to map claims
+func addExpirationToClaims(claims config.JWTClaims, ttl time.Duration) config.JWTClaims {
+	switch c := claims.(type) {
+	case map[string]any:
+		newClaims := deepCopyMap(c)
+		newClaims[config.JWTClaimExpiration] = time.Now().Add(ttl).Unix()
+		return newClaims
+	case HS256Claims:
+		newClaims := deepCopyMap(c)
+		newClaims[config.JWTClaimExpiration] = time.Now().Add(ttl).Unix()
+		return HS256Claims(newClaims)
+	default:
+		return claims
+	}
+}
+
+// addTypeToClaims adds type claim to map claims
+func addTypeToClaims(claims config.JWTClaims, tokenType string) config.JWTClaims {
+	switch c := claims.(type) {
+	case map[string]any:
+		newClaims := deepCopyMap(c)
+		newClaims[config.JWTClaimType] = tokenType
+		return newClaims
+	case HS256Claims:
+		newClaims := deepCopyMap(c)
+		newClaims[config.JWTClaimType] = tokenType
+		return HS256Claims(newClaims)
+	default:
+		return claims
+	}
+}

--- a/middleware/jwt_auth.go
+++ b/middleware/jwt_auth.go
@@ -269,9 +269,45 @@ func (j JWTClaims) Issuer() string {
 	return getStringClaim(j.claims, config.JWTClaimIssuer)
 }
 
-// Audience returns the 'aud' claim.
-func (j JWTClaims) Audience() string {
-	return getStringClaim(j.claims, config.JWTClaimAudience)
+// Audience returns the 'aud' claim as a string slice.
+// Returns all audiences if 'aud' is an array, or a single-element slice if it's a string.
+func (j JWTClaims) Audience() []string {
+	if j.claims == nil {
+		return nil
+	}
+
+	extractAud := func(m map[string]any) []string {
+		if aud, ok := m[config.JWTClaimAudience]; ok {
+			switch v := aud.(type) {
+			case string:
+				return []string{v}
+			case []string:
+				return v
+			case []any:
+				audiences := make([]string, 0, len(v))
+				for _, a := range v {
+					if s, ok := a.(string); ok {
+						audiences = append(audiences, s)
+					}
+				}
+				return audiences
+			}
+		}
+		return nil
+	}
+
+	switch c := j.claims.(type) {
+	case map[string]any:
+		return extractAud(c)
+	case HS256Claims:
+		return extractAud(c)
+	}
+	return nil
+}
+
+// HasAudience checks if the token has a specific audience.
+func (j JWTClaims) HasAudience(audience string) bool {
+	return slices.Contains(j.Audience(), audience)
 }
 
 // JTI returns the 'jti' claim (JWT ID).

--- a/middleware/jwt_auth_test.go
+++ b/middleware/jwt_auth_test.go
@@ -13,6 +13,19 @@ import (
 	"github.com/alexferl/zerohttp/config"
 )
 
+// slicesEqual compares two string slices for equality
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // mockTokenStore is a test implementation of config.TokenStore
 type mockTokenStore struct {
 	validateFunc func(token string) (config.JWTClaims, error)
@@ -452,32 +465,37 @@ func TestGetJWTClaimsAudience(t *testing.T) {
 	tests := []struct {
 		name     string
 		claims   config.JWTClaims
-		expected string
+		expected []string
 	}{
 		{
 			name:     "has audience string",
 			claims:   map[string]any{"aud": "my-audience"},
-			expected: "my-audience",
+			expected: []string{"my-audience"},
 		},
 		{
 			name:     "has audience array",
 			claims:   map[string]any{"aud": []string{"aud1", "aud2"}},
-			expected: "aud1",
+			expected: []string{"aud1", "aud2"},
+		},
+		{
+			name:     "has audience any array",
+			claims:   map[string]any{"aud": []any{"aud1", "aud2"}},
+			expected: []string{"aud1", "aud2"},
 		},
 		{
 			name:     "missing audience",
 			claims:   map[string]any{},
-			expected: "",
+			expected: nil,
 		},
 		{
 			name:     "nil claims",
 			claims:   nil,
-			expected: "",
+			expected: nil,
 		},
 		{
 			name:     "non-map claims",
 			claims:   "not-a-map",
-			expected: "",
+			expected: nil,
 		},
 	}
 
@@ -486,8 +504,8 @@ func TestGetJWTClaimsAudience(t *testing.T) {
 			ctx := context.WithValue(context.Background(), JWTClaimsContextKey, tt.claims)
 			req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
 			got := GetJWTClaims(req).Audience()
-			if got != tt.expected {
-				t.Errorf("GetJWTClaimsAudience() = %q, want %q", got, tt.expected)
+			if !slicesEqual(got, tt.expected) {
+				t.Errorf("GetJWTClaimsAudience() = %v, want %v", got, tt.expected)
 			}
 		})
 	}
@@ -1500,8 +1518,32 @@ func TestClaimsWrapper_Audience(t *testing.T) {
 	claims := map[string]any{"aud": "my-audience"}
 	jwt := JWTClaims{claims: claims}
 
-	if got := jwt.Audience(); got != "my-audience" {
-		t.Errorf("Audience() = %q, want 'my-audience'", got)
+	if got := jwt.Audience(); !slicesEqual(got, []string{"my-audience"}) {
+		t.Errorf("Audience() = %v, want ['my-audience']", got)
+	}
+}
+
+func TestClaimsWrapper_Audience_Array(t *testing.T) {
+	claims := map[string]any{"aud": []string{"aud1", "aud2"}}
+	jwt := JWTClaims{claims: claims}
+
+	if got := jwt.Audience(); !slicesEqual(got, []string{"aud1", "aud2"}) {
+		t.Errorf("Audience() = %v, want ['aud1', 'aud2']", got)
+	}
+}
+
+func TestClaimsWrapper_HasAudience(t *testing.T) {
+	claims := map[string]any{"aud": []string{"aud1", "aud2"}}
+	jwt := JWTClaims{claims: claims}
+
+	if !jwt.HasAudience("aud1") {
+		t.Error("HasAudience('aud1') = false, want true")
+	}
+	if !jwt.HasAudience("aud2") {
+		t.Error("HasAudience('aud2') = false, want true")
+	}
+	if jwt.HasAudience("aud3") {
+		t.Error("HasAudience('aud3') = true, want false")
 	}
 }
 

--- a/middleware/jwt_auth_test.go
+++ b/middleware/jwt_auth_test.go
@@ -1,0 +1,1926 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alexferl/zerohttp/config"
+)
+
+// mockTokenStore is a test implementation of config.TokenStore
+type mockTokenStore struct {
+	validateFunc func(token string) (config.JWTClaims, error)
+	generateFunc func(claims config.JWTClaims, tokenType config.TokenType) (string, error)
+	revokeFunc   func(claims config.JWTClaims) error
+	isRevoked    bool
+}
+
+func (m *mockTokenStore) Validate(token string) (config.JWTClaims, error) {
+	if m.validateFunc != nil {
+		return m.validateFunc(token)
+	}
+	return nil, errors.New("validator not configured")
+}
+
+func (m *mockTokenStore) Generate(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+	if m.generateFunc != nil {
+		return m.generateFunc(claims, tokenType)
+	}
+	return "", errors.New("generator not configured")
+}
+
+func (m *mockTokenStore) Revoke(claims config.JWTClaims) error {
+	if m.revokeFunc != nil {
+		return m.revokeFunc(claims)
+	}
+	return nil
+}
+
+func (m *mockTokenStore) IsRevoked(claims config.JWTClaims) bool {
+	return m.isRevoked
+}
+
+func TestJWTAuth_MissingToken(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(token string) (config.JWTClaims, error) {
+			return map[string]any{"sub": "user123"}, nil
+		},
+	}
+
+	middleware := JWTAuth(config.JWTAuthConfig{
+		TokenStore: store,
+	})
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/protected", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d, got %d", http.StatusUnauthorized, rr.Code)
+	}
+
+	var errResp JWTAuthError
+	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("failed to unmarshal error response: %v", err)
+	}
+
+	if errResp.Type != "urn:ietf:rfc:9457:jwt-auth:missing-token" {
+		t.Errorf("expected error type 'urn:ietf:rfc:9457:jwt-auth:missing-token', got %s", errResp.Type)
+	}
+}
+
+func TestJWTAuth_InvalidToken(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(token string) (config.JWTClaims, error) {
+			return nil, errors.New("invalid token")
+		},
+	}
+
+	middleware := JWTAuth(config.JWTAuthConfig{
+		TokenStore: store,
+	})
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/protected", nil)
+	req.Header.Set("Authorization", "Bearer invalid-token")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d, got %d", http.StatusUnauthorized, rr.Code)
+	}
+
+	var errResp JWTAuthError
+	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("failed to unmarshal error response: %v", err)
+	}
+
+	if errResp.Type != "urn:ietf:rfc:9457:jwt-auth:invalid-token" {
+		t.Errorf("expected error type 'urn:ietf:rfc:9457:jwt-auth:invalid-token', got %s", errResp.Type)
+	}
+}
+
+func TestJWTAuth_Success(t *testing.T) {
+	expectedClaims := map[string]any{
+		"sub":   "user123",
+		"scope": "read write",
+	}
+
+	store := &mockTokenStore{
+		validateFunc: func(token string) (config.JWTClaims, error) {
+			return expectedClaims, nil
+		},
+	}
+
+	middleware := JWTAuth(config.JWTAuthConfig{
+		TokenStore: store,
+	})
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		jwt := GetJWTClaims(r)
+		if jwt.Raw() == nil {
+			t.Error("expected claims in context")
+		}
+
+		token := GetJWTToken(r)
+		if token != "valid-token" {
+			t.Errorf("expected token 'valid-token', got %q", token)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("success"))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/protected", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rr.Code)
+	}
+	if strings.TrimSpace(rr.Body.String()) != "success" {
+		t.Errorf("expected body 'success', got %q", rr.Body.String())
+	}
+}
+
+func TestJWTAuth_ExemptPath(t *testing.T) {
+	middleware := JWTAuth(config.JWTAuthConfig{
+		ExemptPaths: []string{"/health"},
+	})
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	tests := []struct {
+		path       string
+		wantStatus int
+	}{
+		{"/health", http.StatusOK},
+		{"/api/protected", http.StatusUnauthorized},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			if rr.Code != tt.wantStatus {
+				t.Errorf("expected status %d for path %s, got %d", tt.wantStatus, tt.path, rr.Code)
+			}
+		})
+	}
+}
+
+func TestJWTAuth_ExemptMethod(t *testing.T) {
+	middleware := JWTAuth(config.JWTAuthConfig{
+		ExemptMethods: []string{http.MethodHead},
+	})
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	tests := []struct {
+		method     string
+		wantStatus int
+	}{
+		{http.MethodHead, http.StatusOK},
+		{http.MethodOptions, http.StatusOK},
+		{http.MethodGet, http.StatusUnauthorized},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, "/api/protected", nil)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			if rr.Code != tt.wantStatus {
+				t.Errorf("expected status %d for method %s, got %d", tt.wantStatus, tt.method, rr.Code)
+			}
+		})
+	}
+}
+
+func TestJWTAuth_RequiredClaims(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(token string) (config.JWTClaims, error) {
+			return map[string]any{
+				"sub": "user123",
+			}, nil
+		},
+	}
+
+	middleware := JWTAuth(config.JWTAuthConfig{
+		TokenStore:     store,
+		RequiredClaims: []string{"sub", "iss"},
+	})
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/protected", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("expected status %d, got %d", http.StatusForbidden, rr.Code)
+	}
+
+	var errResp JWTAuthError
+	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("failed to unmarshal error response: %v", err)
+	}
+
+	if errResp.Type != "urn:ietf:rfc:9457:jwt-auth:missing-claim" {
+		t.Errorf("expected error type 'urn:ietf:rfc:9457:jwt-auth:missing-claim', got %s", errResp.Type)
+	}
+}
+
+func TestJWTAuth_CustomErrorHandler(t *testing.T) {
+	customHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = w.Write([]byte(`{"error":"custom error"}`))
+	}
+
+	middleware := JWTAuth(config.JWTAuthConfig{
+		ErrorHandler: customHandler,
+	})
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/protected", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusTeapot {
+		t.Errorf("expected status %d, got %d", http.StatusTeapot, rr.Code)
+	}
+}
+
+func TestJWTAuth_OnSuccess(t *testing.T) {
+	successCalled := false
+	var receivedClaims config.JWTClaims
+
+	store := &mockTokenStore{
+		validateFunc: func(token string) (config.JWTClaims, error) {
+			return map[string]any{"sub": "user123"}, nil
+		},
+	}
+
+	middleware := JWTAuth(config.JWTAuthConfig{
+		TokenStore: store,
+		OnSuccess: func(r *http.Request, claims config.JWTClaims) {
+			successCalled = true
+			receivedClaims = claims
+		},
+	})
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/protected", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if !successCalled {
+		t.Error("OnSuccess should have been called")
+	}
+	if receivedClaims == nil {
+		t.Error("claims should have been passed to OnSuccess")
+	}
+}
+
+func TestGetJWTClaims_NotSet(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	jwt := GetJWTClaims(req)
+	if jwt.Raw() != nil {
+		t.Error("expected nil claims")
+	}
+}
+
+func TestGetJWTToken(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := GetJWTToken(r)
+		if token != "my-token" {
+			t.Errorf("expected token 'my-token', got %q", token)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ctx := context.WithValue(context.Background(), JWTTokenContextKey, "my-token")
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+}
+
+func TestGetJWTError(t *testing.T) {
+	err := &JWTAuthError{
+		Type:   "test-error",
+		Title:  "Test Error",
+		Status: http.StatusUnauthorized,
+		Detail: "test detail",
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := GetJWTError(r)
+		if got != err {
+			t.Error("expected error in context")
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ctx := context.WithValue(context.Background(), JWTErrorContextKey, err)
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+}
+
+func TestGetJWTClaimsSubject(t *testing.T) {
+	tests := []struct {
+		name     string
+		claims   config.JWTClaims
+		expected string
+	}{
+		{
+			name:     "has subject",
+			claims:   map[string]any{"sub": "user123"},
+			expected: "user123",
+		},
+		{
+			name:     "missing subject",
+			claims:   map[string]any{},
+			expected: "",
+		},
+		{
+			name:     "nil claims",
+			claims:   nil,
+			expected: "",
+		},
+		{
+			name:     "non-map claims",
+			claims:   "not-a-map",
+			expected: "",
+		},
+		{
+			name:     "HS256Claims type",
+			claims:   HS256Claims{"sub": "user123"},
+			expected: "user123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.WithValue(context.Background(), JWTClaimsContextKey, tt.claims)
+			req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+			got := GetJWTClaims(req).Subject()
+			if got != tt.expected {
+				t.Errorf("GetJWTClaimsSubject() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetJWTClaimsIssuer(t *testing.T) {
+	tests := []struct {
+		name     string
+		claims   config.JWTClaims
+		expected string
+	}{
+		{
+			name:     "has issuer",
+			claims:   map[string]any{"iss": "my-issuer"},
+			expected: "my-issuer",
+		},
+		{
+			name:     "missing issuer",
+			claims:   map[string]any{},
+			expected: "",
+		},
+		{
+			name:     "nil claims",
+			claims:   nil,
+			expected: "",
+		},
+		{
+			name:     "non-map claims",
+			claims:   "not-a-map",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.WithValue(context.Background(), JWTClaimsContextKey, tt.claims)
+			req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+			got := GetJWTClaims(req).Issuer()
+			if got != tt.expected {
+				t.Errorf("GetJWTClaimsIssuer() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetJWTClaimsAudience(t *testing.T) {
+	tests := []struct {
+		name     string
+		claims   config.JWTClaims
+		expected string
+	}{
+		{
+			name:     "has audience string",
+			claims:   map[string]any{"aud": "my-audience"},
+			expected: "my-audience",
+		},
+		{
+			name:     "has audience array",
+			claims:   map[string]any{"aud": []string{"aud1", "aud2"}},
+			expected: "aud1",
+		},
+		{
+			name:     "missing audience",
+			claims:   map[string]any{},
+			expected: "",
+		},
+		{
+			name:     "nil claims",
+			claims:   nil,
+			expected: "",
+		},
+		{
+			name:     "non-map claims",
+			claims:   "not-a-map",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.WithValue(context.Background(), JWTClaimsContextKey, tt.claims)
+			req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+			got := GetJWTClaims(req).Audience()
+			if got != tt.expected {
+				t.Errorf("GetJWTClaimsAudience() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetJWTClaimsJTI(t *testing.T) {
+	tests := []struct {
+		name     string
+		claims   config.JWTClaims
+		expected string
+	}{
+		{
+			name:     "has jti",
+			claims:   map[string]any{"jti": "token-id-123"},
+			expected: "token-id-123",
+		},
+		{
+			name:     "missing jti",
+			claims:   map[string]any{},
+			expected: "",
+		},
+		{
+			name:     "nil claims",
+			claims:   nil,
+			expected: "",
+		},
+		{
+			name:     "non-map claims",
+			claims:   "not-a-map",
+			expected: "",
+		},
+		{
+			name:     "HS256Claims type",
+			claims:   HS256Claims{"jti": "token-id-456"},
+			expected: "token-id-456",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.WithValue(context.Background(), JWTClaimsContextKey, tt.claims)
+			req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+			got := GetJWTClaims(req).JTI()
+			if got != tt.expected {
+				t.Errorf("GetJWTClaimsJTI() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetJWTClaimsScopes(t *testing.T) {
+	tests := []struct {
+		name     string
+		claims   config.JWTClaims
+		expected []string
+	}{
+		{
+			name:     "space-separated scopes",
+			claims:   map[string]any{"scope": "read write delete"},
+			expected: []string{"read", "write", "delete"},
+		},
+		{
+			name:     "string slice scopes",
+			claims:   map[string]any{"scope": []string{"read", "write"}},
+			expected: []string{"read", "write"},
+		},
+		{
+			name:     "any slice scopes",
+			claims:   map[string]any{"scope": []any{"read", "write"}},
+			expected: []string{"read", "write"},
+		},
+		{
+			name:     "missing scope",
+			claims:   map[string]any{},
+			expected: nil,
+		},
+		{
+			name:     "empty scope string",
+			claims:   map[string]any{"scope": ""},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.WithValue(context.Background(), JWTClaimsContextKey, tt.claims)
+			req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+			scopes := GetJWTClaims(req).Scopes()
+			if len(scopes) != len(tt.expected) {
+				t.Errorf("GetJWTClaimsScopes() length = %d, want %d", len(scopes), len(tt.expected))
+				return
+			}
+			for i := range scopes {
+				if scopes[i] != tt.expected[i] {
+					t.Errorf("GetJWTClaimsScopes()[%d] = %q, want %q", i, scopes[i], tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestJWTClaims_HasScope(t *testing.T) {
+	claims := map[string]any{"scope": "read write admin"}
+	ctx := context.WithValue(context.Background(), JWTClaimsContextKey, claims)
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+
+	jwt := GetJWTClaims(req)
+	if !jwt.HasScope("read") {
+		t.Error("should have 'read' scope")
+	}
+	if !jwt.HasScope("write") {
+		t.Error("should have 'write' scope")
+	}
+	if !jwt.HasScope("admin") {
+		t.Error("should have 'admin' scope")
+	}
+	if jwt.HasScope("delete") {
+		t.Error("should not have 'delete' scope")
+	}
+}
+
+func TestJWTClaims_HasScope_NoClaims(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	jwt := GetJWTClaims(req)
+	if jwt.HasScope("read") {
+		t.Error("should return false with no claims")
+	}
+}
+
+func TestJWTAuthError(t *testing.T) {
+	err := &JWTAuthError{
+		Type:   "test-error",
+		Title:  "Test Error",
+		Status: http.StatusBadRequest,
+		Detail: "something went wrong",
+	}
+
+	if err.Error() != "something went wrong" {
+		t.Errorf("expected error message 'something went wrong', got %q", err.Error())
+	}
+}
+
+func TestGenerateAccessToken_NoStore(t *testing.T) {
+	cfg := config.JWTAuthConfig{}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	_, err := GenerateAccessToken(req, map[string]any{"sub": "user"}, cfg)
+	if err == nil {
+		t.Error("expected error when store not configured")
+	}
+}
+
+func TestGenerateRefreshToken_NoStore(t *testing.T) {
+	cfg := config.JWTAuthConfig{}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	_, err := GenerateRefreshToken(req, map[string]any{"sub": "user"}, cfg)
+	if err == nil {
+		t.Error("expected error when store not configured")
+	}
+}
+
+func TestGenerateAccessToken_Success(t *testing.T) {
+	store := &mockTokenStore{
+		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+			return "generated-access-token", nil
+		},
+	}
+
+	cfg := config.JWTAuthConfig{
+		TokenStore:     store,
+		AccessTokenTTL: 15 * time.Minute,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	token, err := GenerateAccessToken(req, map[string]any{"sub": "user"}, cfg)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	if token != "generated-access-token" {
+		t.Errorf("expected token 'generated-access-token', got %q", token)
+	}
+}
+
+func TestGenerateRefreshToken_Success(t *testing.T) {
+	store := &mockTokenStore{
+		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+			return "generated-refresh-token", nil
+		},
+	}
+
+	cfg := config.JWTAuthConfig{
+		TokenStore:      store,
+		RefreshTokenTTL: 7 * 24 * time.Hour,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	token, err := GenerateRefreshToken(req, map[string]any{"sub": "user"}, cfg)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	if token != "generated-refresh-token" {
+		t.Errorf("expected token 'generated-refresh-token', got %q", token)
+	}
+}
+
+func TestGenerateAccessToken_StoreError(t *testing.T) {
+	store := &mockTokenStore{
+		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+			return "", errors.New("token generation failed")
+		},
+	}
+
+	cfg := config.JWTAuthConfig{
+		TokenStore:     store,
+		AccessTokenTTL: 15 * time.Minute,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	_, err := GenerateAccessToken(req, map[string]any{"sub": "user"}, cfg)
+	if err == nil {
+		t.Error("expected error when generator fails")
+	}
+	if err.Error() != "token generation failed" {
+		t.Errorf("expected error message 'token generation failed', got %q", err.Error())
+	}
+}
+
+func TestGenerateRefreshToken_StoreError(t *testing.T) {
+	store := &mockTokenStore{
+		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+			return "", errors.New("token generation failed")
+		},
+	}
+
+	cfg := config.JWTAuthConfig{
+		TokenStore:      store,
+		RefreshTokenTTL: 7 * 24 * time.Hour,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	_, err := GenerateRefreshToken(req, map[string]any{"sub": "user"}, cfg)
+	if err == nil {
+		t.Error("expected error when generator fails")
+	}
+	if err.Error() != "token generation failed" {
+		t.Errorf("expected error message 'token generation failed', got %q", err.Error())
+	}
+}
+
+func TestRefreshTokenHandler(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(token string) (config.JWTClaims, error) {
+			if token == "valid-refresh-token" {
+				return map[string]any{
+					"sub":  "user123",
+					"type": config.TokenTypeRefresh,
+				}, nil
+			}
+			return nil, errors.New("invalid token")
+		},
+		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+			if tokenType == config.AccessToken {
+				return "new-access-token", nil
+			}
+			return "new-refresh-token", nil
+		},
+	}
+
+	cfg := config.JWTAuthConfig{
+		TokenStore:      store,
+		AccessTokenTTL:  15 * time.Minute,
+		RefreshTokenTTL: 7 * 24 * time.Hour,
+	}
+
+	handler := RefreshTokenHandler(cfg)
+
+	body := `{"refresh_token":"valid-refresh-token"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rr.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp["access_token"] != "new-access-token" {
+		t.Errorf("expected access_token 'new-access-token', got %v", resp["access_token"])
+	}
+	if resp["refresh_token"] != "new-refresh-token" {
+		t.Errorf("expected refresh_token 'new-refresh-token', got %v", resp["refresh_token"])
+	}
+	if resp["token_type"] != "Bearer" {
+		t.Errorf("expected token_type 'Bearer', got %v", resp["token_type"])
+	}
+}
+
+func TestRefreshTokenHandler_InvalidMethod(t *testing.T) {
+	cfg := config.JWTAuthConfig{}
+	handler := RefreshTokenHandler(cfg)
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/refresh", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status %d, got %d", http.StatusMethodNotAllowed, rr.Code)
+	}
+}
+
+func TestRefreshTokenHandler_MissingToken(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(token string) (config.JWTClaims, error) {
+			return nil, errors.New("invalid token")
+		},
+		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+			return "token", nil
+		},
+	}
+	cfg := config.JWTAuthConfig{
+		TokenStore: store,
+	}
+	handler := RefreshTokenHandler(cfg)
+
+	body := `{}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected status %d, got %d", http.StatusUnprocessableEntity, rr.Code)
+	}
+}
+
+func TestRefreshTokenHandler_InvalidToken(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(token string) (config.JWTClaims, error) {
+			return nil, errors.New("invalid token")
+		},
+		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+			return "token", nil
+		},
+	}
+
+	cfg := config.JWTAuthConfig{
+		TokenStore: store,
+	}
+
+	handler := RefreshTokenHandler(cfg)
+
+	body := `{"refresh_token":"invalid-token"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d, got %d", http.StatusUnauthorized, rr.Code)
+	}
+}
+
+func TestRefreshTokenHandler_NotRefreshToken(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(token string) (config.JWTClaims, error) {
+			return map[string]any{
+				"sub":  "user123",
+				"type": "access",
+			}, nil
+		},
+		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+			return "token", nil
+		},
+	}
+
+	cfg := config.JWTAuthConfig{
+		TokenStore: store,
+	}
+
+	handler := RefreshTokenHandler(cfg)
+
+	body := `{"refresh_token":"access-token"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected status %d, got %d", http.StatusUnprocessableEntity, rr.Code)
+	}
+}
+
+func TestRefreshTokenHandler_TokenRevoked(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(token string) (config.JWTClaims, error) {
+			return map[string]any{
+				"sub":  "user123",
+				"type": config.TokenTypeRefresh,
+				"jti":  "token-id-123",
+			}, nil
+		},
+		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+			return "token", nil
+		},
+		isRevoked: true,
+	}
+
+	cfg := config.JWTAuthConfig{
+		TokenStore: store,
+	}
+
+	handler := RefreshTokenHandler(cfg)
+
+	body := `{"refresh_token":"revoked-refresh-token"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d, got %d", http.StatusUnauthorized, rr.Code)
+	}
+
+	var errResp JWTAuthError
+	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("failed to unmarshal error response: %v", err)
+	}
+
+	if errResp.Type != "urn:ietf:rfc:9457:jwt-auth:token-revoked" {
+		t.Errorf("expected error type 'urn:ietf:rfc:9457:jwt-auth:token-revoked', got %s", errResp.Type)
+	}
+}
+
+func TestRefreshTokenHandler_TokenAllowed(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(token string) (config.JWTClaims, error) {
+			return map[string]any{
+				"sub":  "user123",
+				"type": config.TokenTypeRefresh,
+				"jti":  "valid-token-id",
+			}, nil
+		},
+		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+			if tokenType == config.AccessToken {
+				return "new-access-token", nil
+			}
+			return "new-refresh-token", nil
+		},
+		isRevoked: false,
+	}
+
+	cfg := config.JWTAuthConfig{
+		TokenStore:     store,
+		AccessTokenTTL: 15 * time.Minute,
+	}
+
+	handler := RefreshTokenHandler(cfg)
+
+	body := `{"refresh_token":"valid-refresh-token"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rr.Code)
+	}
+}
+
+func TestLogoutTokenHandler(t *testing.T) {
+	revokeCalled := false
+	store := &mockTokenStore{
+		validateFunc: func(token string) (config.JWTClaims, error) {
+			return map[string]any{
+				"sub":  "user123",
+				"type": config.TokenTypeRefresh,
+				"jti":  "token-id-123",
+			}, nil
+		},
+		revokeFunc: func(claims config.JWTClaims) error {
+			revokeCalled = true
+			return nil
+		},
+	}
+
+	cfg := config.JWTAuthConfig{
+		TokenStore: store,
+	}
+
+	handler := LogoutTokenHandler(cfg)
+
+	body := `{"refresh_token":"valid-refresh-token"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if !revokeCalled {
+		t.Error("Revoke should have been called")
+	}
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rr.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp["message"] != "logged out successfully" {
+		t.Errorf("expected message 'logged out successfully', got %v", resp["message"])
+	}
+}
+
+func TestLogoutTokenHandler_InvalidMethod(t *testing.T) {
+	cfg := config.JWTAuthConfig{}
+	handler := LogoutTokenHandler(cfg)
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/logout", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status %d, got %d", http.StatusMethodNotAllowed, rr.Code)
+	}
+}
+
+func TestLogoutTokenHandler_NoTokenStore(t *testing.T) {
+	cfg := config.JWTAuthConfig{}
+	handler := LogoutTokenHandler(cfg)
+
+	body := `{"refresh_token":"some-token"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d, got %d", http.StatusUnauthorized, rr.Code)
+	}
+}
+
+func TestLogoutTokenHandler_MissingToken(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(token string) (config.JWTClaims, error) {
+			return nil, errors.New("invalid token")
+		},
+	}
+
+	cfg := config.JWTAuthConfig{
+		TokenStore: store,
+	}
+	handler := LogoutTokenHandler(cfg)
+
+	body := `{}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected status %d, got %d", http.StatusUnprocessableEntity, rr.Code)
+	}
+}
+
+func TestLogoutTokenHandler_InvalidToken(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(token string) (config.JWTClaims, error) {
+			return nil, errors.New("invalid token")
+		},
+	}
+
+	cfg := config.JWTAuthConfig{
+		TokenStore: store,
+	}
+
+	handler := LogoutTokenHandler(cfg)
+
+	body := `{"refresh_token":"invalid-token"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d, got %d", http.StatusUnauthorized, rr.Code)
+	}
+}
+
+func TestLogoutTokenHandler_NotRefreshToken(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(token string) (config.JWTClaims, error) {
+			return map[string]any{
+				"sub":  "user123",
+				"type": "access",
+			}, nil
+		},
+	}
+
+	cfg := config.JWTAuthConfig{
+		TokenStore: store,
+	}
+
+	handler := LogoutTokenHandler(cfg)
+
+	body := `{"refresh_token":"access-token"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected status %d, got %d", http.StatusUnprocessableEntity, rr.Code)
+	}
+}
+
+func TestLogoutTokenHandler_RevokeError(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(token string) (config.JWTClaims, error) {
+			return map[string]any{
+				"sub":  "user123",
+				"type": config.TokenTypeRefresh,
+				"jti":  "token-id-123",
+			}, nil
+		},
+		revokeFunc: func(claims config.JWTClaims) error {
+			return errors.New("database error")
+		},
+	}
+
+	cfg := config.JWTAuthConfig{
+		TokenStore: store,
+	}
+
+	handler := LogoutTokenHandler(cfg)
+
+	body := `{"refresh_token":"valid-refresh-token"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("expected status %d, got %d", http.StatusInternalServerError, rr.Code)
+	}
+
+	var errResp JWTAuthError
+	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("failed to unmarshal error response: %v", err)
+	}
+
+	if errResp.Type != "urn:ietf:rfc:9457:jwt-auth:revocation-failed" {
+		t.Errorf("expected error type 'urn:ietf:rfc:9457:jwt-auth:revocation-failed', got %s", errResp.Type)
+	}
+}
+
+func TestGetJWTClaimsExpiration(t *testing.T) {
+	now := time.Now()
+	expUnix := now.Add(15 * time.Minute).Unix()
+
+	tests := []struct {
+		name     string
+		claims   config.JWTClaims
+		expected time.Time
+	}{
+		{
+			name:     "float64 exp",
+			claims:   map[string]any{"exp": float64(expUnix)},
+			expected: time.Unix(expUnix, 0),
+		},
+		{
+			name:     "int64 exp",
+			claims:   map[string]any{"exp": expUnix},
+			expected: time.Unix(expUnix, 0),
+		},
+		{
+			name:     "missing exp",
+			claims:   map[string]any{},
+			expected: time.Time{},
+		},
+		{
+			name:     "nil claims",
+			claims:   nil,
+			expected: time.Time{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.WithValue(context.Background(), JWTClaimsContextKey, tt.claims)
+			req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+			got := GetJWTClaims(req).Expiration()
+			if !got.Equal(tt.expected) {
+				t.Errorf("GetJWTClaimsExpiration() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAddExpirationToClaims(t *testing.T) {
+	ttl := 15 * time.Minute
+	before := time.Now()
+
+	claims := map[string]any{"sub": "user123"}
+	result := addExpirationToClaims(claims, ttl)
+
+	resultMap, ok := result.(map[string]any)
+	if !ok {
+		t.Fatal("result should be map[string]any")
+	}
+
+	if resultMap["sub"] != "user123" {
+		t.Errorf("expected sub = 'user123', got %v", resultMap["sub"])
+	}
+
+	exp, ok := resultMap["exp"].(int64)
+	if !ok {
+		t.Fatal("exp should be int64")
+	}
+
+	after := time.Now().Add(ttl)
+	if exp < before.Add(ttl).Unix() || exp > after.Unix() {
+		t.Errorf("exp %d not in expected range [%d, %d]", exp, before.Add(ttl).Unix(), after.Unix())
+	}
+
+	if _, exists := claims["exp"]; exists {
+		t.Error("original claims should not be modified")
+	}
+}
+
+func TestAddTypeToClaims(t *testing.T) {
+	claims := map[string]any{"sub": "user123"}
+	result := addTypeToClaims(claims, "refresh")
+
+	resultMap, ok := result.(map[string]any)
+	if !ok {
+		t.Fatal("result should be map[string]any")
+	}
+
+	if resultMap["type"] != "refresh" {
+		t.Errorf("expected type = 'refresh', got %v", resultMap["type"])
+	}
+
+	if _, exists := claims["type"]; exists {
+		t.Error("original claims should not be modified")
+	}
+}
+
+func TestHasClaim(t *testing.T) {
+	claims := map[string]any{"sub": "user123", "iss": "test"}
+
+	if !hasClaim(claims, "sub") {
+		t.Error("should have 'sub' claim")
+	}
+	if !hasClaim(claims, "iss") {
+		t.Error("should have 'iss' claim")
+	}
+	if hasClaim(claims, "aud") {
+		t.Error("should not have 'aud' claim")
+	}
+
+	// Test with HS256Claims type
+	hsClaims := HS256Claims{"sub": "user123", "iss": "test"}
+	if !hasClaim(hsClaims, "sub") {
+		t.Error("should have 'sub' claim in HS256Claims")
+	}
+	if !hasClaim(hsClaims, "iss") {
+		t.Error("should have 'iss' claim in HS256Claims")
+	}
+	if hasClaim(hsClaims, "aud") {
+		t.Error("should not have 'aud' claim in HS256Claims")
+	}
+}
+
+// Define a custom map type to simulate jwt.MapClaims from golang-jwt/jwt
+type customMapClaims map[string]any
+
+func TestHasClaim_CustomMapType(t *testing.T) {
+	// Test with custom map type (like jwt.MapClaims)
+	claims := customMapClaims{"sub": "user123", "iss": "test"}
+
+	if !hasClaim(claims, "sub") {
+		t.Error("should have 'sub' claim in custom map type")
+	}
+	if !hasClaim(claims, "iss") {
+		t.Error("should have 'iss' claim in custom map type")
+	}
+	if hasClaim(claims, "aud") {
+		t.Error("should not have 'aud' claim in custom map type")
+	}
+}
+
+func TestGetStringClaim(t *testing.T) {
+	tests := []struct {
+		name     string
+		claims   config.JWTClaims
+		key      string
+		expected string
+	}{
+		{
+			name:     "string value",
+			claims:   map[string]any{"sub": "user123"},
+			key:      "sub",
+			expected: "user123",
+		},
+		{
+			name:     "string slice first value",
+			claims:   map[string]any{"aud": []string{"aud1", "aud2"}},
+			key:      "aud",
+			expected: "aud1",
+		},
+		{
+			name:     "any slice first value",
+			claims:   map[string]any{"aud": []any{"aud1", "aud2"}},
+			key:      "aud",
+			expected: "aud1",
+		},
+		{
+			name:     "missing key",
+			claims:   map[string]any{},
+			key:      "sub",
+			expected: "",
+		},
+		{
+			name:     "non-map claims",
+			claims:   "not-a-map",
+			key:      "sub",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getStringClaim(tt.claims, tt.key)
+			if got != tt.expected {
+				t.Errorf("getStringClaim() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetMapClaim(t *testing.T) {
+	tests := []struct {
+		name     string
+		claims   config.JWTClaims
+		key      string
+		expected any
+	}{
+		{
+			name:     "map[string]any",
+			claims:   map[string]any{"sub": "user123"},
+			key:      "sub",
+			expected: "user123",
+		},
+		{
+			name:     "custom map type",
+			claims:   customMapClaims{"sub": "user456"},
+			key:      "sub",
+			expected: "user456",
+		},
+		{
+			name:     "missing key",
+			claims:   map[string]any{},
+			key:      "sub",
+			expected: nil,
+		},
+		{
+			name:     "nil claims",
+			claims:   nil,
+			key:      "sub",
+			expected: nil,
+		},
+		{
+			name:     "non-map claims",
+			claims:   "not-a-map",
+			key:      "sub",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getMapClaim(tt.claims, tt.key)
+			if got != tt.expected {
+				t.Errorf("getMapClaim() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractStringValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    any
+		expected string
+	}{
+		{name: "string", value: "hello", expected: "hello"},
+		{name: "nil", value: nil, expected: ""},
+		{name: "string slice", value: []string{"a", "b"}, expected: "a"},
+		{name: "any slice", value: []any{"x", "y"}, expected: "x"},
+		{name: "empty slice", value: []string{}, expected: ""},
+		{name: "int", value: 42, expected: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractStringValue(tt.value)
+			if got != tt.expected {
+				t.Errorf("extractStringValue() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetJWTClaims(t *testing.T) {
+	claims := map[string]any{"sub": "user123"}
+	ctx := context.WithValue(context.Background(), JWTClaimsContextKey, claims)
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+
+	jwt := GetJWTClaims(req)
+	if jwt.Raw() == nil {
+		t.Error("GetJWTClaims should return claims from context")
+	}
+
+	// Compare by checking we can access the same data
+	wrappedClaims, ok := jwt.Raw().(map[string]any)
+	if !ok {
+		t.Fatal("Raw() should return the original claims type")
+	}
+	if wrappedClaims["sub"] != "user123" {
+		t.Error("GetJWTClaims should preserve the claims data")
+	}
+
+	// Test direct accessor
+	if jwt.Subject() != "user123" {
+		t.Errorf("Subject() = %q, want 'user123'", jwt.Subject())
+	}
+}
+
+func TestClaimsWrapper_Subject(t *testing.T) {
+	tests := []struct {
+		name     string
+		claims   config.JWTClaims
+		expected string
+	}{
+		{
+			name:     "has subject",
+			claims:   map[string]any{"sub": "user123"},
+			expected: "user123",
+		},
+		{
+			name:     "missing subject",
+			claims:   map[string]any{},
+			expected: "",
+		},
+		{
+			name:     "nil claims",
+			claims:   nil,
+			expected: "",
+		},
+		{
+			name:     "HS256Claims",
+			claims:   HS256Claims{"sub": "user456"},
+			expected: "user456",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jwt := JWTClaims{claims: tt.claims}
+			got := jwt.Subject()
+			if got != tt.expected {
+				t.Errorf("Subject() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestClaimsWrapper_Issuer(t *testing.T) {
+	claims := map[string]any{"iss": "my-issuer"}
+	jwt := JWTClaims{claims: claims}
+
+	if got := jwt.Issuer(); got != "my-issuer" {
+		t.Errorf("Issuer() = %q, want 'my-issuer'", got)
+	}
+}
+
+func TestClaimsWrapper_Audience(t *testing.T) {
+	claims := map[string]any{"aud": "my-audience"}
+	jwt := JWTClaims{claims: claims}
+
+	if got := jwt.Audience(); got != "my-audience" {
+		t.Errorf("Audience() = %q, want 'my-audience'", got)
+	}
+}
+
+func TestClaimsWrapper_JTI(t *testing.T) {
+	claims := map[string]any{"jti": "token-id-123"}
+	jwt := JWTClaims{claims: claims}
+
+	if got := jwt.JTI(); got != "token-id-123" {
+		t.Errorf("JTI() = %q, want 'token-id-123'", got)
+	}
+}
+
+func TestClaimsWrapper_Expiration(t *testing.T) {
+	now := time.Now()
+	expUnix := now.Add(time.Hour).Unix()
+
+	tests := []struct {
+		name     string
+		claims   config.JWTClaims
+		expected time.Time
+	}{
+		{
+			name:     "float64 exp",
+			claims:   map[string]any{"exp": float64(expUnix)},
+			expected: time.Unix(expUnix, 0),
+		},
+		{
+			name:     "int64 exp",
+			claims:   map[string]any{"exp": expUnix},
+			expected: time.Unix(expUnix, 0),
+		},
+		{
+			name:     "missing exp",
+			claims:   map[string]any{},
+			expected: time.Time{},
+		},
+		{
+			name:     "nil claims",
+			claims:   nil,
+			expected: time.Time{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jwt := JWTClaims{claims: tt.claims}
+			got := jwt.Expiration()
+			if !got.Equal(tt.expected) {
+				t.Errorf("Expiration() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestClaimsWrapper_Scopes(t *testing.T) {
+	tests := []struct {
+		name     string
+		claims   config.JWTClaims
+		expected []string
+	}{
+		{
+			name:     "space-separated",
+			claims:   map[string]any{"scope": "read write delete"},
+			expected: []string{"read", "write", "delete"},
+		},
+		{
+			name:     "string slice",
+			claims:   map[string]any{"scope": []string{"read", "write"}},
+			expected: []string{"read", "write"},
+		},
+		{
+			name:     "any slice",
+			claims:   map[string]any{"scope": []any{"read", "write"}},
+			expected: []string{"read", "write"},
+		},
+		{
+			name:     "missing scope",
+			claims:   map[string]any{},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jwt := JWTClaims{claims: tt.claims}
+			got := jwt.Scopes()
+			if len(got) != len(tt.expected) {
+				t.Errorf("Scopes() length = %d, want %d", len(got), len(tt.expected))
+				return
+			}
+			for i := range got {
+				if got[i] != tt.expected[i] {
+					t.Errorf("Scopes()[%d] = %q, want %q", i, got[i], tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestClaimsWrapper_HasScope(t *testing.T) {
+	claims := map[string]any{"scope": "read write admin"}
+	jwt := JWTClaims{claims: claims}
+
+	if !jwt.HasScope("read") {
+		t.Error("should have 'read' scope")
+	}
+	if !jwt.HasScope("write") {
+		t.Error("should have 'write' scope")
+	}
+	if !jwt.HasScope("admin") {
+		t.Error("should have 'admin' scope")
+	}
+	if jwt.HasScope("delete") {
+		t.Error("should not have 'delete' scope")
+	}
+}
+
+func TestClaimsWrapper_HasScope_NoClaims(t *testing.T) {
+	jwt := JWTClaims{claims: nil}
+	if jwt.HasScope("read") {
+		t.Error("should return false with nil claims")
+	}
+}
+
+func TestGetJWTToken_NotSet(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	token := GetJWTToken(req)
+	if token != "" {
+		t.Errorf("expected empty string, got %q", token)
+	}
+}
+
+func TestGetJWTError_NotSet(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	err := GetJWTError(req)
+	if err != nil {
+		t.Error("expected nil error")
+	}
+}
+
+func TestGetJWTError_NotJWTError(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := context.WithValue(req.Context(), JWTErrorContextKey, errors.New("some error"))
+	err := GetJWTError(req.WithContext(ctx))
+	if err != nil {
+		t.Error("expected nil for non-JWTAuthError")
+	}
+}
+
+func TestExpiration_NonMapClaims(t *testing.T) {
+	// Test with non-map claims type
+	jwt := JWTClaims{claims: "not a map"}
+	exp := jwt.Expiration()
+	if !exp.IsZero() {
+		t.Error("expected zero time for non-map claims")
+	}
+}
+
+func TestExpiration_Int64(t *testing.T) {
+	claims := map[string]any{"exp": int64(time.Now().Add(time.Hour).Unix())}
+	jwt := JWTClaims{claims: claims}
+	exp := jwt.Expiration()
+	if exp.IsZero() {
+		t.Error("expected valid expiration time")
+	}
+}
+
+func TestScopes_NonMapClaims(t *testing.T) {
+	jwt := JWTClaims{claims: "not a map"}
+	scopes := jwt.Scopes()
+	if scopes != nil {
+		t.Error("expected nil for non-map claims")
+	}
+}
+
+func TestScopes_EmptyString(t *testing.T) {
+	jwt := JWTClaims{claims: map[string]any{"scope": ""}}
+	scopes := jwt.Scopes()
+	if len(scopes) != 0 {
+		t.Errorf("expected empty slice, got %v", scopes)
+	}
+}
+
+func TestDefaultJWTErrorHandler_NoError(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+
+	// Call handler without setting error in context
+	defaultJWTErrorHandler(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d, got %d", http.StatusUnauthorized, rr.Code)
+	}
+}
+
+func TestExtractBearerToken_NoBearer(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Basic abc123")
+
+	token := extractBearerToken(req)
+	if token != "" {
+		t.Errorf("expected empty token, got %q", token)
+	}
+}
+
+func TestExtractBearerToken_EmptyAuth(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	token := extractBearerToken(req)
+	if token != "" {
+		t.Errorf("expected empty token, got %q", token)
+	}
+}
+
+func TestDeepCopyMap_Nil(t *testing.T) {
+	result := deepCopyMap(nil)
+	if result != nil {
+		t.Error("expected nil for nil input")
+	}
+}
+
+func TestDeepCopyMap_Nested(t *testing.T) {
+	original := map[string]any{
+		"user": map[string]any{
+			"name": "alice",
+			"tags": []any{"admin", "user"},
+		},
+	}
+
+	copied := deepCopyMap(original)
+
+	// Modify original
+	original["user"].(map[string]any)["name"] = "bob"
+	original["user"].(map[string]any)["tags"].([]any)[0] = "superadmin"
+
+	// Check copy wasn't affected
+	user := copied["user"].(map[string]any)
+	if user["name"] != "alice" {
+		t.Error("deep copy failed - name was modified")
+	}
+	tags := user["tags"].([]any)
+	if tags[0] != "admin" {
+		t.Error("deep copy failed - tags were modified")
+	}
+}
+
+func TestDeepCopySlice_Nil(t *testing.T) {
+	result := deepCopySlice(nil)
+	if result != nil {
+		t.Error("expected nil for nil input")
+	}
+}
+
+func TestAddExpirationToClaims_NonMap(t *testing.T) {
+	claims := "not a map"
+	result := addExpirationToClaims(claims, time.Hour)
+	if result != claims {
+		t.Error("expected original claims for non-map type")
+	}
+}
+
+func TestAddTypeToClaims_NonMap(t *testing.T) {
+	claims := "not a map"
+	result := addTypeToClaims(claims, "refresh")
+	if result != claims {
+		t.Error("expected original claims for non-map type")
+	}
+}
+
+func TestGenerateAccessToken_DefaultTTL(t *testing.T) {
+	store := &mockTokenStore{
+		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+			return "token", nil
+		},
+	}
+	cfg := config.JWTAuthConfig{
+		TokenStore:     store,
+		AccessTokenTTL: 0, // Should use default
+	}
+	claims := map[string]any{"sub": "user123"}
+
+	token, err := GenerateAccessToken(nil, claims, cfg)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if token != "token" {
+		t.Errorf("expected 'token', got %q", token)
+	}
+}
+
+func TestRefreshTokenHandler_StoreError(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(token string) (config.JWTClaims, error) {
+			return map[string]any{
+				"sub":  "user123",
+				"type": config.TokenTypeRefresh,
+			}, nil
+		},
+		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+			if tokenType == config.AccessToken {
+				return "", errors.New("generate failed")
+			}
+			return "refresh", nil
+		},
+	}
+	cfg := config.JWTAuthConfig{
+		TokenStore: store,
+	}
+	handler := RefreshTokenHandler(cfg)
+
+	body := `{"refresh_token":"valid-refresh-token"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("expected status %d, got %d", http.StatusInternalServerError, rr.Code)
+	}
+}
+
+func TestLogoutTokenHandler_AlreadyRevoked(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(token string) (config.JWTClaims, error) {
+			return map[string]any{
+				"sub":  "user123",
+				"type": config.TokenTypeRefresh,
+			}, nil
+		},
+		isRevoked: true,
+	}
+	cfg := config.JWTAuthConfig{
+		TokenStore: store,
+	}
+	handler := LogoutTokenHandler(cfg)
+
+	body := `{"refresh_token":"valid-refresh-token"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d, got %d", http.StatusUnauthorized, rr.Code)
+	}
+}
+
+func TestJWTAuth_RevokedToken(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(token string) (config.JWTClaims, error) {
+			return map[string]any{"sub": "user123"}, nil
+		},
+		isRevoked: true,
+	}
+
+	middleware := JWTAuth(config.JWTAuthConfig{
+		TokenStore: store,
+	})
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/protected", nil)
+	req.Header.Set("Authorization", "Bearer revoked-token")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d, got %d", http.StatusUnauthorized, rr.Code)
+	}
+
+	var errResp JWTAuthError
+	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("failed to unmarshal error response: %v", err)
+	}
+
+	if errResp.Type != "urn:ietf:rfc:9457:jwt-auth:token-revoked" {
+		t.Errorf("expected error type 'urn:ietf:rfc:9457:jwt-auth:token-revoked', got %s", errResp.Type)
+	}
+}
+
+func TestJWTAuth_RefreshTokenAsAccessToken(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(token string) (config.JWTClaims, error) {
+			return map[string]any{
+				"sub":  "user123",
+				"type": config.TokenTypeRefresh,
+			}, nil
+		},
+	}
+
+	middleware := JWTAuth(config.JWTAuthConfig{
+		TokenStore: store,
+	})
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/protected", nil)
+	req.Header.Set("Authorization", "Bearer refresh-token")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d, got %d", http.StatusUnauthorized, rr.Code)
+	}
+
+	var errResp JWTAuthError
+	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("failed to unmarshal error response: %v", err)
+	}
+
+	if errResp.Type != "urn:ietf:rfc:9457:jwt-auth:invalid-token-type" {
+		t.Errorf("expected error type 'urn:ietf:rfc:9457:jwt-auth:invalid-token-type', got %s", errResp.Type)
+	}
+}

--- a/middleware/jwt_hs256.go
+++ b/middleware/jwt_hs256.go
@@ -1,0 +1,279 @@
+package middleware
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/alexferl/zerohttp/config"
+)
+
+// HS256TokenStore implements the config.TokenStore interface using HMAC-SHA256.
+// This provides a zero-dependency JWT implementation using only the standard library.
+type HS256TokenStore struct {
+	secret []byte
+	opts   HS256Options
+}
+
+// NewHS256TokenStore creates a new HS256TokenStore.
+// This provides a zero-dependency JWT implementation that satisfies the TokenStore interface.
+//
+// Example:
+//
+//	store := middleware.NewHS256TokenStore([]byte("your-secret"), middleware.HS256Options{
+//	    Issuer: "my-app",
+//	})
+//
+//	cfg := config.JWTAuthConfig{
+//	    TokenStore: store,
+//	}
+func NewHS256TokenStore(secret []byte, opts HS256Options) *HS256TokenStore {
+	return &HS256TokenStore{
+		secret: secret,
+		opts:   opts,
+	}
+}
+
+// Validate parses and validates an HS256 JWT token.
+func (s *HS256TokenStore) Validate(token string) (config.JWTClaims, error) {
+	return parseHS256Token(token, s.secret, s.opts)
+}
+
+// Generate creates a new HS256 JWT token for the given claims.
+func (s *HS256TokenStore) Generate(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+	return generateHS256Token(claims, s.secret, s.opts)
+}
+
+// Revoke is a no-op for HS256TokenStore. In-memory revocation is not supported.
+// Use a database-backed TokenStore implementation for revocation support.
+func (s *HS256TokenStore) Revoke(claims config.JWTClaims) error {
+	// No-op: HS256TokenStore doesn't support revocation
+	// Users should implement their own TokenStore with Redis/DB for revocation
+	return nil
+}
+
+// IsRevoked always returns false for HS256TokenStore.
+// Use a database-backed TokenStore implementation for revocation support.
+func (s *HS256TokenStore) IsRevoked(claims config.JWTClaims) bool {
+	// Always returns false: HS256TokenStore doesn't support revocation
+	// Users should implement their own TokenStore with Redis/DB for revocation
+	return false
+}
+
+// HS256Options configures the built-in HS256 JWT implementation.
+//
+// Security Note: This implementation uses HMAC-SHA256 symmetric signing. It is suitable
+// for simple use cases and when you control both token issuance and validation. For
+// production systems requiring asymmetric keys (RS256, ES256, EdDSA), key rotation,
+// or JWKS support, use a proper JWT library like golang-jwt/jwt or lestrrat-go/jwx.
+//
+// The Secret must be kept secure. Use a cryptographically secure random key with
+// at least 256 bits (32 bytes) of entropy. Do not hardcode secrets in source code.
+type HS256Options struct {
+	// Secret is the HMAC secret key. Must be at least 32 bytes for security.
+	Secret []byte
+
+	// Issuer is the JWT issuer (iss claim)
+	Issuer string
+
+	// Audience is the JWT audience (aud claim)
+	Audience string
+
+	// ValidateIssuer validates the issuer claim
+	ValidateIssuer bool
+
+	// ValidateAudience validates the audience claim
+	ValidateAudience bool
+}
+
+// HS256Claims represents JWT claims for the built-in HS256 implementation
+type HS256Claims map[string]any
+
+// HS256Validator creates a TokenValidator function for HS256 tokens
+// This provides a zero-dependency JWT implementation using only the standard library
+func HS256Validator(secret []byte, opts HS256Options) func(token string) (config.JWTClaims, error) {
+	return func(token string) (config.JWTClaims, error) {
+		return parseHS256Token(token, secret, opts)
+	}
+}
+
+// HS256Generator creates a TokenGenerator function for HS256 tokens
+func HS256Generator(secret []byte, opts HS256Options) func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+	return func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+		return generateHS256Token(claims, secret, opts)
+	}
+}
+
+// GetHS256Subject extracts the subject from HS256 claims
+func GetHS256Subject(claims config.JWTClaims) string {
+	hsClaims, ok := claims.(HS256Claims)
+	if !ok {
+		return ""
+	}
+
+	if sub, ok := hsClaims["sub"].(string); ok {
+		return sub
+	}
+	return ""
+}
+
+// GetHS256Expiration extracts the expiration time from HS256 claims
+func GetHS256Expiration(claims config.JWTClaims) time.Time {
+	hsClaims, ok := claims.(HS256Claims)
+	if !ok {
+		return time.Time{}
+	}
+
+	if exp, ok := hsClaims["exp"].(float64); ok {
+		return time.Unix(int64(exp), 0)
+	}
+	return time.Time{}
+}
+
+// parseHS256Token parses and validates an HS256 JWT token
+func parseHS256Token(tokenString string, secret []byte, opts HS256Options) (config.JWTClaims, error) {
+	parts := strings.Split(tokenString, ".")
+	if len(parts) != 3 {
+		return nil, errors.New("invalid token format")
+	}
+
+	headerB64, payloadB64, signatureB64 := parts[0], parts[1], parts[2]
+
+	headerJSON, err := base64.RawURLEncoding.DecodeString(headerB64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid header: %w", err)
+	}
+
+	var header struct {
+		Alg string `json:"alg"`
+		Typ string `json:"typ"`
+	}
+	if err := json.Unmarshal(headerJSON, &header); err != nil {
+		return nil, fmt.Errorf("invalid header JSON: %w", err)
+	}
+
+	if header.Alg != "HS256" {
+		return nil, fmt.Errorf("unsupported algorithm: %s", header.Alg)
+	}
+
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(payloadB64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid payload: %w", err)
+	}
+
+	var claims HS256Claims
+	if err := json.Unmarshal(payloadJSON, &claims); err != nil {
+		return nil, fmt.Errorf("invalid payload JSON: %w", err)
+	}
+
+	expectedSignature := signHS256(headerB64+"."+payloadB64, secret)
+	if signatureB64 != expectedSignature {
+		return nil, errors.New("invalid signature")
+	}
+
+	if exp, ok := claims["exp"].(float64); ok {
+		if time.Now().Unix() > int64(exp) {
+			return nil, errors.New("token expired")
+		}
+	}
+
+	if nbf, ok := claims["nbf"].(float64); ok {
+		if time.Now().Unix() < int64(nbf) {
+			return nil, errors.New("token not yet valid")
+		}
+	}
+
+	if opts.ValidateIssuer && opts.Issuer != "" {
+		if iss, ok := claims["iss"].(string); !ok || iss != opts.Issuer {
+			return nil, errors.New("invalid issuer")
+		}
+	}
+
+	if opts.ValidateAudience && opts.Audience != "" {
+		aud, ok := claims["aud"]
+		if !ok {
+			return nil, errors.New("missing audience")
+		}
+
+		switch v := aud.(type) {
+		case string:
+			if v != opts.Audience {
+				return nil, errors.New("invalid audience")
+			}
+		case []any:
+			found := false
+			for _, a := range v {
+				if s, ok := a.(string); ok && s == opts.Audience {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return nil, errors.New("invalid audience")
+			}
+		default:
+			return nil, errors.New("invalid audience format")
+		}
+	}
+
+	return claims, nil
+}
+
+// generateHS256Token generates an HS256 JWT token
+func generateHS256Token(claims config.JWTClaims, secret []byte, opts HS256Options) (string, error) {
+	hsClaims, ok := claims.(HS256Claims)
+	if !ok {
+		switch c := claims.(type) {
+		case map[string]any:
+			hsClaims = c
+		default:
+			return "", errors.New("unsupported claims type for HS256")
+		}
+	}
+
+	if opts.Issuer != "" {
+		hsClaims["iss"] = opts.Issuer
+	}
+
+	if opts.Audience != "" {
+		hsClaims["aud"] = opts.Audience
+	}
+
+	if _, ok := hsClaims["iat"]; !ok {
+		hsClaims["iat"] = time.Now().Unix()
+	}
+
+	header := map[string]string{
+		"alg": "HS256",
+		"typ": "JWT",
+	}
+
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal header: %w", err)
+	}
+
+	payloadJSON, err := json.Marshal(hsClaims)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal payload: %w", err)
+	}
+
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerJSON)
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payloadJSON)
+
+	signature := signHS256(headerB64+"."+payloadB64, secret)
+
+	return headerB64 + "." + payloadB64 + "." + signature, nil
+}
+
+// signHS256 creates an HMAC-SHA256 signature
+func signHS256(data string, secret []byte) string {
+	h := hmac.New(sha256.New, secret)
+	h.Write([]byte(data))
+	return base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+}

--- a/middleware/jwt_hs256_test.go
+++ b/middleware/jwt_hs256_test.go
@@ -1,0 +1,793 @@
+package middleware
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alexferl/zerohttp/config"
+)
+
+func TestHS256Validator_Success(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{}
+
+	generator := HS256Generator(secret, opts)
+	validator := HS256Validator(secret, opts)
+
+	// Generate a token
+	claims := HS256Claims{
+		"sub": "user123",
+		"exp": float64(time.Now().Add(time.Hour).Unix()),
+	}
+
+	token, err := generator(claims, config.AccessToken)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	// Validate the token
+	validatedClaims, err := validator(token)
+	if err != nil {
+		t.Fatalf("failed to validate token: %v", err)
+	}
+
+	hsClaims, ok := validatedClaims.(HS256Claims)
+	if !ok {
+		t.Fatal("expected HS256Claims")
+	}
+
+	if hsClaims["sub"] != "user123" {
+		t.Errorf("expected sub = 'user123', got %v", hsClaims["sub"])
+	}
+}
+
+func TestHS256Validator_InvalidSignature(t *testing.T) {
+	secret := []byte("my-secret-key")
+	wrongSecret := []byte("wrong-secret")
+	opts := HS256Options{}
+
+	generator := HS256Generator(secret, opts)
+
+	// Generate a token with correct secret
+	claims := HS256Claims{
+		"sub": "user123",
+		"exp": float64(time.Now().Add(time.Hour).Unix()),
+	}
+
+	token, err := generator(claims, config.AccessToken)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	// Create validator with wrong secret
+	wrongValidator := HS256Validator(wrongSecret, opts)
+
+	_, err = wrongValidator(token)
+	if err == nil {
+		t.Error("expected validation to fail with wrong secret")
+	}
+	if !strings.Contains(err.Error(), "invalid signature") {
+		t.Errorf("expected 'invalid signature' error, got: %v", err)
+	}
+}
+
+func TestHS256Validator_ExpiredToken(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{}
+
+	generator := HS256Generator(secret, opts)
+	validator := HS256Validator(secret, opts)
+
+	// Generate an expired token
+	claims := HS256Claims{
+		"sub": "user123",
+		"exp": float64(time.Now().Add(-time.Hour).Unix()),
+	}
+
+	token, err := generator(claims, config.AccessToken)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	_, err = validator(token)
+	if err == nil {
+		t.Error("expected validation to fail for expired token")
+	}
+	if !strings.Contains(err.Error(), "expired") {
+		t.Errorf("expected 'expired' error, got: %v", err)
+	}
+}
+
+func TestHS256Validator_NotBefore(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{}
+
+	generator := HS256Generator(secret, opts)
+	validator := HS256Validator(secret, opts)
+
+	// Generate a token that is not yet valid
+	claims := HS256Claims{
+		"sub": "user123",
+		"exp": float64(time.Now().Add(time.Hour).Unix()),
+		"nbf": float64(time.Now().Add(time.Hour).Unix()),
+	}
+
+	token, err := generator(claims, config.AccessToken)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	_, err = validator(token)
+	if err == nil {
+		t.Error("expected validation to fail for not-yet-valid token")
+	}
+	if !strings.Contains(err.Error(), "not yet valid") {
+		t.Errorf("expected 'not yet valid' error, got: %v", err)
+	}
+}
+
+func TestHS256Validator_InvalidFormat(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{}
+
+	validator := HS256Validator(secret, opts)
+
+	// Invalid token format
+	tests := []string{
+		"invalid",
+		"only.two.parts",
+		"too.many.parts.here.now",
+	}
+
+	for _, token := range tests {
+		_, err := validator(token)
+		if err == nil {
+			t.Errorf("expected error for token %q", token)
+		}
+	}
+}
+
+func TestHS256Validator_InvalidAlgorithm(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{}
+
+	validator := HS256Validator(secret, opts)
+
+	// Token with unsupported algorithm (this is a manually crafted token header)
+	// Header: {"alg":"RS256","typ":"JWT"}
+	invalidToken := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMTIzIn0.invalid"
+
+	_, err := validator(invalidToken)
+	if err == nil {
+		t.Error("expected error for unsupported algorithm")
+	}
+	if !strings.Contains(err.Error(), "unsupported algorithm") {
+		t.Errorf("expected 'unsupported algorithm' error, got: %v", err)
+	}
+}
+
+func TestHS256Validator_ValidateIssuer(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{
+		Issuer:         "my-app",
+		ValidateIssuer: true,
+	}
+
+	generator := HS256Generator(secret, opts)
+	validator := HS256Validator(secret, opts)
+
+	// Generate a valid token
+	claims := HS256Claims{
+		"sub": "user123",
+		"exp": float64(time.Now().Add(time.Hour).Unix()),
+	}
+
+	token, err := generator(claims, config.AccessToken)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	// Should validate successfully (generator adds issuer)
+	_, err = validator(token)
+	if err != nil {
+		t.Errorf("expected validation to succeed: %v", err)
+	}
+
+	// Test with wrong issuer
+	wrongOpts := HS256Options{
+		Issuer:         "wrong-app",
+		ValidateIssuer: true,
+	}
+	wrongValidator := HS256Validator(secret, wrongOpts)
+
+	_, err = wrongValidator(token)
+	if err == nil {
+		t.Error("expected validation to fail with wrong issuer")
+	}
+}
+
+func TestHS256Validator_ValidateAudience(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{
+		Audience:         "my-api",
+		ValidateAudience: true,
+	}
+
+	generator := HS256Generator(secret, opts)
+	validator := HS256Validator(secret, opts)
+
+	// Generate a valid token
+	claims := HS256Claims{
+		"sub": "user123",
+		"exp": float64(time.Now().Add(time.Hour).Unix()),
+	}
+
+	token, err := generator(claims, config.AccessToken)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	// Should validate successfully
+	_, err = validator(token)
+	if err != nil {
+		t.Errorf("expected validation to succeed: %v", err)
+	}
+
+	// Test with wrong audience
+	wrongOpts := HS256Options{
+		Audience:         "wrong-api",
+		ValidateAudience: true,
+	}
+	wrongValidator := HS256Validator(secret, wrongOpts)
+
+	_, err = wrongValidator(token)
+	if err == nil {
+		t.Error("expected validation to fail with wrong audience")
+	}
+}
+
+func TestHS256Generator_WithMapClaims(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{
+		Issuer: "test-issuer",
+	}
+
+	generator := HS256Generator(secret, opts)
+
+	// Use regular map[string]any instead of HS256Claims
+	claims := map[string]any{
+		"sub": "user123",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+
+	token, err := generator(claims, config.AccessToken)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	// Token should have 3 parts
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Errorf("expected 3 parts, got %d", len(parts))
+	}
+}
+
+func TestHS256Generator_UnsupportedClaimsType(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{}
+
+	generator := HS256Generator(secret, opts)
+
+	// Use unsupported claims type
+	_, err := generator("not a map", config.AccessToken)
+	if err == nil {
+		t.Error("expected error for unsupported claims type")
+	}
+}
+
+func TestGetHS256Subject(t *testing.T) {
+	claims := HS256Claims{
+		"sub": "user123",
+	}
+
+	sub := GetHS256Subject(claims)
+	if sub != "user123" {
+		t.Errorf("expected sub = 'user123', got %q", sub)
+	}
+
+	// Test with non-HS256Claims
+	sub = GetHS256Subject(map[string]any{"sub": "user456"})
+	if sub != "" {
+		t.Errorf("expected empty string for non-HS256Claims, got %q", sub)
+	}
+}
+
+func TestGetHS256Expiration(t *testing.T) {
+	expTime := time.Now().Add(time.Hour)
+	claims := HS256Claims{
+		"exp": float64(expTime.Unix()),
+	}
+
+	got := GetHS256Expiration(claims)
+	if !got.Equal(time.Unix(expTime.Unix(), 0)) {
+		t.Errorf("expected exp = %v, got %v", expTime, got)
+	}
+
+	// Test with non-HS256Claims
+	got = GetHS256Expiration(map[string]any{"exp": float64(expTime.Unix())})
+	if !got.IsZero() {
+		t.Errorf("expected zero time for non-HS256Claims, got %v", got)
+	}
+}
+
+func TestSignHS256(t *testing.T) {
+	secret := []byte("my-secret")
+	data := "header.payload"
+
+	sig1 := signHS256(data, secret)
+	sig2 := signHS256(data, secret)
+
+	// Same input should produce same signature
+	if sig1 != sig2 {
+		t.Error("expected same signature for same input")
+	}
+
+	// Different secret should produce different signature
+	otherSig := signHS256(data, []byte("other-secret"))
+	if sig1 == otherSig {
+		t.Error("expected different signature for different secret")
+	}
+}
+
+// Tests for HS256TokenStore (TokenStore interface implementation)
+
+func TestNewHS256TokenStore(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{
+		Issuer:   "test-issuer",
+		Audience: "test-audience",
+	}
+
+	store := NewHS256TokenStore(secret, opts)
+	if store == nil {
+		t.Fatal("expected store to be created")
+	}
+}
+
+func TestHS256TokenStore_Validate(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{}
+	store := NewHS256TokenStore(secret, opts)
+
+	// Generate a token first
+	claims := HS256Claims{
+		"sub": "user123",
+		"exp": float64(time.Now().Add(time.Hour).Unix()),
+	}
+
+	token, err := store.Generate(claims, config.AccessToken)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	// Validate the token
+	validatedClaims, err := store.Validate(token)
+	if err != nil {
+		t.Fatalf("failed to validate token: %v", err)
+	}
+
+	hsClaims, ok := validatedClaims.(HS256Claims)
+	if !ok {
+		t.Fatal("expected HS256Claims")
+	}
+
+	if hsClaims["sub"] != "user123" {
+		t.Errorf("expected sub = 'user123', got %v", hsClaims["sub"])
+	}
+}
+
+func TestHS256TokenStore_Validate_InvalidToken(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{}
+	store := NewHS256TokenStore(secret, opts)
+
+	_, err := store.Validate("invalid.token.here")
+	if err == nil {
+		t.Error("expected error for invalid token")
+	}
+}
+
+func TestHS256TokenStore_Generate(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{
+		Issuer: "test-issuer",
+	}
+	store := NewHS256TokenStore(secret, opts)
+
+	claims := HS256Claims{
+		"sub": "user123",
+		"exp": float64(time.Now().Add(time.Hour).Unix()),
+	}
+
+	token, err := store.Generate(claims, config.AccessToken)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	// Token should have 3 parts
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Errorf("expected 3 parts, got %d", len(parts))
+	}
+}
+
+func TestHS256TokenStore_Generate_WithMapClaims(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{}
+	store := NewHS256TokenStore(secret, opts)
+
+	// Use regular map[string]any
+	claims := map[string]any{
+		"sub": "user123",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+
+	token, err := store.Generate(claims, config.AccessToken)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	// Token should have 3 parts
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Errorf("expected 3 parts, got %d", len(parts))
+	}
+}
+
+func TestHS256TokenStore_Generate_UnsupportedClaimsType(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{}
+	store := NewHS256TokenStore(secret, opts)
+
+	// Use unsupported claims type
+	_, err := store.Generate("not a map", config.AccessToken)
+	if err == nil {
+		t.Error("expected error for unsupported claims type")
+	}
+}
+
+func TestHS256TokenStore_Revoke(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{}
+	store := NewHS256TokenStore(secret, opts)
+
+	// Revoke is a no-op for HS256TokenStore
+	claims := HS256Claims{"sub": "user123"}
+	err := store.Revoke(claims)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+}
+
+func TestHS256TokenStore_IsRevoked(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{}
+	store := NewHS256TokenStore(secret, opts)
+
+	// IsRevoked always returns false for HS256TokenStore
+	claims := HS256Claims{"sub": "user123", "jti": "token-id"}
+	if store.IsRevoked(claims) {
+		t.Error("expected IsRevoked to return false")
+	}
+}
+
+func TestHS256TokenStore_RoundTrip(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{
+		Issuer:   "test-issuer",
+		Audience: "test-audience",
+	}
+	store := NewHS256TokenStore(secret, opts)
+
+	// Generate token
+	claims := HS256Claims{
+		"sub":   "user123",
+		"scope": "read write",
+		"exp":   float64(time.Now().Add(time.Hour).Unix()),
+	}
+
+	token, err := store.Generate(claims, config.AccessToken)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	// Validate token
+	validatedClaims, err := store.Validate(token)
+	if err != nil {
+		t.Fatalf("failed to validate token: %v", err)
+	}
+
+	hsClaims, ok := validatedClaims.(HS256Claims)
+	if !ok {
+		t.Fatal("expected HS256Claims")
+	}
+
+	// Check claims survived round trip
+	if hsClaims["sub"] != "user123" {
+		t.Errorf("expected sub = 'user123', got %v", hsClaims["sub"])
+	}
+	if hsClaims["scope"] != "read write" {
+		t.Errorf("expected scope = 'read write', got %v", hsClaims["scope"])
+	}
+
+	// Issuer and audience should be added by generator
+	if hsClaims["iss"] != "test-issuer" {
+		t.Errorf("expected iss = 'test-issuer', got %v", hsClaims["iss"])
+	}
+	if hsClaims["aud"] != "test-audience" {
+		t.Errorf("expected aud = 'test-audience', got %v", hsClaims["aud"])
+	}
+}
+
+func TestParseHS256Token_InvalidBase64(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{}
+
+	validator := HS256Validator(secret, opts)
+
+	// Invalid base64 in header
+	_, err := validator("!!!.eyJzdWIiOiJ1c2VyMTIzIn0.signature")
+	if err == nil {
+		t.Error("expected error for invalid base64 header")
+	}
+}
+
+func TestParseHS256Token_InvalidHeaderJSON(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{}
+
+	validator := HS256Validator(secret, opts)
+
+	// Valid base64 but invalid JSON
+	invalidHeader := base64.RawURLEncoding.EncodeToString([]byte("not json"))
+	token := invalidHeader + ".eyJzdWIiOiJ1c2VyMTIzIn0.signature"
+
+	_, err := validator(token)
+	if err == nil {
+		t.Error("expected error for invalid header JSON")
+	}
+}
+
+func TestParseHS256Token_InvalidPayloadBase64(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{}
+
+	validator := HS256Validator(secret, opts)
+
+	// Valid header, invalid payload base64
+	validHeader := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	token := validHeader + ".!!!.signature"
+
+	_, err := validator(token)
+	if err == nil {
+		t.Error("expected error for invalid payload base64")
+	}
+}
+
+func TestParseHS256Token_InvalidPayloadJSON(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{}
+
+	validator := HS256Validator(secret, opts)
+
+	// Valid header, invalid payload JSON
+	validHeader := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	invalidPayload := base64.RawURLEncoding.EncodeToString([]byte("not json"))
+	token := validHeader + "." + invalidPayload + ".signature"
+
+	_, err := validator(token)
+	if err == nil {
+		t.Error("expected error for invalid payload JSON")
+	}
+}
+
+func TestParseHS256Token_MissingAudience(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{
+		Audience:         "my-api",
+		ValidateAudience: true,
+	}
+
+	validator := HS256Validator(secret, opts)
+
+	// Create a token manually without audience
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"user123","exp":` + fmt.Sprintf("%d", time.Now().Add(time.Hour).Unix()) + `}`))
+	signature := signHS256(header+"."+payload, secret)
+	tokenWithoutAud := header + "." + payload + "." + signature
+
+	_, err := validator(tokenWithoutAud)
+	if err == nil || !strings.Contains(err.Error(), "audience") {
+		t.Errorf("expected 'missing audience' error, got: %v", err)
+	}
+}
+
+func TestParseHS256Token_InvalidAudienceArray(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{
+		Audience:         "my-api",
+		ValidateAudience: true,
+	}
+
+	// Create a token with audience as array that doesn't contain expected audience
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"user123","aud":["other-api"],"exp":` + fmt.Sprintf("%d", time.Now().Add(time.Hour).Unix()) + `}`))
+	signature := signHS256(header+"."+payload, secret)
+	token := header + "." + payload + "." + signature
+
+	validator := HS256Validator(secret, opts)
+	_, err := validator(token)
+	if err == nil || !strings.Contains(err.Error(), "invalid audience") {
+		t.Errorf("expected 'invalid audience' error, got: %v", err)
+	}
+}
+
+func TestParseHS256Token_AudienceWrongFormat(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{
+		Audience:         "my-api",
+		ValidateAudience: true,
+	}
+
+	// Create a token with audience as number (invalid format)
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"user123","aud":123,"exp":` + fmt.Sprintf("%d", time.Now().Add(time.Hour).Unix()) + `}`))
+	signature := signHS256(header+"."+payload, secret)
+	token := header + "." + payload + "." + signature
+
+	validator := HS256Validator(secret, opts)
+	_, err := validator(token)
+	if err == nil || !strings.Contains(err.Error(), "invalid audience format") {
+		t.Errorf("expected 'invalid audience format' error, got: %v", err)
+	}
+}
+
+func TestParseHS256Token_NoExpiration(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{}
+
+	generator := HS256Generator(secret, opts)
+
+	// Generate claims without expiration
+	claims := HS256Claims{
+		"sub": "user123",
+	}
+
+	token, err := generator(claims, config.AccessToken)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	// Token without exp should be valid
+	validator := HS256Validator(secret, opts)
+	validatedClaims, err := validator(token)
+	if err != nil {
+		t.Errorf("expected token without exp to be valid: %v", err)
+	}
+	if validatedClaims == nil {
+		t.Error("expected claims to be returned")
+	}
+}
+
+func TestParseHS256Token_NoNotBefore(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{}
+
+	generator := HS256Generator(secret, opts)
+
+	// Generate claims without nbf
+	claims := HS256Claims{
+		"sub": "user123",
+		"exp": float64(time.Now().Add(time.Hour).Unix()),
+	}
+
+	token, err := generator(claims, config.AccessToken)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	// Token without nbf should be valid
+	validator := HS256Validator(secret, opts)
+	validatedClaims, err := validator(token)
+	if err != nil {
+		t.Errorf("expected token without nbf to be valid: %v", err)
+	}
+	if validatedClaims == nil {
+		t.Error("expected claims to be returned")
+	}
+}
+
+func TestGenerateHS256Token_NoIssuer(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{
+		Issuer: "", // No issuer set
+	}
+
+	store := NewHS256TokenStore(secret, opts)
+
+	claims := HS256Claims{
+		"sub": "user123",
+		"exp": float64(time.Now().Add(time.Hour).Unix()),
+	}
+
+	token, err := store.Generate(claims, config.AccessToken)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	// Validate and check issuer wasn't added
+	validatedClaims, err := store.Validate(token)
+	if err != nil {
+		t.Fatalf("failed to validate token: %v", err)
+	}
+
+	hsClaims := validatedClaims.(HS256Claims)
+	if _, ok := hsClaims["iss"]; ok {
+		t.Error("expected no issuer claim when Issuer is empty")
+	}
+}
+
+func TestGenerateHS256Token_NoAudience(t *testing.T) {
+	secret := []byte("my-secret-key")
+	opts := HS256Options{
+		Audience: "", // No audience set
+	}
+
+	store := NewHS256TokenStore(secret, opts)
+
+	claims := HS256Claims{
+		"sub": "user123",
+		"exp": float64(time.Now().Add(time.Hour).Unix()),
+	}
+
+	token, err := store.Generate(claims, config.AccessToken)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	// Validate and check audience wasn't added
+	validatedClaims, err := store.Validate(token)
+	if err != nil {
+		t.Fatalf("failed to validate token: %v", err)
+	}
+
+	hsClaims := validatedClaims.(HS256Claims)
+	if _, ok := hsClaims["aud"]; ok {
+		t.Error("expected no audience claim when Audience is empty")
+	}
+}
+
+func TestGetHS256Subject_Missing(t *testing.T) {
+	claims := HS256Claims{
+		// No "sub" claim
+	}
+
+	sub := GetHS256Subject(claims)
+	if sub != "" {
+		t.Errorf("expected empty subject, got %q", sub)
+	}
+}
+
+func TestGetHS256Expiration_Missing(t *testing.T) {
+	claims := HS256Claims{
+		// No "exp" claim
+	}
+
+	exp := GetHS256Expiration(claims)
+	if !exp.IsZero() {
+		t.Errorf("expected zero time, got %v", exp)
+	}
+}

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -20,14 +20,18 @@ func DefaultMiddlewares(cfg config.Config, logger log.Logger) []func(http.Handle
 
 // pathMatches checks if a request path matches an exempt path.
 // Supports exact matches and prefix matches (paths ending with /).
-// For example, "/api/public/" matches "/api/public/users" and "/api/public/status".
+// For example, "/api/public/" matches "/api/public", "/api/public/users", and "/api/public/status".
 func pathMatches(requestPath, exemptPath string) bool {
 	if exemptPath == requestPath {
 		return true
 	}
 
 	// Support prefix matching for paths ending with /
-	if strings.HasSuffix(exemptPath, "/") {
+	if base, hasSuffix := strings.CutSuffix(exemptPath, "/"); hasSuffix {
+		// Also match the path without the trailing slash (e.g., "/api/public" matches "/api/public/")
+		if requestPath == base {
+			return true
+		}
 		return strings.HasPrefix(requestPath, exemptPath)
 	}
 

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -80,12 +80,14 @@ func TestPathMatches(t *testing.T) {
 		{"/health", "/health", true},
 		{"/health", "/metrics", false},
 		{"/api/public/users", "/api/public/", true},
-		{"/api/public", "/api/public/", false},
-		{"/api/publicx", "/api/public/", false},
+		{"/api/public", "/api/public/", true},   // path without trailing slash matches
+		{"/api/public/", "/api/public/", true},  // exact match with trailing slash
+		{"/api/publicx", "/api/public/", false}, // different path, shouldn't match
 		{"/", "/", true},
 		{"", "", true},
 		{"/api/v1/users", "/api/", true},
-		{"/api/v1/users", "/api", false},
+		{"/api/v1/users", "/api", false}, // no trailing slash = no prefix match
+		{"/api", "/api/", true},          // path without trailing slash matches
 		{"/different", "/api/", false},
 	}
 


### PR DESCRIPTION
Add pluggable JWT authentication with TokenStore interface, allowing users to bring their own JWT library (golang-jwt/jwt, lestrrat-go/jwx) or use the built-in zero-dependency HS256 implementation.

Features:
  - TokenStore interface for custom JWT implementations
  - Built-in HS256 TokenStore (standard library only)
  - Access token and refresh token generation
  - Token revocation support with IsRevoked() checking
  - Refresh token rotation (new refresh token on each refresh)
  - Built-in refresh and logout handlers
  - Customizable token extraction (header, cookie, etc.)
  - RFC 9457 Problem Details error responses