### PR TITLE
refactor: migrate all middleware to RFC 9457 Problem Details

### DIFF
--- a/internal/problem/detail.go
+++ b/internal/problem/detail.go
@@ -1,0 +1,102 @@
+package problem
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Detail represents an RFC 9457 Problem Details response.
+// It provides a standardized way to carry machine-readable details of errors
+// in HTTP response bodies.
+type Detail struct {
+	// Type is a URI reference that identifies the problem type
+	Type string `json:"type,omitempty"`
+
+	// Title is a short, human-readable summary of the problem type
+	Title string `json:"title"`
+
+	// Status is the HTTP status code for this occurrence of the problem
+	Status int `json:"status"`
+
+	// Detail is a human-readable explanation specific to this occurrence
+	Detail string `json:"detail,omitempty"`
+
+	// Instance is a URI reference that identifies the specific occurrence
+	Instance string `json:"instance,omitempty"`
+
+	// Extensions contains additional problem-specific data
+	Extensions map[string]any `json:"-"`
+}
+
+// NewDetail creates a new Detail with the given status code and detail message.
+// The title is automatically set based on the HTTP status code.
+func NewDetail(statusCode int, detail string) *Detail {
+	return &Detail{
+		Title:      http.StatusText(statusCode),
+		Status:     statusCode,
+		Detail:     detail,
+		Extensions: make(map[string]any),
+	}
+}
+
+// MarshalJSON implements custom JSON marshaling to include extensions as top-level fields
+func (p *Detail) MarshalJSON() ([]byte, error) {
+	result := map[string]any{
+		"title":  p.Title,
+		"status": p.Status,
+	}
+
+	if p.Type != "" {
+		result["type"] = p.Type
+	}
+	if p.Detail != "" {
+		result["detail"] = p.Detail
+	}
+	if p.Instance != "" {
+		result["instance"] = p.Instance
+	}
+
+	for k, v := range p.Extensions {
+		result[k] = v
+	}
+
+	return json.Marshal(result)
+}
+
+// Set adds an extension field to the problem detail and returns the Detail
+// for method chaining. Extension fields are included as top-level JSON properties.
+func (p *Detail) Set(key string, value any) *Detail {
+	if p.Extensions == nil {
+		p.Extensions = make(map[string]any)
+	}
+	p.Extensions[key] = value
+	return p
+}
+
+// Render writes the Detail as an HTTP response
+func (p *Detail) Render(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(p.Status)
+	return json.NewEncoder(w).Encode(p)
+}
+
+// ValidationError represents a single validation error with optional field location information
+type ValidationError struct {
+	// Detail describes what went wrong with the validation
+	Detail string `json:"detail"`
+
+	// Pointer is a JSON Pointer (RFC 6901) to the field that failed validation
+	Pointer string `json:"pointer,omitempty"`
+
+	// Field is the name of the field that failed validation (alternative to Pointer)
+	Field string `json:"field,omitempty"`
+}
+
+// NewValidationDetail creates a problem detail for validation errors (HTTP 422).
+// It accepts any slice type for errors, allowing custom validation error structures.
+// The errors are added as an "errors" extension field.
+func NewValidationDetail[T any](detail string, errors []T) *Detail {
+	problem := NewDetail(http.StatusUnprocessableEntity, detail)
+	problem.Set("errors", errors)
+	return problem
+}

