### PR TITLE
fix: resolve static analysis and reliability issues

### DIFF
--- a/config/recover.go
+++ b/config/recover.go
@@ -6,10 +6,14 @@ type RecoverConfig struct {
 	StackSize int64
 	// EnableStackTrace determines if stack traces should be included (defaults to true)
 	EnableStackTrace bool
+	// RequestIDHeader is the header name for the request ID (defaults to "X-Request-Id")
+	// This should match the header configured in RequestIDConfig
+	RequestIDHeader string
 }
 
 // DefaultRecoverConfig contains the default panic recovery configuration
 var DefaultRecoverConfig = RecoverConfig{
 	StackSize:        4 << 10, // 4KB
 	EnableStackTrace: true,
+	RequestIDHeader:  "X-Request-Id",
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,34 @@
+// Package errors provides shared error types to avoid import cycles
+// between the main zerohttp package and middleware.
+package errors
+
+import "errors"
+
+// ValidationErrorer is the interface for validation errors.
+type ValidationErrorer interface {
+	error
+	ValidationErrors() map[string][]string
+}
+
+// BindError wraps binding errors to distinguish them from validation errors.
+// The default error handler uses this to return 400 instead of 422.
+type BindError struct {
+	Err error
+}
+
+func (e *BindError) Error() string {
+	return "bind error: " + e.Err.Error()
+}
+
+func (e *BindError) Unwrap() error {
+	return e.Err
+}
+
+// IsBindError checks if an error is a binding error.
+func IsBindError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var be *BindError
+	return errors.As(err, &be)
+}

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,0 +1,70 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestBindError(t *testing.T) {
+	inner := errors.New("invalid JSON")
+	be := &BindError{Err: inner}
+
+	// Test Error() message
+	if msg := be.Error(); msg != "bind error: invalid JSON" {
+		t.Errorf("expected 'bind error: invalid JSON', got %q", msg)
+	}
+
+	// Test Unwrap
+	if unwrapped := be.Unwrap(); unwrapped != inner {
+		t.Error("expected Unwrap to return inner error")
+	}
+}
+
+func TestIsBindError(t *testing.T) {
+	// Test with nil
+	if IsBindError(nil) {
+		t.Error("expected IsBindError(nil) to be false")
+	}
+
+	// Test with regular error
+	regularErr := errors.New("some error")
+	if IsBindError(regularErr) {
+		t.Error("expected IsBindError(regularErr) to be false")
+	}
+
+	// Test with BindError
+	bindErr := &BindError{Err: errors.New("bind error")}
+	if !IsBindError(bindErr) {
+		t.Error("expected IsBindError(bindErr) to be true")
+	}
+
+	// Test with wrapped BindError
+	wrappedErr := fmt.Errorf("wrapped: %w", bindErr)
+	if !IsBindError(wrappedErr) {
+		t.Error("expected IsBindError(wrappedErr) to be true")
+	}
+}
+
+func TestValidationErrorer(t *testing.T) {
+	// Test that ValidationErrorer interface works
+	var ve ValidationErrorer = &testValidationError{
+		errs: map[string][]string{"field": {"required"}},
+	}
+
+	if errs := ve.ValidationErrors(); len(errs) != 1 {
+		t.Errorf("expected 1 validation error, got %d", len(errs))
+	}
+}
+
+type testValidationError struct {
+	errs map[string][]string
+}
+
+func (t *testValidationError) Error() string {
+	return "validation failed"
+}
+
+func (t *testValidationError) ValidationErrors() map[string][]string {
+	return t.errs
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -39,6 +39,8 @@ type Counter interface {
 }
 
 // Gauge can go up and down.
+// Note: Gauge values are stored with fixed-point precision (3 decimal places).
+// Values are rounded to the nearest 0.001. For example, 1.2345 becomes 1.235.
 type Gauge interface {
 	Inc()
 	Dec()
@@ -254,8 +256,10 @@ type gaugeVec struct {
 }
 
 // gauge is a single gauge instance.
+// Values are stored with fixed-point precision (3 decimal places) using int64.
+// The value is multiplied by 1000 for storage, allowing precision to 0.001.
 type gauge struct {
-	value int64 // stored as fixed-point for atomic operations
+	value int64 // stored as fixed-point (val * 1000) for atomic operations
 }
 
 func (g *gauge) Inc() {

--- a/middleware/jwt_auth.go
+++ b/middleware/jwt_auth.go
@@ -92,6 +92,11 @@ var (
 		Status: http.StatusInternalServerError,
 		Detail: "Token generation is not configured",
 	}
+	errTokenStoreNotConfigured = &JWTAuthError{
+		Title:  "Token Store Not Configured",
+		Status: http.StatusUnauthorized,
+		Detail: "JWT authentication is not properly configured",
+	}
 )
 
 // JWTAuth creates JWT authentication middleware
@@ -149,8 +154,8 @@ func JWTAuth(cfg ...config.JWTAuthConfig) func(http.Handler) http.Handler {
 			}
 
 			if c.TokenStore == nil {
-				reg.Counter("jwt_auth_requests_total", "result").WithLabelValues("invalid").Inc()
-				handleJWTError(w, r, errInvalidToken, errorHandler)
+				reg.Counter("jwt_auth_requests_total", "result").WithLabelValues("not_configured").Inc()
+				handleJWTError(w, r, errTokenStoreNotConfigured, errorHandler)
 				return
 			}
 
@@ -163,8 +168,8 @@ func JWTAuth(cfg ...config.JWTAuthConfig) func(http.Handler) http.Handler {
 
 			claims, err := c.TokenStore.Validate(tokenString)
 			if err != nil {
-				reg.Counter("jwt_auth_requests_total", "result").WithLabelValues("invalid").Inc()
-				handleJWTError(w, r, errInvalidToken, errorHandler)
+				reg.Counter("jwt_auth_requests_total", "result").WithLabelValues("not_configured").Inc()
+				handleJWTError(w, r, errTokenStoreNotConfigured, errorHandler)
 				return
 			}
 
@@ -261,6 +266,12 @@ func GetJWTClaims(r *http.Request) JWTClaims {
 	return JWTClaims{}
 }
 
+// asMap normalizes claims to map[string]any for consistent access.
+// Handles both map[string]any and HS256Claims types.
+func (j JWTClaims) asMap() (map[string]any, bool) {
+	return normalizeClaims(j.claims)
+}
+
 // Subject returns the 'sub' claim.
 func (j JWTClaims) Subject() string {
 	return getStringClaim(j.claims, config.JWTClaimSubject)
@@ -274,35 +285,26 @@ func (j JWTClaims) Issuer() string {
 // Audience returns the 'aud' claim as a string slice.
 // Returns all audiences if 'aud' is an array, or a single-element slice if it's a string.
 func (j JWTClaims) Audience() []string {
-	if j.claims == nil {
+	m, ok := j.asMap()
+	if !ok {
 		return nil
 	}
 
-	extractAud := func(m map[string]any) []string {
-		if aud, ok := m[config.JWTClaimAudience]; ok {
-			switch v := aud.(type) {
-			case string:
-				return []string{v}
-			case []string:
-				return v
-			case []any:
-				audiences := make([]string, 0, len(v))
-				for _, a := range v {
-					if s, ok := a.(string); ok {
-						audiences = append(audiences, s)
-					}
+	if aud, ok := m[config.JWTClaimAudience]; ok {
+		switch v := aud.(type) {
+		case string:
+			return []string{v}
+		case []string:
+			return v
+		case []any:
+			audiences := make([]string, 0, len(v))
+			for _, a := range v {
+				if s, ok := a.(string); ok {
+					audiences = append(audiences, s)
 				}
-				return audiences
 			}
+			return audiences
 		}
-		return nil
-	}
-
-	switch c := j.claims.(type) {
-	case map[string]any:
-		return extractAud(c)
-	case HS256Claims:
-		return extractAud(c)
 	}
 	return nil
 }
@@ -319,62 +321,44 @@ func (j JWTClaims) JTI() string {
 
 // Expiration returns the 'exp' claim as time.Time.
 func (j JWTClaims) Expiration() time.Time {
-	if j.claims == nil {
+	m, ok := j.asMap()
+	if !ok {
 		return time.Time{}
 	}
 
-	extractExp := func(m map[string]any) time.Time {
-		if exp, ok := m[config.JWTClaimExpiration]; ok {
-			switch v := exp.(type) {
-			case float64:
-				return time.Unix(int64(v), 0)
-			case int64:
-				return time.Unix(v, 0)
-			}
+	if exp, ok := m[config.JWTClaimExpiration]; ok {
+		switch v := exp.(type) {
+		case float64:
+			return time.Unix(int64(v), 0)
+		case int64:
+			return time.Unix(v, 0)
 		}
-		return time.Time{}
-	}
-
-	switch c := j.claims.(type) {
-	case map[string]any:
-		return extractExp(c)
-	case HS256Claims:
-		return extractExp(c)
 	}
 	return time.Time{}
 }
 
 // Scopes returns the 'scope' claim as a string slice.
 func (j JWTClaims) Scopes() []string {
-	if j.claims == nil {
+	m, ok := j.asMap()
+	if !ok {
 		return nil
 	}
 
-	extractScopes := func(m map[string]any) []string {
-		if scope, ok := m[config.JWTClaimScope]; ok {
-			switch v := scope.(type) {
-			case string:
-				return strings.Fields(v)
-			case []string:
-				return v
-			case []any:
-				scopes := make([]string, 0, len(v))
-				for _, s := range v {
-					if str, ok := s.(string); ok {
-						scopes = append(scopes, str)
-					}
+	if scope, ok := m[config.JWTClaimScope]; ok {
+		switch v := scope.(type) {
+		case string:
+			return strings.Fields(v)
+		case []string:
+			return v
+		case []any:
+			scopes := make([]string, 0, len(v))
+			for _, s := range v {
+				if str, ok := s.(string); ok {
+					scopes = append(scopes, str)
 				}
-				return scopes
 			}
+			return scopes
 		}
-		return nil
-	}
-
-	switch c := j.claims.(type) {
-	case map[string]any:
-		return extractScopes(c)
-	case HS256Claims:
-		return extractScopes(c)
 	}
 	return nil
 }
@@ -450,7 +434,7 @@ func tokenHandlerRequest(w http.ResponseWriter, r *http.Request, cfg config.JWTA
 	}
 
 	if cfg.TokenStore == nil {
-		writeJWTError(w, errInvalidToken)
+		writeJWTError(w, errTokenStoreNotConfigured)
 		return nil, false
 	}
 
@@ -627,9 +611,26 @@ func hasClaim(claims config.JWTClaims, key string) bool {
 	}
 }
 
+// normalizeClaims converts claims to map[string]any for consistent access.
+// Handles map[string]any, HS256Claims, and other map types via reflection.
+func normalizeClaims(claims config.JWTClaims) (map[string]any, bool) {
+	if claims == nil {
+		return nil, false
+	}
+	switch c := claims.(type) {
+	case map[string]any:
+		return c, true
+	case HS256Claims:
+		return c, true
+	default:
+		// For other map types, use reflection
+		return nil, false
+	}
+}
+
 // getStringClaim extracts a string claim from claims
 func getStringClaim(claims config.JWTClaims, key string) string {
-	extractFromMap := func(m map[string]any) string {
+	if m, ok := normalizeClaims(claims); ok {
 		if v, ok := m[key]; ok {
 			switch s := v.(type) {
 			case string:
@@ -649,16 +650,9 @@ func getStringClaim(claims config.JWTClaims, key string) string {
 		return ""
 	}
 
-	switch c := claims.(type) {
-	case map[string]any:
-		return extractFromMap(c)
-	case HS256Claims:
-		return extractFromMap(c)
-	default:
-		// Handle other map types (e.g., jwt.MapClaims from golang-jwt)
-		if v := getMapClaim(claims, key); v != nil {
-			return extractStringValue(v)
-		}
+	// Handle other map types (e.g., jwt.MapClaims from golang-jwt) via reflection
+	if v := getMapClaim(claims, key); v != nil {
+		return extractStringValue(v)
 	}
 	return ""
 }

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -9,9 +9,13 @@ import (
 )
 
 func DefaultMiddlewares(cfg config.Config, logger log.Logger) []func(http.Handler) http.Handler {
+	// Sync RequestID header configuration with Recover config
+	recoverConfig := cfg.Recover
+	recoverConfig.RequestIDHeader = cfg.RequestID.Header
+
 	return []func(http.Handler) http.Handler{
 		RequestID(cfg.RequestID),
-		Recover(logger, cfg.Recover),
+		Recover(logger, recoverConfig),
 		RequestBodySize(cfg.RequestBodySize),
 		SecurityHeaders(cfg.SecurityHeaders),
 		RequestLogger(logger, cfg.RequestLogger),

--- a/middleware/recover.go
+++ b/middleware/recover.go
@@ -9,17 +9,14 @@ import (
 	"time"
 
 	"github.com/alexferl/zerohttp/config"
+	zerrors "github.com/alexferl/zerohttp/internal/errors"
 	"github.com/alexferl/zerohttp/internal/problem"
 	"github.com/alexferl/zerohttp/log"
 	"github.com/alexferl/zerohttp/metrics"
 )
 
-// ValidationErrorer is the interface for validation errors.
-// This is duplicated from the main package to avoid import cycle.
-type ValidationErrorer interface {
-	error
-	ValidationErrors() map[string][]string
-}
+// ValidationErrorer is an alias for internal/errors.ValidationErrorer.
+type ValidationErrorer = zerrors.ValidationErrorer
 
 // Recover is a middleware that recovers from panics, logs the panic (and a backtrace),
 // and returns HTTP 500 if possible. It prints a request ID if one is provided.
@@ -34,6 +31,9 @@ func Recover(logger log.Logger, cfg ...config.RecoverConfig) func(http.Handler) 
 	}
 	if c.StackSize <= 0 {
 		c.StackSize = config.DefaultRecoverConfig.StackSize
+	}
+	if c.RequestIDHeader == "" {
+		c.RequestIDHeader = config.DefaultRecoverConfig.RequestIDHeader
 	}
 
 	return func(next http.Handler) http.Handler {
@@ -56,7 +56,7 @@ func Recover(logger log.Logger, cfg ...config.RecoverConfig) func(http.Handler) 
 					metrics.SafeRegistry(metrics.GetRegistry(r.Context())).Counter("recover_panics_total").Inc()
 
 					// Real panic - log as error with stack trace
-					reqID := r.Header.Get("X-Request-Id")
+					reqID := r.Header.Get(c.RequestIDHeader)
 					if reqID == "" {
 						reqID = fmt.Sprintf("recover-%d", time.Now().UnixNano())
 					}
@@ -107,8 +107,7 @@ func handleExpectedError(w http.ResponseWriter, _ *http.Request, logger log.Logg
 	}
 
 	// Check for binding errors (400)
-	// bindError prefix: "bind error: "
-	if strings.HasPrefix(err.Error(), "bind error: ") {
+	if zerrors.IsBindError(err) {
 		// Log the actual error for debugging, but return a sanitized message
 		logger.Debug("Binding error", log.P(err))
 

--- a/middleware/recover_test.go
+++ b/middleware/recover_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/alexferl/zerohttp/config"
+	zerrors "github.com/alexferl/zerohttp/internal/errors"
 	"github.com/alexferl/zerohttp/log"
 	"github.com/alexferl/zerohttp/metrics"
 	"github.com/alexferl/zerohttp/zhtest"
@@ -340,8 +341,8 @@ func TestRecover_HandlerError_ValidationError(t *testing.T) {
 
 func TestRecover_HandlerError_BindingError(t *testing.T) {
 	logger := &mockLogger{}
-	// Binding errors have prefix "bind error: "
-	bindErr := errors.New("bind error: invalid JSON")
+	// Binding errors use the BindError type
+	bindErr := &zerrors.BindError{Err: errors.New("invalid JSON")}
 	handlerErr := fmt.Errorf("handler error: %w", bindErr)
 	handler := Recover(logger)(panicHandler(handlerErr))
 	req := zhtest.NewRequest(http.MethodGet, "/").Build()
@@ -438,5 +439,63 @@ func TestRecover_Metrics(t *testing.T) {
 	}
 	if len(counter.Metrics) != 1 {
 		t.Errorf("expected 1 panic metric, got %d", len(counter.Metrics))
+	}
+}
+
+func TestRecover_CustomRequestIDHeader(t *testing.T) {
+	logger := &mockLogger{}
+	customHeader := "X-Custom-Request-ID"
+
+	cfg := config.RecoverConfig{
+		RequestIDHeader:  customHeader,
+		EnableStackTrace: false,
+	}
+
+	handler := Recover(logger, cfg)(panicHandler("test panic"))
+
+	// Test 1: Request with custom header should log that request ID
+	req1 := zhtest.NewRequest(http.MethodGet, "/").WithHeader(customHeader, "custom-req-456").Build()
+	w1 := zhtest.Serve(handler, req1)
+
+	if w1.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w1.Code)
+	}
+
+	foundCustomID := false
+	for _, fields := range logger.errorFields {
+		for _, field := range fields {
+			if field.Key == "request_id" && field.Value == "custom-req-456" {
+				foundCustomID = true
+				break
+			}
+		}
+	}
+	if !foundCustomID {
+		t.Error("expected custom request ID to be logged")
+	}
+
+	// Reset logger for next test
+	logger.errorFields = nil
+	logger.errorLogs = nil
+
+	// Test 2: Request with default X-Request-Id header should NOT use it
+	req2 := zhtest.NewRequest(http.MethodGet, "/").WithHeader("X-Request-Id", "should-be-ignored").Build()
+	w2 := zhtest.Serve(handler, req2)
+
+	if w2.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w2.Code)
+	}
+
+	foundDefaultID := false
+	for _, fields := range logger.errorFields {
+		for _, field := range fields {
+			if field.Key == "request_id" && field.Value == "should-be-ignored" {
+				foundDefaultID = true
+				break
+			}
+		}
+	}
+	if foundDefaultID {
+		t.Error("expected default X-Request-Id header to be ignored when custom header is configured")
 	}
 }

--- a/router.go
+++ b/router.go
@@ -61,7 +61,7 @@ func handleHandlerError(w http.ResponseWriter, err error) bool {
 	}
 
 	// Check for binding errors (400)
-	if strings.HasPrefix(err.Error(), "bind error: ") {
+	if IsBindError(err) {
 		w.Header().Set("Content-Type", "application/problem+json")
 		w.WriteHeader(http.StatusBadRequest)
 		response := map[string]any{
@@ -428,13 +428,12 @@ func (r *defaultRouter) createStaticHandler(filesystem fs.FS, fallback bool, api
 		}
 
 		if file, err := filesystem.Open(strings.TrimPrefix(cleanPath, "/")); err == nil {
-			defer func() {
-				if cErr := file.Close(); cErr != nil {
-					r.logger.Error("Failed to close file", log.F("error", cErr), log.F("path", cleanPath))
-				}
-			}()
+			stat, err := file.Stat()
+			if closeErr := file.Close(); closeErr != nil {
+				r.logger.Error("Failed to close file", log.F("error", closeErr), log.F("path", cleanPath))
+			}
 
-			if stat, err := file.Stat(); err == nil && !stat.IsDir() {
+			if err == nil && !stat.IsDir() {
 				http.FileServer(http.FS(filesystem)).ServeHTTP(w, req)
 				middleware.LogRequest(r.logger, r.config.RequestLogger, req, http.StatusOK, time.Since(start))
 				return

--- a/server.go
+++ b/server.go
@@ -27,6 +27,17 @@ type Server struct {
 	// route registration, middleware support, and request handling.
 	Router
 
+	// mu protects concurrent access to server fields during startup,
+	// shutdown, and configuration operations.
+	mu sync.RWMutex
+
+	// baseCtx is the root context for all requests.
+	// It is cancelled when Shutdown is called to signal request cancellation.
+	baseCtx context.Context
+
+	// cancelBaseCtx cancels the base context.
+	cancelBaseCtx context.CancelFunc
+
 	// server is the HTTP server instance for handling plain HTTP traffic.
 	// If nil, HTTP server will not be started.
 	server *http.Server
@@ -109,10 +120,6 @@ type Server struct {
 	// If nil, WebTransport support will not be enabled.
 	// The server will be started automatically when ListenAndServeTLS or Start is called.
 	webTransportServer config.WebTransportServer
-
-	// mu protects concurrent access to server fields during startup,
-	// shutdown, and configuration operations.
-	mu sync.RWMutex
 }
 
 // mergeRecoverConfig merges user config with defaults
@@ -357,6 +364,9 @@ func New(cfg ...config.Config) *Server {
 		registry = metrics.NewRegistry()
 	}
 
+	// Create base context for request cancellation during shutdown
+	baseCtx, cancelBaseCtx := context.WithCancel(context.Background())
+
 	s := &Server{
 		Router:             router,
 		server:             server,
@@ -377,6 +387,8 @@ func New(cfg ...config.Config) *Server {
 		preShutdownHooks:   c.PreShutdownHooks,
 		shutdownHooks:      c.ShutdownHooks,
 		postShutdownHooks:  c.PostShutdownHooks,
+		baseCtx:            baseCtx,
+		cancelBaseCtx:      cancelBaseCtx,
 	}
 
 	// Configure separate metrics server if ServerAddr is set
@@ -414,10 +426,16 @@ func New(cfg ...config.Config) *Server {
 
 	if s.server != nil {
 		s.server.Handler = router
+		s.server.BaseContext = func(net.Listener) context.Context {
+			return s.baseCtx
+		}
 	}
 
 	if s.tlsServer != nil {
 		s.tlsServer.Handler = router
+		s.tlsServer.BaseContext = func(net.Listener) context.Context {
+			return s.baseCtx
+		}
 	}
 
 	// Register metrics endpoint on main router only if no separate metrics server
@@ -1143,6 +1161,12 @@ func (s *Server) SetWebTransportServer(server config.WebTransportServer) {
 // Returns the first error encountered during shutdown, or nil if successful.
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.logger.Info("Shutting down server...")
+
+	// Cancel the base context to signal all requests to close
+	// This happens before pre-shutdown hooks so requests can start terminating
+	if s.cancelBaseCtx != nil {
+		s.cancelBaseCtx()
+	}
 
 	// Execute pre-shutdown hooks sequentially
 	if err := s.runPreShutdownHooks(ctx); err != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -2708,7 +2708,7 @@ func TestServer_RequestContextCancellation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create listener: %v", err)
 	}
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 
 	server.listener = listener
 	server.server.Addr = listener.Addr().String()

--- a/server_test.go
+++ b/server_test.go
@@ -2677,3 +2677,83 @@ func TestServer_MetricsDedicatedServerNotExposedOnMainServer(t *testing.T) {
 	defer cancel()
 	_ = srv.Shutdown(ctx)
 }
+
+func TestServer_RequestContextCancellation(t *testing.T) {
+	// This test verifies that when Shutdown is called, the base context
+	// is cancelled and requests can detect it via r.Context().Done()
+
+	ctxCancelled := make(chan bool, 1)
+	requestStarted := make(chan bool, 1)
+
+	server := New()
+
+	// Add a handler that waits for context cancellation
+	server.GET("/wait", HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		close(requestStarted)
+
+		select {
+		case <-r.Context().Done():
+			ctxCancelled <- true
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return nil
+		case <-time.After(5 * time.Second):
+			ctxCancelled <- false
+			w.WriteHeader(http.StatusOK)
+			return nil
+		}
+	}))
+
+	// Start server
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	defer listener.Close()
+
+	server.listener = listener
+	server.server.Addr = listener.Addr().String()
+
+	// Start server in goroutine using ListenAndServe (not Start)
+	go func() {
+		_ = server.ListenAndServe()
+	}()
+
+	// Wait for server to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Make a request in the background
+	go func() {
+		_, _ = http.Get("http://" + listener.Addr().String() + "/wait")
+	}()
+
+	// Wait for request to start
+	select {
+	case <-requestStarted:
+		// Good, request started
+	case <-time.After(2 * time.Second):
+		t.Fatal("request did not start in time")
+	}
+
+	// Small delay to ensure handler is waiting
+	time.Sleep(100 * time.Millisecond)
+
+	// Shutdown the server - this should cancel the base context
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err = server.Shutdown(shutdownCtx)
+	if err != nil {
+		t.Errorf("shutdown error: %v", err)
+	}
+
+	// Wait to see if the handler detected context cancellation
+	select {
+	case wasCancelled := <-ctxCancelled:
+		if !wasCancelled {
+			t.Error("handler did not receive context cancellation signal")
+		}
+		// Success - context was cancelled
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for handler to detect cancellation")
+	}
+}

--- a/validate.go
+++ b/validate.go
@@ -17,6 +17,8 @@ import (
 	"time"
 	"unicode"
 	"unicode/utf8"
+
+	zerrors "github.com/alexferl/zerohttp/internal/errors"
 )
 
 // Validate is the default validator instance used by the package
@@ -158,7 +160,7 @@ func BindAndValidate(r *http.Request, dst any) error {
 
 	if bindErr != nil {
 		// Wrap as binding error (400)
-		return &bindError{err: bindErr}
+		return &zerrors.BindError{Err: bindErr}
 	}
 
 	// Validate
@@ -169,27 +171,17 @@ func BindAndValidate(r *http.Request, dst any) error {
 	return nil
 }
 
-// bindError wraps binding errors to distinguish them from validation errors.
-// The default error handler uses this to return 400 instead of 422.
-type bindError struct {
-	err error
-}
+// BindError is an alias for internal/errors.BindError
+type BindError = zerrors.BindError
 
-func (e *bindError) Error() string {
-	return fmt.Sprintf("bind error: %v", e.err)
-}
-
-func (e *bindError) Unwrap() error {
-	return e.err
+// IsBindError checks if an error is a binding error (should return 400).
+func IsBindError(err error) bool {
+	return zerrors.IsBindError(err)
 }
 
 // IsBindingError checks if an error is a binding error (should return 400).
 func IsBindingError(err error) bool {
-	if err == nil {
-		return false
-	}
-	errStr := err.Error()
-	return len(errStr) >= 11 && errStr[:11] == "bind error:"
+	return IsBindError(err)
 }
 
 // IsValidationError checks if an error is a validation error (should return 422).

--- a/validate_test.go
+++ b/validate_test.go
@@ -652,9 +652,9 @@ func TestBindError_Unwrap(t *testing.T) {
 		t.Error("expected IsBindingError(nil) to be false")
 	}
 	// Test errors.As works with wrapped error
-	var bindErr *bindError
+	var bindErr *BindError
 	if !errors.As(err, &bindErr) {
-		t.Error("expected error to be bindError")
+		t.Error("expected error to be BindError")
 	}
 	// Unwrap should return the inner error
 	if bindErr.Unwrap() == nil {


### PR DESCRIPTION
- Add configurable RequestIDHeader to RecoverConfig instead of hardcoded value
- Fix file handle leak in static handler with explicit Close after stat check
- Replace string-based error detection with typed BindError in internal/errors package
- Simplify JWT claims handling with normalizeClaims helper function
- Document gauge precision limitation (3 decimal places) in metrics
- Improve JWT nil TokenStore error message to indicate configuration issue
- Add request context cancellation wiring for graceful shutdown propagation