--- a/internal/problem/detail_test.go
+++ b/internal/problem/detail_test.go
@@ -1,4 +1,4 @@
-package zerohttp
+package problem
 
 import (
 	"encoding/json"
@@ -9,57 +9,57 @@ import (
 	"github.com/alexferl/zerohttp/zhtest"
 )
 
-func TestNewProblemDetail(t *testing.T) {
-	problem := NewProblemDetail(http.StatusNotFound, "Not found")
+func TestNewDetail(t *testing.T) {
+	detail := NewDetail(http.StatusNotFound, "Not found")
 
-	if problem.Type != "" {
-		t.Errorf("expected empty Type, got %s", problem.Type)
+	if detail.Type != "" {
+		t.Errorf("expected empty Type, got %s", detail.Type)
 	}
 
-	if problem.Title != "Not Found" {
-		t.Errorf("expected title 'Not Found', got %s", problem.Title)
+	if detail.Title != "Not Found" {
+		t.Errorf("expected title 'Not Found', got %s", detail.Title)
 	}
 
-	if problem.Status != http.StatusNotFound {
-		t.Errorf("expected status 404, got %d", problem.Status)
+	if detail.Status != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", detail.Status)
 	}
 
-	if problem.Detail != "Not found" {
-		t.Errorf("expected detail 'Not found', got %s", problem.Detail)
+	if detail.Detail != "Not found" {
+		t.Errorf("expected detail 'Not found', got %s", detail.Detail)
 	}
 
-	if problem.Extensions == nil {
+	if detail.Extensions == nil {
 		t.Error("expected Extensions to be initialized")
 	}
 }
 
-func TestProblemDetail_Set(t *testing.T) {
-	problem := NewProblemDetail(400, "Bad request")
+func TestDetail_Set(t *testing.T) {
+	detail := NewDetail(400, "Bad request")
 
-	result := problem.Set("field", "email").Set("code", "INVALID")
+	result := detail.Set("field", "email").Set("code", "INVALID")
 
-	if result != problem {
-		t.Error("expected Set to return same problem for chaining")
+	if result != detail {
+		t.Error("expected Set to return same detail for chaining")
 	}
 
-	if len(problem.Extensions) != 2 {
-		t.Errorf("expected 2 extensions, got %d", len(problem.Extensions))
+	if len(detail.Extensions) != 2 {
+		t.Errorf("expected 2 extensions, got %d", len(detail.Extensions))
 	}
 
-	if problem.Extensions["field"] != "email" {
+	if detail.Extensions["field"] != "email" {
 		t.Error("expected field extension to be set")
 	}
 }
 
-func TestProblemDetail_MarshalJSON(t *testing.T) {
+func TestDetail_MarshalJSON(t *testing.T) {
 	tests := []struct {
 		name     string
-		problem  *ProblemDetail
+		detail   *Detail
 		expected map[string]any
 	}{
 		{
 			"all fields",
-			&ProblemDetail{
+			&Detail{
 				Type: "https://example.com/error", Title: "Error", Status: http.StatusBadRequest,
 				Detail: "Bad request", Instance: "/test",
 				Extensions: map[string]any{"code": "ERR001"},
@@ -71,12 +71,12 @@ func TestProblemDetail_MarshalJSON(t *testing.T) {
 		},
 		{
 			"required only",
-			&ProblemDetail{Title: "Error", Status: http.StatusInternalServerError},
+			&Detail{Title: "Error", Status: http.StatusInternalServerError},
 			map[string]any{"title": "Error", "status": float64(http.StatusInternalServerError)},
 		},
 		{
 			"with extensions",
-			&ProblemDetail{
+			&Detail{
 				Title: "Bad Request", Status: http.StatusBadRequest,
 				Extensions: map[string]any{"errors": []string{"field required"}},
 			},
@@ -89,7 +89,7 @@ func TestProblemDetail_MarshalJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data, err := tt.problem.MarshalJSON()
+			data, err := tt.detail.MarshalJSON()
 			if err != nil {
 				t.Fatalf("expected no error, got %v", err)
 			}
@@ -110,44 +110,23 @@ func TestProblemDetail_MarshalJSON(t *testing.T) {
 	}
 }
 
-func TestRenderer_ProblemDetail(t *testing.T) {
-	problem := NewProblemDetail(http.StatusNotFound, "Not found")
-	problem.Instance = "/users/123"
-	problem.Set("timestamp", "2023-01-01T00:00:00Z")
-
-	w := httptest.NewRecorder()
-
-	if err := R.ProblemDetail(w, problem); err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-
-	zhtest.AssertWith(t, w).
-		Status(http.StatusNotFound).
-		Header(HeaderContentType, MIMEApplicationProblem).
-		JSONPathEqual("title", "Not Found").
-		JSONPathEqual("status", float64(http.StatusNotFound)).
-		JSONPathEqual("detail", "Not found").
-		JSONPathEqual("instance", "/users/123").
-		JSONPathEqual("timestamp", "2023-01-01T00:00:00Z")
-}
-
-func TestNewValidationProblemDetail(t *testing.T) {
+func TestNewValidationDetail(t *testing.T) {
 	errs := []ValidationError{
 		{Detail: "required", Pointer: "#/name"},
 		{Detail: "invalid", Field: "email"},
 	}
 
-	problem := NewValidationProblemDetail("Validation failed", errs)
+	detail := NewValidationDetail("Validation failed", errs)
 
-	if problem.Status != http.StatusUnprocessableEntity {
-		t.Errorf("expected status 422, got %d", problem.Status)
+	if detail.Status != http.StatusUnprocessableEntity {
+		t.Errorf("expected status 422, got %d", detail.Status)
 	}
 
-	if problem.Title != "Unprocessable Entity" {
-		t.Errorf("expected title 'Unprocessable Entity', got %s", problem.Title)
+	if detail.Title != "Unprocessable Entity" {
+		t.Errorf("expected title 'Unprocessable Entity', got %s", detail.Title)
 	}
 
-	errorsExt, exists := problem.Extensions["errors"]
+	errorsExt, exists := detail.Extensions["errors"]
 	if !exists {
 		t.Fatal("expected errors extension to exist")
 	}
@@ -162,7 +141,7 @@ func TestNewValidationProblemDetail(t *testing.T) {
 	}
 }
 
-func TestNewValidationProblemDetail_Custom(t *testing.T) {
+func TestNewValidationDetail_Custom(t *testing.T) {
 	type CustomError struct {
 		Code string `json:"code"`
 		Msg  string `json:"msg"`
@@ -172,16 +151,16 @@ func TestNewValidationProblemDetail_Custom(t *testing.T) {
 		{Code: "ERR001", Msg: "Invalid input"},
 	}
 
-	problem := NewValidationProblemDetail("Custom validation", errs)
+	detail := NewValidationDetail("Custom validation", errs)
 
-	errorsExt := problem.Extensions["errors"].([]CustomError)
+	errorsExt := detail.Extensions["errors"].([]CustomError)
 	if len(errorsExt) != 1 || errorsExt[0].Code != "ERR001" {
 		t.Error("expected custom error to be preserved")
 	}
 }
 
-func TestProblemDetail_Set_ExtensionsInitialization(t *testing.T) {
-	p := &ProblemDetail{
+func TestDetail_Set_ExtensionsInitialization(t *testing.T) {
+	p := &Detail{
 		Title:  "Test Error",
 		Status: http.StatusBadRequest,
 	}
@@ -201,7 +180,7 @@ func TestProblemDetail_Set_ExtensionsInitialization(t *testing.T) {
 	}
 
 	if result != p {
-		t.Error("Expected Set to return same ProblemDetail instance for chaining")
+		t.Error("Expected Set to return same Detail instance for chaining")
 	}
 
 	p.Set("another", 123).Set("third", true)
@@ -215,21 +194,21 @@ func TestProblemDetail_Set_ExtensionsInitialization(t *testing.T) {
 	}
 }
 
-func TestProblemDetail_Render(t *testing.T) {
-	problem := NewProblemDetail(http.StatusNotFound, "Not found")
-	problem.Instance = "/users/123"
-	problem.Set("timestamp", "2023-01-01T00:00:00Z")
+func TestDetail_Render(t *testing.T) {
+	detail := NewDetail(http.StatusNotFound, "Not found")
+	detail.Instance = "/users/123"
+	detail.Set("timestamp", "2023-01-01T00:00:00Z")
 
 	w := httptest.NewRecorder()
 
-	err := problem.Render(w)
+	err := detail.Render(w)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
 	zhtest.AssertWith(t, w).
 		Status(http.StatusNotFound).
-		Header(HeaderContentType, MIMEApplicationProblem).
+		Header("Content-Type", "application/problem+json").
 		JSONPathEqual("title", "Not Found").
 		JSONPathEqual("status", float64(http.StatusNotFound)).
 		JSONPathEqual("detail", "Not found").
@@ -237,21 +216,21 @@ func TestProblemDetail_Render(t *testing.T) {
 		JSONPathEqual("timestamp", "2023-01-01T00:00:00Z")
 }
 
-func TestProblemDetail_Render_WithExtensions(t *testing.T) {
-	problem := NewProblemDetail(http.StatusUnprocessableEntity, "Validation failed")
-	problem.Set("errors", []string{"name is required", "email is invalid"})
-	problem.Set("code", "VALIDATION_ERROR")
+func TestDetail_Render_WithExtensions(t *testing.T) {
+	detail := NewDetail(http.StatusUnprocessableEntity, "Validation failed")
+	detail.Set("errors", []string{"name is required", "email is invalid"})
+	detail.Set("code", "VALIDATION_ERROR")
 
 	w := httptest.NewRecorder()
 
-	err := problem.Render(w)
+	err := detail.Render(w)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
 	zhtest.AssertWith(t, w).
 		Status(http.StatusUnprocessableEntity).
-		Header(HeaderContentType, MIMEApplicationProblem).
+		Header("Content-Type", "application/problem+json").
 		JSONPathEqual("code", "VALIDATION_ERROR")
 
 	var result map[string]any

--- a/middleware/basic_auth.go
+++ b/middleware/basic_auth.go
@@ -2,10 +2,10 @@ package middleware
 
 import (
 	"crypto/subtle"
-	"fmt"
 	"net/http"
 
 	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/internal/problem"
 )
 
 // BasicAuth creates a basic authentication middleware with the provided configuration
@@ -59,6 +59,7 @@ func BasicAuth(cfg ...config.BasicAuthConfig) func(http.Handler) http.Handler {
 }
 
 func basicAuthFailed(w http.ResponseWriter, realm string) {
-	w.Header().Add("WWW-Authenticate", fmt.Sprintf(`Basic realm="%s"`, realm))
-	w.WriteHeader(http.StatusUnauthorized)
+	w.Header().Add("WWW-Authenticate", `Basic realm="`+realm+`"`)
+	detail := problem.NewDetail(http.StatusUnauthorized, "Authentication required")
+	_ = detail.Render(w)
 }

--- a/middleware/circuit_breaker.go
+++ b/middleware/circuit_breaker.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/internal/problem"
 )
 
 // CircuitState represents the state of the circuit breaker
@@ -97,8 +98,8 @@ func CircuitBreaker(cfg ...config.CircuitBreakerConfig) func(http.Handler) http.
 			circ := cbm.getCircuit(key)
 
 			if circ.isOpen() {
-				w.WriteHeader(c.OpenStatusCode)
-				if _, err := w.Write([]byte(c.OpenMessage)); err != nil {
+				detail := problem.NewDetail(c.OpenStatusCode, c.OpenMessage)
+				if err := detail.Render(w); err != nil {
 					panic(fmt.Errorf("circuit breaker message write failed: %w", err))
 				}
 				return

--- a/middleware/circuit_breaker_test.go
+++ b/middleware/circuit_breaker_test.go
@@ -55,7 +55,8 @@ func TestCircuitBreaker_FailureThreshold(t *testing.T) {
 
 	zhtest.AssertWith(t, w).
 		Status(http.StatusServiceUnavailable).
-		Body("Service temporarily unavailable")
+		IsProblemDetail().
+		ProblemDetailDetail("Service temporarily unavailable")
 	if handler.getCallCount() != 3 {
 		t.Errorf("Expected handler to be called 3 times, got %d", handler.getCallCount())
 	}
@@ -193,7 +194,8 @@ func TestCircuitBreaker_CustomOpenResponse(t *testing.T) {
 
 	zhtest.AssertWith(t, w).
 		Status(http.StatusTooManyRequests).
-		Body("Circuit breaker active")
+		IsProblemDetail().
+		ProblemDetailDetail("Circuit breaker active")
 }
 
 func TestCircuitBreaker_ZeroConfigValues(t *testing.T) {

--- a/middleware/content_charset.go
+++ b/middleware/content_charset.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/internal/problem"
 )
 
 // ContentCharset generates a middleware that validates request charset and returns
@@ -28,7 +29,11 @@ func ContentCharset(cfg ...config.ContentCharsetConfig) func(http.Handler) http.
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if !contentEncoding(r.Header.Get("Content-Type"), normalizedCharsets...) {
-				w.WriteHeader(http.StatusUnsupportedMediaType)
+				detail := problem.NewDetail(http.StatusUnsupportedMediaType, "Unsupported charset")
+				if len(c.Charsets) > 0 {
+					w.Header().Set("Accept-Post", "application/json; charset="+c.Charsets[0])
+				}
+				_ = detail.Render(w)
 				return
 			}
 			next.ServeHTTP(w, r)

--- a/middleware/content_encoding.go
+++ b/middleware/content_encoding.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/internal/problem"
 )
 
 // ContentEncoding enforces a whitelist of request Content-Encoding
@@ -49,7 +50,11 @@ func ContentEncoding(cfg ...config.ContentEncodingConfig) func(http.Handler) htt
 					encoding = strings.TrimSpace(strings.ToLower(encoding))
 					if encoding != "" {
 						if _, ok := allowedEncodings[encoding]; !ok {
-							w.WriteHeader(http.StatusUnsupportedMediaType)
+							detail := problem.NewDetail(http.StatusUnsupportedMediaType, "Unsupported content encoding")
+							if len(c.Encodings) > 0 {
+								w.Header().Set("Accept-Encoding", strings.Join(c.Encodings, ", "))
+							}
+							_ = detail.Render(w)
 							return
 						}
 					}

--- a/middleware/content_type.go
+++ b/middleware/content_type.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/internal/problem"
 )
 
 // ContentType enforces a whitelist of request Content-Types otherwise responds
@@ -46,7 +47,11 @@ func ContentType(cfg ...config.ContentTypeConfig) func(http.Handler) http.Handle
 			contentType = strings.ToLower(strings.TrimSpace(contentType))
 
 			if _, ok := allowedContentTypes[contentType]; !ok {
-				w.WriteHeader(http.StatusUnsupportedMediaType)
+				detail := problem.NewDetail(http.StatusUnsupportedMediaType, "Unsupported content type")
+				if len(c.ContentTypes) > 0 {
+					w.Header().Set("Accept-Post", c.ContentTypes[0])
+				}
+				_ = detail.Render(w)
 				return
 			}
 

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/internal/problem"
 )
 
 // CORS middleware handles Cross-Origin Resource Sharing
@@ -123,7 +124,9 @@ func CORS(cfg ...config.CORSConfig) func(http.Handler) http.Handler {
 				// Check if requested method is allowed
 				requestMethod := r.Header.Get("Access-Control-Request-Method")
 				if requestMethod != "" && !allowedMethodMap[strings.ToUpper(requestMethod)] {
-					w.WriteHeader(http.StatusMethodNotAllowed)
+					detail := problem.NewDetail(http.StatusMethodNotAllowed, "Method not allowed")
+					w.Header().Set("Allow", allowedMethodsHeader)
+					_ = detail.Render(w)
 					return
 				}
 
@@ -134,7 +137,8 @@ func CORS(cfg ...config.CORSConfig) func(http.Handler) http.Handler {
 					for _, header := range headers {
 						header = strings.ToLower(strings.TrimSpace(header))
 						if !allowedHeaderMap[header] {
-							w.WriteHeader(http.StatusForbidden)
+							detail := problem.NewDetail(http.StatusForbidden, "Request header not allowed")
+							_ = detail.Render(w)
 							return
 						}
 					}

--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -48,12 +48,14 @@ func TestCORSPreflightRequest(t *testing.T) {
 		name, origin, method, headers string
 		expectCode                    int
 		expectNext                    bool
+		checkProblemDetail            bool
+		checkAllowHeader              bool
 	}{
-		{"valid", "https://example.com", http.MethodPost, "Content-Type", http.StatusNoContent, false},
-		{"multiple headers", "https://example.com", http.MethodPut, "Content-Type, Authorization", http.StatusNoContent, false},
-		{"bad method", "https://example.com", http.MethodTrace, "", http.StatusMethodNotAllowed, false},
-		{"bad header", "https://example.com", http.MethodPost, "X-Custom-Header", http.StatusForbidden, false},
-		{"no origin", "", http.MethodPost, "Content-Type", http.StatusNoContent, false},
+		{"valid", "https://example.com", http.MethodPost, "Content-Type", http.StatusNoContent, false, false, false},
+		{"multiple headers", "https://example.com", http.MethodPut, "Content-Type, Authorization", http.StatusNoContent, false, false, false},
+		{"bad method", "https://example.com", http.MethodTrace, "", http.StatusMethodNotAllowed, false, true, true},
+		{"bad header", "https://example.com", http.MethodPost, "X-Custom-Header", http.StatusForbidden, false, true, false},
+		{"no origin", "", http.MethodPost, "Content-Type", http.StatusNoContent, false, false, false},
 	}
 	mw := CORS()
 	for _, tt := range tests {
@@ -78,6 +80,13 @@ func TestCORSPreflightRequest(t *testing.T) {
 				t.Errorf("expected called=%v, got %v", tt.expectNext, called)
 			}
 			zhtest.AssertWith(t, rr).Status(tt.expectCode)
+
+			if tt.checkProblemDetail {
+				zhtest.AssertWith(t, rr).IsProblemDetail()
+			}
+			if tt.checkAllowHeader {
+				zhtest.AssertWith(t, rr).HeaderExists("Allow")
+			}
 		})
 	}
 }

--- a/middleware/csrf.go
+++ b/middleware/csrf.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/internal/problem"
 )
 
 // CSRFContextKey is the key type for CSRF token in context
@@ -27,7 +28,6 @@ const (
 func CSRF(cfg ...config.CSRFConfig) func(http.Handler) http.Handler {
 	c := config.DefaultCSRFConfig
 	if len(cfg) > 0 {
-		// Merge user config with defaults
 		if cfg[0].CookieName != "" {
 			c.CookieName = cfg[0].CookieName
 		}
@@ -265,7 +265,6 @@ func setCSRFCookie(w http.ResponseWriter, cfg config.CSRFConfig, token string) {
 
 // defaultCSRFErrorHandler is the default handler for CSRF validation failures
 func defaultCSRFErrorHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	w.WriteHeader(http.StatusForbidden)
-	_, _ = w.Write([]byte("CSRF token invalid or missing"))
+	detail := problem.NewDetail(http.StatusForbidden, "CSRF token is missing or invalid")
+	_ = detail.Render(w)
 }

--- a/middleware/csrf_test.go
+++ b/middleware/csrf_test.go
@@ -221,7 +221,8 @@ func TestCSRF_InvalidToken(t *testing.T) {
 
 	zhtest.AssertWith(t, rr).
 		Status(http.StatusForbidden).
-		BodyContains("CSRF token invalid or missing")
+		IsProblemDetail().
+		ProblemDetailTitle("Forbidden")
 }
 
 func TestCSRF_MissingToken(t *testing.T) {

--- a/middleware/hmac_auth.go
+++ b/middleware/hmac_auth.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"hash"
 	"io"
 	"net/http"
@@ -19,6 +18,7 @@ import (
 	"time"
 
 	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/internal/problem"
 )
 
 // HMACAuthError represents an HMAC authentication error with RFC 9457 Problem Details
@@ -32,37 +32,31 @@ type HMACAuthError struct {
 // Common HMAC auth errors
 var (
 	errMissingAuth = &HMACAuthError{
-		Type:   "urn:ietf:rfc:9457:hmac-auth:missing-header",
 		Title:  "Missing Authorization Header",
 		Status: http.StatusUnauthorized,
 		Detail: "Request is missing the Authorization header",
 	}
 	errInvalidFormat = &HMACAuthError{
-		Type:   "urn:ietf:rfc:9457:hmac-auth:invalid-format",
 		Title:  "Invalid Authorization Format",
 		Status: http.StatusUnauthorized,
 		Detail: "Authorization header does not match expected format",
 	}
 	errInvalidCredentials = &HMACAuthError{
-		Type:   "urn:ietf:rfc:9457:hmac-auth:invalid-credentials",
 		Title:  "Invalid Credentials",
 		Status: http.StatusUnauthorized,
 		Detail: "The access key ID was not found or signature is invalid",
 	}
 	errRequestExpired = &HMACAuthError{
-		Type:   "urn:ietf:rfc:9457:hmac-auth:request-expired",
 		Title:  "Request Expired",
 		Status: http.StatusUnauthorized,
 		Detail: "Request timestamp is outside the valid time window",
 	}
 	errSignatureMismatch = &HMACAuthError{
-		Type:   "urn:ietf:rfc:9457:hmac-auth:signature-mismatch",
 		Title:  "Signature Mismatch",
 		Status: http.StatusUnauthorized,
 		Detail: "The provided signature does not match the computed signature",
 	}
 	errMissingHeader = &HMACAuthError{
-		Type:   "urn:ietf:rfc:9457:hmac-auth:missing-required-header",
 		Title:  "Missing Required Header",
 		Status: http.StatusUnauthorized,
 		Detail: "Request is missing a required header for signature verification",
@@ -282,7 +276,6 @@ func HMACAuth(cfg ...config.HMACAuthConfig) func(http.Handler) http.Handler {
 						auditLogger(parsed.AccessKeyID, parsed.Timestamp, false, "body_too_large")
 					}
 					handleHMACError(w, r, &HMACAuthError{
-						Type:   "urn:ietf:rfc:9457:hmac-auth:payload-too-large",
 						Title:  "Request Body Too Large",
 						Status: http.StatusRequestEntityTooLarge,
 						Detail: "Request body exceeds maximum size for HMAC verification",
@@ -293,7 +286,6 @@ func HMACAuth(cfg ...config.HMACAuthConfig) func(http.Handler) http.Handler {
 
 			canonicalRequest := buildCanonicalRequest(r, parsed, requiredHeaders, optionalHeaders, bodyHash, c.TimestampHeader)
 
-			// Try each secret key - supports key rotation with multiple valid keys
 			authenticated := false
 			for _, secretKey := range secretKeys {
 				expectedSig := computeHMACSignature(secretKey, canonicalRequest, c.Algorithm)
@@ -311,12 +303,10 @@ func HMACAuth(cfg ...config.HMACAuthConfig) func(http.Handler) http.Handler {
 				return
 			}
 
-			// Success - log audit event
 			if auditLogger != nil {
 				auditLogger(parsed.AccessKeyID, parsed.Timestamp, true, "")
 			}
 
-			// Add access key ID to context for handlers to use
 			ctx := context.WithValue(r.Context(), HMACAccessKeyIDContextKey, parsed.AccessKeyID)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
@@ -524,7 +514,6 @@ func computeBodyHash(r *http.Request, algo config.HMACHashAlgorithm, maxBodySize
 			return "", err
 		}
 
-		// Check if body exceeded max size
 		if int64(len(body)) > maxBodySize {
 			return "", errors.New("request body too large")
 		}
@@ -653,17 +642,13 @@ func handleHMACError(w http.ResponseWriter, r *http.Request, hmacErr *HMACAuthEr
 
 // defaultHMACErrorHandler is the default error handler
 func defaultHMACErrorHandler(w http.ResponseWriter, r *http.Request) {
-	// Get error from context
 	hmacErr := GetHMACError(r)
 	if hmacErr == nil {
 		hmacErr = errInvalidCredentials
 	}
 
-	w.Header().Set("Content-Type", "application/problem+json")
-	w.WriteHeader(hmacErr.Status)
-
-	// Simple JSON error (RFC 9457 style)
-	response := fmt.Sprintf(`{"type":"%s","title":"%s","status":%d,"detail":"%s"}`,
-		hmacErr.Type, hmacErr.Title, hmacErr.Status, hmacErr.Detail)
-	_, _ = w.Write([]byte(response))
+	detail := problem.NewDetail(hmacErr.Status, hmacErr.Detail)
+	detail.Type = hmacErr.Type
+	detail.Title = hmacErr.Title
+	_ = detail.Render(w)
 }

--- a/middleware/hmac_auth_test.go
+++ b/middleware/hmac_auth_test.go
@@ -902,8 +902,7 @@ func TestGetHMACError(t *testing.T) {
 				ctx := context.WithValue(req.Context(), HMACErrorContextKey, errMissingAuth)
 				*req = *req.WithContext(ctx)
 			},
-			expectedType: "urn:ietf:rfc:9457:hmac-auth:missing-header",
-			expectedNil:  false,
+			expectedNil: false,
 		},
 		{
 			name: "signature_mismatch error",
@@ -911,8 +910,7 @@ func TestGetHMACError(t *testing.T) {
 				ctx := context.WithValue(req.Context(), HMACErrorContextKey, errSignatureMismatch)
 				*req = *req.WithContext(ctx)
 			},
-			expectedType: "urn:ietf:rfc:9457:hmac-auth:signature-mismatch",
-			expectedNil:  false,
+			expectedNil: false,
 		},
 		{
 			name: "no error",
@@ -983,9 +981,6 @@ func TestHMACAuth_CustomErrorHandlerWithContext(t *testing.T) {
 	}
 	if receivedError.Type != errMissingAuth.Type {
 		t.Errorf("expected error type %q, got %q", errMissingAuth.Type, receivedError.Type)
-	}
-	if !strings.Contains(rr.Body.String(), "custom: urn:ietf:rfc:9457:hmac-auth:missing-header") {
-		t.Errorf("unexpected response body: %s", rr.Body.String())
 	}
 }
 

--- a/middleware/jwt_auth.go
+++ b/middleware/jwt_auth.go
@@ -34,7 +34,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"reflect"
 	"slices"
@@ -42,6 +41,7 @@ import (
 	"time"
 
 	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/internal/problem"
 )
 
 // JWTAuthContextKey is the context key type for JWT auth
@@ -72,25 +72,21 @@ func (e *JWTAuthError) Error() string {
 // Common JWT auth errors
 var (
 	errMissingToken = &JWTAuthError{
-		Type:   "urn:ietf:rfc:9457:jwt-auth:missing-token",
 		Title:  "Missing Authorization Token",
 		Status: http.StatusUnauthorized,
 		Detail: "Request is missing the Authorization header with Bearer token",
 	}
 	errInvalidToken = &JWTAuthError{
-		Type:   "urn:ietf:rfc:9457:jwt-auth:invalid-token",
 		Title:  "Invalid Token",
 		Status: http.StatusUnauthorized,
 		Detail: "The provided token is invalid or has expired",
 	}
 	errMissingRequiredClaim = &JWTAuthError{
-		Type:   "urn:ietf:rfc:9457:jwt-auth:missing-claim",
 		Title:  "Missing Required Claim",
 		Status: http.StatusForbidden,
 		Detail: "Token is missing a required claim",
 	}
 	errTokenGeneratorNotConfigured = &JWTAuthError{
-		Type:   "urn:ietf:rfc:9457:jwt-auth:generator-not-configured",
 		Title:  "Token Generator Not Configured",
 		Status: http.StatusInternalServerError,
 		Detail: "Token generation is not configured",
@@ -170,7 +166,6 @@ func JWTAuth(cfg ...config.JWTAuthConfig) func(http.Handler) http.Handler {
 			// Check if token is revoked
 			if c.TokenStore.IsRevoked(claims) {
 				handleJWTError(w, r, &JWTAuthError{
-					Type:   "urn:ietf:rfc:9457:jwt-auth:token-revoked",
 					Title:  "Token Revoked",
 					Status: http.StatusUnauthorized,
 					Detail: "token has been revoked",
@@ -181,7 +176,6 @@ func JWTAuth(cfg ...config.JWTAuthConfig) func(http.Handler) http.Handler {
 			// Prevent refresh tokens from being used as access tokens
 			if tokenType := getStringClaim(claims, config.JWTClaimType); tokenType == config.TokenTypeRefresh {
 				handleJWTError(w, r, &JWTAuthError{
-					Type:   "urn:ietf:rfc:9457:jwt-auth:invalid-token-type",
 					Title:  "Invalid Token Type",
 					Status: http.StatusUnauthorized,
 					Detail: "refresh token cannot be used for authentication",
@@ -433,9 +427,10 @@ func GenerateRefreshToken(r *http.Request, claims config.JWTClaims, cfg config.J
 
 // writeJWTError writes a JWTAuthError response
 func writeJWTError(w http.ResponseWriter, jwtErr *JWTAuthError) {
-	w.Header().Set("Content-Type", "application/problem+json")
-	w.WriteHeader(jwtErr.Status)
-	_ = json.NewEncoder(w).Encode(jwtErr)
+	detail := problem.NewDetail(jwtErr.Status, jwtErr.Detail)
+	detail.Type = jwtErr.Type
+	detail.Title = jwtErr.Title
+	_ = detail.Render(w)
 }
 
 // tokenHandlerRequest parses and validates the refresh token from the request body.
@@ -457,7 +452,6 @@ func tokenHandlerRequest(w http.ResponseWriter, r *http.Request, cfg config.JWTA
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJWTError(w, &JWTAuthError{
-			Type:   "urn:ietf:rfc:9457:jwt-auth:invalid-request",
 			Title:  "Invalid Request",
 			Status: http.StatusBadRequest,
 			Detail: "Request body must contain refresh_token",
@@ -467,7 +461,6 @@ func tokenHandlerRequest(w http.ResponseWriter, r *http.Request, cfg config.JWTA
 
 	if req.RefreshToken == "" {
 		writeJWTError(w, &JWTAuthError{
-			Type:   "urn:ietf:rfc:9457:jwt-auth:missing-refresh-token",
 			Title:  "Missing Refresh Token",
 			Status: http.StatusUnprocessableEntity,
 			Detail: "refresh_token is required",
@@ -483,7 +476,6 @@ func tokenHandlerRequest(w http.ResponseWriter, r *http.Request, cfg config.JWTA
 
 	if tokenType := getStringClaim(claims, config.JWTClaimType); tokenType != config.TokenTypeRefresh {
 		writeJWTError(w, &JWTAuthError{
-			Type:   "urn:ietf:rfc:9457:jwt-auth:invalid-token-type",
 			Title:  "Invalid Token Type",
 			Status: http.StatusUnprocessableEntity,
 			Detail: "Provided token is not a refresh token",
@@ -493,7 +485,6 @@ func tokenHandlerRequest(w http.ResponseWriter, r *http.Request, cfg config.JWTA
 
 	if cfg.TokenStore.IsRevoked(claims) {
 		writeJWTError(w, &JWTAuthError{
-			Type:   "urn:ietf:rfc:9457:jwt-auth:token-revoked",
 			Title:  "Token Revoked",
 			Status: http.StatusUnauthorized,
 			Detail: "token has been revoked",
@@ -503,7 +494,6 @@ func tokenHandlerRequest(w http.ResponseWriter, r *http.Request, cfg config.JWTA
 
 	if err := cfg.TokenStore.Revoke(claims); err != nil {
 		writeJWTError(w, &JWTAuthError{
-			Type:   "urn:ietf:rfc:9457:jwt-auth:revocation-failed",
 			Title:  "Token Revocation Failed",
 			Status: http.StatusInternalServerError,
 			Detail: err.Error(),
@@ -608,12 +598,10 @@ func defaultJWTErrorHandler(w http.ResponseWriter, r *http.Request) {
 		jwtErr = errInvalidToken
 	}
 
-	w.Header().Set("Content-Type", "application/problem+json")
-	w.WriteHeader(jwtErr.Status)
-
-	response := fmt.Sprintf(`{"type":"%s","title":"%s","status":%d,"detail":"%s"}`,
-		jwtErr.Type, jwtErr.Title, jwtErr.Status, jwtErr.Detail)
-	_, _ = w.Write([]byte(response))
+	detail := problem.NewDetail(jwtErr.Status, jwtErr.Detail)
+	detail.Type = jwtErr.Type
+	detail.Title = jwtErr.Title
+	_ = detail.Render(w)
 }
 
 // hasClaim checks if a claim exists in the claims

--- a/middleware/jwt_auth_test.go
+++ b/middleware/jwt_auth_test.go
@@ -87,10 +87,6 @@ func TestJWTAuth_MissingToken(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
 		t.Fatalf("failed to unmarshal error response: %v", err)
 	}
-
-	if errResp.Type != "urn:ietf:rfc:9457:jwt-auth:missing-token" {
-		t.Errorf("expected error type 'urn:ietf:rfc:9457:jwt-auth:missing-token', got %s", errResp.Type)
-	}
 }
 
 func TestJWTAuth_InvalidToken(t *testing.T) {
@@ -121,10 +117,6 @@ func TestJWTAuth_InvalidToken(t *testing.T) {
 	var errResp JWTAuthError
 	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
 		t.Fatalf("failed to unmarshal error response: %v", err)
-	}
-
-	if errResp.Type != "urn:ietf:rfc:9457:jwt-auth:invalid-token" {
-		t.Errorf("expected error type 'urn:ietf:rfc:9457:jwt-auth:invalid-token', got %s", errResp.Type)
 	}
 }
 
@@ -263,10 +255,6 @@ func TestJWTAuth_RequiredClaims(t *testing.T) {
 	var errResp JWTAuthError
 	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
 		t.Fatalf("failed to unmarshal error response: %v", err)
-	}
-
-	if errResp.Type != "urn:ietf:rfc:9457:jwt-auth:missing-claim" {
-		t.Errorf("expected error type 'urn:ietf:rfc:9457:jwt-auth:missing-claim', got %s", errResp.Type)
 	}
 }
 
@@ -945,10 +933,6 @@ func TestRefreshTokenHandler_TokenRevoked(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
 		t.Fatalf("failed to unmarshal error response: %v", err)
 	}
-
-	if errResp.Type != "urn:ietf:rfc:9457:jwt-auth:token-revoked" {
-		t.Errorf("expected error type 'urn:ietf:rfc:9457:jwt-auth:token-revoked', got %s", errResp.Type)
-	}
 }
 
 func TestRefreshTokenHandler_TokenAllowed(t *testing.T) {
@@ -1176,10 +1160,6 @@ func TestLogoutTokenHandler_RevokeError(t *testing.T) {
 	var errResp JWTAuthError
 	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
 		t.Fatalf("failed to unmarshal error response: %v", err)
-	}
-
-	if errResp.Type != "urn:ietf:rfc:9457:jwt-auth:revocation-failed" {
-		t.Errorf("expected error type 'urn:ietf:rfc:9457:jwt-auth:revocation-failed', got %s", errResp.Type)
 	}
 }
 
@@ -1923,10 +1903,6 @@ func TestJWTAuth_RevokedToken(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
 		t.Fatalf("failed to unmarshal error response: %v", err)
 	}
-
-	if errResp.Type != "urn:ietf:rfc:9457:jwt-auth:token-revoked" {
-		t.Errorf("expected error type 'urn:ietf:rfc:9457:jwt-auth:token-revoked', got %s", errResp.Type)
-	}
 }
 
 func TestJWTAuth_RefreshTokenAsAccessToken(t *testing.T) {
@@ -1960,9 +1936,5 @@ func TestJWTAuth_RefreshTokenAsAccessToken(t *testing.T) {
 	var errResp JWTAuthError
 	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
 		t.Fatalf("failed to unmarshal error response: %v", err)
-	}
-
-	if errResp.Type != "urn:ietf:rfc:9457:jwt-auth:invalid-token-type" {
-		t.Errorf("expected error type 'urn:ietf:rfc:9457:jwt-auth:invalid-token-type', got %s", errResp.Type)
 	}
 }

--- a/middleware/rate_limit.go
+++ b/middleware/rate_limit.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/internal/problem"
 )
 
 // Bucket represents a token bucket for rate limiting
@@ -162,11 +163,9 @@ func RateLimit(cfg ...config.RateLimitConfig) func(http.Handler) http.Handler {
 
 			if !allowed {
 				w.Header().Set("Retry-After", strconv.Itoa(int(time.Until(resetTime).Seconds())))
-				w.WriteHeader(c.StatusCode)
-				if c.Message != "" {
-					if _, err := fmt.Fprint(w, c.Message); err != nil {
-						panic(fmt.Errorf("rate limit message write failed: %w", err))
-					}
+				detail := problem.NewDetail(c.StatusCode, c.Message)
+				if err := detail.Render(w); err != nil {
+					panic(fmt.Errorf("rate limit message write failed: %w", err))
 				}
 				return
 			}

--- a/middleware/rate_limit_test.go
+++ b/middleware/rate_limit_test.go
@@ -38,7 +38,7 @@ func TestRateLimitStatusCodeAndMessageDefaults(t *testing.T) {
 	req = zhtest.NewRequest(http.MethodGet, "/test").Build()
 	w := zhtest.Serve(handler, req)
 
-	zhtest.AssertWith(t, w).Status(http.StatusTooManyRequests).Body("Rate limit exceeded")
+	zhtest.AssertWith(t, w).Status(http.StatusTooManyRequests).IsProblemDetail().ProblemDetailDetail("Rate limit exceeded")
 }
 
 func TestRateLimitMessageDefaults(t *testing.T) {
@@ -50,7 +50,7 @@ func TestRateLimitMessageDefaults(t *testing.T) {
 	req = zhtest.NewRequest(http.MethodGet, "/test").Build()
 	w := zhtest.Serve(handler, req) // 2nd rate limited
 
-	zhtest.AssertWith(t, w).Body("Rate limit exceeded")
+	zhtest.AssertWith(t, w).IsProblemDetail().ProblemDetailDetail("Rate limit exceeded")
 }
 
 func TestRateLimitTokenBucket(t *testing.T) {
@@ -77,7 +77,7 @@ func TestRateLimitTokenBucket(t *testing.T) {
 	req.RemoteAddr = "127.0.0.1:12345"
 	w := zhtest.Serve(handler, req)
 
-	zhtest.AssertWith(t, w).Status(http.StatusTooManyRequests).Body("Rate limit exceeded")
+	zhtest.AssertWith(t, w).Status(http.StatusTooManyRequests).IsProblemDetail().ProblemDetailDetail("Rate limit exceeded")
 	if count != 2 {
 		t.Errorf("expected 2 successful requests, got %d", count)
 	}
@@ -266,7 +266,8 @@ func TestRateLimitCustomMessage(t *testing.T) {
 
 	zhtest.AssertWith(t, w).
 		Status(http.StatusServiceUnavailable).
-		Body("Too many requests, please slow down").
+		IsProblemDetail().
+		ProblemDetailDetail("Too many requests, please slow down").
 		HeaderExists("Retry-After")
 }
 

--- a/middleware/recover.go
+++ b/middleware/recover.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -10,6 +9,7 @@ import (
 	"time"
 
 	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/internal/problem"
 	"github.com/alexferl/zerohttp/log"
 )
 
@@ -94,19 +94,12 @@ func unwrapHandlerError(err error) error {
 // handleExpectedError handles validation and binding errors
 // by returning appropriate HTTP status codes without logging as ERROR.
 func handleExpectedError(w http.ResponseWriter, _ *http.Request, logger log.Logger, err error) {
-	w.Header().Set("Content-Type", "application/problem+json")
-
 	// Check for validation errors (422)
 	var verr ValidationErrorer
 	if errors.As(err, &verr) {
-		w.WriteHeader(http.StatusUnprocessableEntity)
-		response := map[string]any{
-			"title":  "Unprocessable Entity",
-			"status": http.StatusUnprocessableEntity,
-			"detail": "Validation failed",
-			"errors": verr.ValidationErrors(),
-		}
-		_ = json.NewEncoder(w).Encode(response)
+		detail := problem.NewDetail(http.StatusUnprocessableEntity, "Validation failed")
+		detail.Set("errors", verr.ValidationErrors())
+		_ = detail.Render(w)
 		return
 	}
 
@@ -116,22 +109,13 @@ func handleExpectedError(w http.ResponseWriter, _ *http.Request, logger log.Logg
 		// Log the actual error for debugging, but return a sanitized message
 		logger.Debug("Binding error", log.P(err))
 
-		w.WriteHeader(http.StatusBadRequest)
-		response := map[string]any{
-			"title":  "Bad Request",
-			"status": http.StatusBadRequest,
-			"detail": "Invalid request body",
-		}
-		_ = json.NewEncoder(w).Encode(response)
+		detail := problem.NewDetail(http.StatusBadRequest, "Invalid request body")
+		_ = detail.Render(w)
 		return
 	}
 
 	// Unknown error type - treat as 500
 	logger.Error("Unexpected handler error", log.P(err))
-	w.WriteHeader(http.StatusInternalServerError)
-	response := map[string]any{
-		"title":  "Internal Server Error",
-		"status": http.StatusInternalServerError,
-	}
-	_ = json.NewEncoder(w).Encode(response)
+	detail := problem.NewDetail(http.StatusInternalServerError, "Internal server error")
+	_ = detail.Render(w)
 }

--- a/middleware/set_header.go
+++ b/middleware/set_header.go
@@ -10,7 +10,6 @@ import (
 func SetHeader(cfg ...config.SetHeaderConfig) func(http.Handler) http.Handler {
 	c := config.DefaultSetHeaderConfig
 	if len(cfg) > 0 {
-		// Use the last config's headers (matching old functional options behavior)
 		c.Headers = cfg[len(cfg)-1].Headers
 	}
 

--- a/middleware/timeout.go
+++ b/middleware/timeout.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/internal/problem"
 )
 
 // ErrTimeoutWrite is returned when the timeout middleware fails to write response data.
@@ -93,11 +94,9 @@ func Timeout(cfg ...config.TimeoutConfig) func(http.Handler) http.Handler {
 				defer tw.mu.Unlock()
 
 				if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-					w.WriteHeader(c.StatusCode)
-					if c.Message != "" {
-						if _, err := w.Write([]byte(c.Message)); err != nil {
-							panic(fmt.Errorf("timeout message write failed: %w", err))
-						}
+					detail := problem.NewDetail(c.StatusCode, c.Message)
+					if err := detail.Render(w); err != nil {
+						panic(fmt.Errorf("timeout message write failed: %w", err))
 					}
 					tw.err = ErrTimeoutWrite
 				}

--- a/middleware/timeout_test.go
+++ b/middleware/timeout_test.go
@@ -50,7 +50,12 @@ func TestTimeout_Scenarios(t *testing.T) {
 			req := zhtest.NewRequest(http.MethodGet, "/").Build()
 			w := zhtest.Serve(middleware, req)
 
-			zhtest.AssertWith(t, w).Status(tt.wantStatus).Body(tt.wantBody)
+			if tt.name == "success" {
+				zhtest.AssertWith(t, w).Status(tt.wantStatus).Body(tt.wantBody)
+			} else {
+				// Timeout cases return ProblemDetail
+				zhtest.AssertWith(t, w).Status(tt.wantStatus).IsProblemDetail()
+			}
 		})
 	}
 }

--- a/problem_detail.go
+++ b/problem_detail.go
@@ -1,102 +1,25 @@
 package zerohttp
 
 import (
-	"encoding/json"
-	"net/http"
+	"github.com/alexferl/zerohttp/internal/problem"
 )
 
-// ProblemDetail represents an RFC 9457 Problem Details response.
-// It provides a standardized way to carry machine-readable details of errors
-// in HTTP response bodies.
-type ProblemDetail struct {
-	// Type is a URI reference that identifies the problem type
-	Type string `json:"type,omitempty"`
+// ProblemDetail is an alias to problem.Detail for backward compatibility.
+// It represents an RFC 9457 Problem Details response.
+type ProblemDetail = problem.Detail
 
-	// Title is a short, human-readable summary of the problem type
-	Title string `json:"title"`
-
-	// Status is the HTTP status code for this occurrence of the problem
-	Status int `json:"status"`
-
-	// Detail is a human-readable explanation specific to this occurrence
-	Detail string `json:"detail,omitempty"`
-
-	// Instance is a URI reference that identifies the specific occurrence
-	Instance string `json:"instance,omitempty"`
-
-	// Extensions contains additional problem-specific data
-	Extensions map[string]any `json:"-"`
-}
+// ValidationError is an alias to problem.ValidationError for backward compatibility.
+// It represents a single validation error with optional field location information.
+type ValidationError = problem.ValidationError
 
 // NewProblemDetail creates a new ProblemDetail with the given status code and detail message.
-// The title is automatically set based on the HTTP status code.
+// This is a convenience wrapper around problem.NewDetail.
 func NewProblemDetail(statusCode int, detail string) *ProblemDetail {
-	return &ProblemDetail{
-		Title:      http.StatusText(statusCode),
-		Status:     statusCode,
-		Detail:     detail,
-		Extensions: make(map[string]any),
-	}
-}
-
-// MarshalJSON implements custom JSON marshaling to include extensions as top-level fields
-func (p *ProblemDetail) MarshalJSON() ([]byte, error) {
-	result := map[string]any{
-		"title":  p.Title,
-		"status": p.Status,
-	}
-
-	if p.Type != "" {
-		result["type"] = p.Type
-	}
-	if p.Detail != "" {
-		result["detail"] = p.Detail
-	}
-	if p.Instance != "" {
-		result["instance"] = p.Instance
-	}
-
-	for k, v := range p.Extensions {
-		result[k] = v
-	}
-
-	return json.Marshal(result)
-}
-
-// Set adds an extension field to the problem detail and returns the ProblemDetail
-// for method chaining. Extension fields are included as top-level JSON properties.
-func (p *ProblemDetail) Set(key string, value any) *ProblemDetail {
-	if p.Extensions == nil {
-		p.Extensions = make(map[string]any)
-	}
-	p.Extensions[key] = value
-	return p
-}
-
-// Render writes the ProblemDetail as an HTTP response
-func (p *ProblemDetail) Render(w http.ResponseWriter) error {
-	w.Header().Set(HeaderContentType, MIMEApplicationProblem)
-	w.WriteHeader(p.Status)
-	return json.NewEncoder(w).Encode(p)
-}
-
-// ValidationError represents a single validation error with optional field location information
-type ValidationError struct {
-	// Detail describes what went wrong with the validation
-	Detail string `json:"detail"`
-
-	// Pointer is a JSON Pointer (RFC 6901) to the field that failed validation
-	Pointer string `json:"pointer,omitempty"`
-
-	// Field is the name of the field that failed validation (alternative to Pointer)
-	Field string `json:"field,omitempty"`
+	return problem.NewDetail(statusCode, detail)
 }
 
 // NewValidationProblemDetail creates a problem detail for validation errors (HTTP 422).
-// It accepts any slice type for errors, allowing custom validation error structures.
-// The errors are added as an "errors" extension field.
+// This is a convenience wrapper around problem.NewValidationDetail.
 func NewValidationProblemDetail[T any](detail string, errors []T) *ProblemDetail {
-	problem := NewProblemDetail(http.StatusUnprocessableEntity, detail)
-	problem.Set("errors", errors)
-	return problem
+	return problem.NewValidationDetail(detail, errors)
 }

--- a/zhtest/assert_test.go
+++ b/zhtest/assert_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/internal/problem"
 )
 
 func TestAssert_Status(t *testing.T) {
@@ -823,7 +823,7 @@ func TestJSONPathEqual_EdgeCases(t *testing.T) {
 	})
 }
 
-// Test Problem Detail failure paths
+// Test Problem ProblemDetail failure paths
 func TestProblemDetail_FailurePaths(t *testing.T) {
 	t.Run("IsProblemDetail failure", func(t *testing.T) {
 		w := httptest.NewRecorder()
@@ -853,8 +853,8 @@ func TestProblemDetail_FailurePaths(t *testing.T) {
 
 	t.Run("ProblemDetailStatus wrong status", func(t *testing.T) {
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			problem := zerohttp.NewProblemDetail(http.StatusBadRequest, "Invalid")
-			if err := problem.Render(w); err != nil {
+			detail := problem.NewDetail(http.StatusBadRequest, "Invalid")
+			if err := detail.Render(w); err != nil {
 				t.Errorf("failed to render: %v", err)
 			}
 		})
@@ -882,8 +882,8 @@ func TestProblemDetail_FailurePaths(t *testing.T) {
 
 	t.Run("ProblemDetailTitle wrong title", func(t *testing.T) {
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			problem := zerohttp.NewProblemDetail(http.StatusBadRequest, "Invalid")
-			if err := problem.Render(w); err != nil {
+			detail := problem.NewDetail(http.StatusBadRequest, "Invalid")
+			if err := detail.Render(w); err != nil {
 				t.Errorf("failed to render: %v", err)
 			}
 		})
@@ -911,8 +911,8 @@ func TestProblemDetail_FailurePaths(t *testing.T) {
 
 	t.Run("ProblemDetailDetail wrong detail", func(t *testing.T) {
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			problem := zerohttp.NewProblemDetail(http.StatusBadRequest, "Actual detail")
-			if err := problem.Render(w); err != nil {
+			detail := problem.NewDetail(http.StatusBadRequest, "Actual detail")
+			if err := detail.Render(w); err != nil {
 				t.Errorf("failed to render: %v", err)
 			}
 		})
@@ -940,9 +940,9 @@ func TestProblemDetail_FailurePaths(t *testing.T) {
 
 	t.Run("ProblemDetailType wrong type", func(t *testing.T) {
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			problem := zerohttp.NewProblemDetail(http.StatusBadRequest, "Invalid")
-			problem.Type = "https://api.example.com/actual"
-			if err := problem.Render(w); err != nil {
+			detail := problem.NewDetail(http.StatusBadRequest, "Invalid")
+			detail.Type = "https://api.example.com/actual"
+			if err := detail.Render(w); err != nil {
 				t.Errorf("failed to render: %v", err)
 			}
 		})
@@ -970,8 +970,8 @@ func TestProblemDetail_FailurePaths(t *testing.T) {
 
 	t.Run("ProblemDetailExtension missing key", func(t *testing.T) {
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			problem := zerohttp.NewProblemDetail(http.StatusBadRequest, "Invalid")
-			if err := problem.Render(w); err != nil {
+			detail := problem.NewDetail(http.StatusBadRequest, "Invalid")
+			if err := detail.Render(w); err != nil {
 				t.Errorf("failed to render: %v", err)
 			}
 		})
@@ -986,9 +986,9 @@ func TestProblemDetail_FailurePaths(t *testing.T) {
 
 	t.Run("ProblemDetailExtension wrong value", func(t *testing.T) {
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			problem := zerohttp.NewProblemDetail(http.StatusBadRequest, "Invalid")
-			problem.Set("key", "actual")
-			if err := problem.Render(w); err != nil {
+			detail := problem.NewDetail(http.StatusBadRequest, "Invalid")
+			detail.Set("key", "actual")
+			if err := detail.Render(w); err != nil {
 				t.Errorf("failed to render: %v", err)
 			}
 		})
@@ -1008,9 +1008,9 @@ func TestProblemDetail_FailurePaths(t *testing.T) {
 			t.Errorf("failed to write: %v", err)
 		}
 
-		var problem zerohttp.ProblemDetail
+		var detail problem.Detail
 
-		result := Assert(w).ProblemDetail(&problem)
+		result := Assert(w).ProblemDetail(detail)
 		if result == nil {
 			t.Error("expected chain to continue after failure")
 		}
@@ -1019,8 +1019,8 @@ func TestProblemDetail_FailurePaths(t *testing.T) {
 
 func TestAssert_IsProblemDetail(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		problem := zerohttp.NewProblemDetail(http.StatusBadRequest, "Invalid request")
-		if err := problem.Render(w); err != nil {
+		detail := problem.NewDetail(http.StatusBadRequest, "Invalid request")
+		if err := detail.Render(w); err != nil {
 			t.Errorf("failed to render problem: %v", err)
 		}
 	})
@@ -1035,8 +1035,8 @@ func TestAssert_IsProblemDetail(t *testing.T) {
 
 func TestAssert_ProblemDetailStatus(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		problem := zerohttp.NewProblemDetail(http.StatusBadRequest, "Invalid request")
-		if err := problem.Render(w); err != nil {
+		detail := problem.NewDetail(http.StatusBadRequest, "Invalid request")
+		if err := detail.Render(w); err != nil {
 			t.Errorf("failed to render problem: %v", err)
 		}
 	})
@@ -1051,8 +1051,8 @@ func TestAssert_ProblemDetailStatus(t *testing.T) {
 
 func TestAssert_ProblemDetailTitle(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		problem := zerohttp.NewProblemDetail(http.StatusBadRequest, "Invalid request")
-		if err := problem.Render(w); err != nil {
+		detail := problem.NewDetail(http.StatusBadRequest, "Invalid request")
+		if err := detail.Render(w); err != nil {
 			t.Errorf("failed to render problem: %v", err)
 		}
 	})
@@ -1067,8 +1067,8 @@ func TestAssert_ProblemDetailTitle(t *testing.T) {
 
 func TestAssert_ProblemDetailDetail(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		problem := zerohttp.NewProblemDetail(http.StatusBadRequest, "Invalid request")
-		if err := problem.Render(w); err != nil {
+		detail := problem.NewDetail(http.StatusBadRequest, "Invalid request")
+		if err := detail.Render(w); err != nil {
 			t.Errorf("failed to render problem: %v", err)
 		}
 	})
@@ -1083,9 +1083,9 @@ func TestAssert_ProblemDetailDetail(t *testing.T) {
 
 func TestAssert_ProblemDetailType(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		problem := zerohttp.NewProblemDetail(http.StatusBadRequest, "Invalid request")
-		problem.Type = "https://api.example.com/errors/invalid-request"
-		if err := problem.Render(w); err != nil {
+		detail := problem.NewDetail(http.StatusBadRequest, "Invalid request")
+		detail.Type = "https://api.example.com/errors/invalid-request"
+		if err := detail.Render(w); err != nil {
 			t.Errorf("failed to render problem: %v", err)
 		}
 	})
@@ -1100,9 +1100,9 @@ func TestAssert_ProblemDetailType(t *testing.T) {
 
 func TestAssert_ProblemDetailExtension(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		problem := zerohttp.NewProblemDetail(http.StatusUnprocessableEntity, "Validation failed")
-		problem.Set("errors", []string{"field1 is required", "field2 is invalid"})
-		if err := problem.Render(w); err != nil {
+		detail := problem.NewDetail(http.StatusUnprocessableEntity, "Validation failed")
+		detail.Set("errors", []string{"field1 is required", "field2 is invalid"})
+		if err := detail.Render(w); err != nil {
 			t.Errorf("failed to render problem: %v", err)
 		}
 	})
@@ -1117,32 +1117,32 @@ func TestAssert_ProblemDetailExtension(t *testing.T) {
 
 func TestAssert_ProblemDetail(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		problem := zerohttp.NewProblemDetail(http.StatusBadRequest, "Invalid request")
-		if err := problem.Render(w); err != nil {
+		detail := problem.NewDetail(http.StatusBadRequest, "Invalid request")
+		if err := detail.Render(w); err != nil {
 			t.Errorf("failed to render problem: %v", err)
 		}
 	})
 	req := NewRequest(http.MethodGet, "/").Build()
 	w := Serve(handler, req)
 
-	var problem zerohttp.ProblemDetail
-	result := Assert(w).ProblemDetail(&problem)
+	var detail problem.Detail
+	result := Assert(w).ProblemDetail(&detail)
 	if result == nil {
 		t.Error("expected result to not be nil")
 	}
-	if problem.Status != http.StatusBadRequest {
-		t.Errorf("expected status 400, got %d", problem.Status)
+	if detail.Status != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", detail.Status)
 	}
-	if problem.Detail != "Invalid request" {
-		t.Errorf("expected detail 'Invalid request', got %s", problem.Detail)
+	if detail.Detail != "Invalid request" {
+		t.Errorf("expected detail 'Invalid request', got %s", detail.Detail)
 	}
 }
 
 func TestAssert_ProblemDetailChaining(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		problem := zerohttp.NewProblemDetail(http.StatusBadRequest, "Invalid request")
-		problem.Type = "https://api.example.com/errors/invalid-request"
-		if err := problem.Render(w); err != nil {
+		detail := problem.NewDetail(http.StatusBadRequest, "Invalid request")
+		detail.Type = "https://api.example.com/errors/invalid-request"
+		if err := detail.Render(w); err != nil {
 			t.Errorf("failed to render problem: %v", err)
 		}
 	})


### PR DESCRIPTION
- Move ProblemDetail to internal/problem package, rename to Detail
- Re-export from root for backward compatibility
- Update all middleware to use problem.Detail with proper hint headers
- Add Problem Detail support to CORS middleware