### PR TITLE
fix: remove panic-based error propagation

### DIFF
--- a/middleware/recover.go
+++ b/middleware/recover.go
@@ -1,29 +1,22 @@
 package middleware
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/alexferl/zerohttp/config"
-	zerrors "github.com/alexferl/zerohttp/internal/errors"
 	"github.com/alexferl/zerohttp/internal/problem"
 	"github.com/alexferl/zerohttp/log"
 	"github.com/alexferl/zerohttp/metrics"
 )
 
-// ValidationErrorer is an alias for internal/errors.ValidationErrorer.
-type ValidationErrorer = zerrors.ValidationErrorer
-
 // Recover is a middleware that recovers from panics, logs the panic (and a backtrace),
 // and returns HTTP 500 if possible. It prints a request ID if one is provided.
 //
-// It also handles expected errors from handlers:
-//   - Validation errors (422 Unprocessable Entity)
-//   - Binding errors (400 Bad Request)
+// Note: Handler errors are handled directly by the router without panic.
+// This middleware only catches actual panics from unexpected errors or explicit panic() calls.
 func Recover(logger log.Logger, cfg ...config.RecoverConfig) func(http.Handler) http.Handler {
 	c := config.DefaultRecoverConfig
 	if len(cfg) > 0 {
@@ -42,15 +35,6 @@ func Recover(logger log.Logger, cfg ...config.RecoverConfig) func(http.Handler) 
 				if rvr := recover(); rvr != nil {
 					if rvr == http.ErrAbortHandler {
 						panic(rvr)
-					}
-
-					// Check if this is a handler error (not a real panic)
-					if err, ok := rvr.(error); ok {
-						if unwrapped := unwrapHandlerError(err); unwrapped != nil {
-							// Handle expected errors (validation, binding)
-							handleExpectedError(w, r, logger, unwrapped)
-							return
-						}
 					}
 
 					metrics.SafeRegistry(metrics.GetRegistry(r.Context())).Counter("recover_panics_total").Inc()
@@ -75,49 +59,12 @@ func Recover(logger log.Logger, cfg ...config.RecoverConfig) func(http.Handler) 
 					logger.Error("Recovered from panic", fields...)
 
 					if r.Header.Get("Connection") != "Upgrade" {
-						w.WriteHeader(http.StatusInternalServerError)
+						detail := problem.NewDetail(http.StatusInternalServerError, "Internal server error")
+						_ = detail.Render(w)
 					}
 				}
 			}()
 			next.ServeHTTP(w, r)
 		})
 	}
-}
-
-// unwrapHandlerError checks if the error is a handler error wrapper
-// and returns the underlying error.
-func unwrapHandlerError(err error) error {
-	// Handler errors are wrapped as "handler error: %w"
-	if !strings.HasPrefix(err.Error(), "handler error: ") {
-		return nil
-	}
-	return errors.Unwrap(err)
-}
-
-// handleExpectedError handles validation and binding errors
-// by returning appropriate HTTP status codes without logging as ERROR.
-func handleExpectedError(w http.ResponseWriter, _ *http.Request, logger log.Logger, err error) {
-	// Check for validation errors (422)
-	var verr ValidationErrorer
-	if errors.As(err, &verr) {
-		detail := problem.NewDetail(http.StatusUnprocessableEntity, "Validation failed")
-		detail.Set("errors", verr.ValidationErrors())
-		_ = detail.Render(w)
-		return
-	}
-
-	// Check for binding errors (400)
-	if zerrors.IsBindError(err) {
-		// Log the actual error for debugging, but return a sanitized message
-		logger.Debug("Binding error", log.P(err))
-
-		detail := problem.NewDetail(http.StatusBadRequest, "Invalid request body")
-		_ = detail.Render(w)
-		return
-	}
-
-	// Unknown error type - treat as 500
-	logger.Error("Unexpected handler error", log.P(err))
-	detail := problem.NewDetail(http.StatusInternalServerError, "Internal server error")
-	_ = detail.Render(w)
 }

--- a/middleware/recover_test.go
+++ b/middleware/recover_test.go
@@ -3,14 +3,12 @@ package middleware
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/alexferl/zerohttp/config"
-	zerrors "github.com/alexferl/zerohttp/internal/errors"
 	"github.com/alexferl/zerohttp/log"
 	"github.com/alexferl/zerohttp/metrics"
 	"github.com/alexferl/zerohttp/zhtest"
@@ -304,89 +302,6 @@ func TestRecover_PanicFieldLogging(t *testing.T) {
 	}
 }
 
-// mockValidationErrors implements ValidationErrorer interface
-type mockValidationErrors map[string][]string
-
-func (m mockValidationErrors) Error() string                         { return "validation failed" }
-func (m mockValidationErrors) ValidationErrors() map[string][]string { return m }
-
-func TestRecover_HandlerError_ValidationError(t *testing.T) {
-	logger := &mockLogger{}
-	// Handler errors are wrapped as: fmt.Errorf("handler error: %w", err)
-	validationErr := mockValidationErrors{"field": {"required"}}
-	handlerErr := fmt.Errorf("handler error: %w", validationErr)
-	handler := Recover(logger)(panicHandler(handlerErr))
-	req := zhtest.NewRequest(http.MethodGet, "/").Build()
-	w := zhtest.Serve(handler, req)
-
-	// Should return 422, not 500
-	if w.Code != http.StatusUnprocessableEntity {
-		t.Errorf("Expected 422 Unprocessable Entity, got %d", w.Code)
-	}
-
-	// Should NOT log as error
-	if len(logger.errorLogs) != 0 {
-		t.Errorf("Expected no error logs for validation errors, got %d", len(logger.errorLogs))
-	}
-
-	// Check response body contains validation errors
-	body := w.Body.String()
-	if !strings.Contains(body, `"status":422`) {
-		t.Errorf("Expected status 422 in response body, got: %s", body)
-	}
-	if !strings.Contains(body, `"field":["required"]`) {
-		t.Errorf("Expected validation errors in response body, got: %s", body)
-	}
-}
-
-func TestRecover_HandlerError_BindingError(t *testing.T) {
-	logger := &mockLogger{}
-	// Binding errors use the BindError type
-	bindErr := &zerrors.BindError{Err: errors.New("invalid JSON")}
-	handlerErr := fmt.Errorf("handler error: %w", bindErr)
-	handler := Recover(logger)(panicHandler(handlerErr))
-	req := zhtest.NewRequest(http.MethodGet, "/").Build()
-	w := zhtest.Serve(handler, req)
-
-	// Should return 400, not 500
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("Expected 400 Bad Request, got %d", w.Code)
-	}
-
-	// Should NOT log as error
-	if len(logger.errorLogs) != 0 {
-		t.Errorf("Expected no error logs for binding errors, got %d", len(logger.errorLogs))
-	}
-
-	// Check response body
-	body := w.Body.String()
-	if !strings.Contains(body, `"status":400`) {
-		t.Errorf("Expected status 400 in response body, got: %s", body)
-	}
-	if !strings.Contains(body, `"detail":"Invalid request body"`) {
-		t.Errorf("Expected sanitized detail in response body, got: %s", body)
-	}
-}
-
-func TestRecover_HandlerError_UnknownError(t *testing.T) {
-	logger := &mockLogger{}
-	// Unknown handler error (not validation or binding)
-	unknownErr := errors.New("handler error: some unexpected error")
-	handler := Recover(logger)(panicHandler(unknownErr))
-	req := zhtest.NewRequest(http.MethodGet, "/").Build()
-	w := zhtest.Serve(handler, req)
-
-	// Should return 500
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("Expected 500 Internal Server Error, got %d", w.Code)
-	}
-
-	// Should log as error
-	if len(logger.errorLogs) != 1 {
-		t.Errorf("Expected 1 error log for unknown handler errors, got %d", len(logger.errorLogs))
-	}
-}
-
 func TestRecover_NonHandlerError(t *testing.T) {
 	logger := &mockLogger{}
 	// Regular panic (not a handler error wrapper)
@@ -402,6 +317,19 @@ func TestRecover_NonHandlerError(t *testing.T) {
 	// Should log as error with stack trace
 	if len(logger.errorLogs) != 1 {
 		t.Errorf("Expected 1 error log for panics, got %d", len(logger.errorLogs))
+	}
+
+	// Should return problem detail response body
+	contentType := w.Header().Get("Content-Type")
+	if !strings.Contains(contentType, "application/problem+json") {
+		t.Errorf("Expected Content-Type to contain application/problem+json, got %s", contentType)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `"status":500`) {
+		t.Errorf("Expected body to contain status 500, got %s", body)
+	}
+	if !strings.Contains(body, `"title":"Internal Server Error"`) {
+		t.Errorf("Expected body to contain title 'Internal Server Error', got %s", body)
 	}
 }
 

--- a/router.go
+++ b/router.go
@@ -19,10 +19,12 @@ import (
 	"github.com/alexferl/zerohttp/middleware"
 )
 
-// HandlerFunc is a handler function that returns an error
+// HandlerFunc is a handler function that returns an error.
+// Errors are handled directly without panic propagation.
 type HandlerFunc func(w http.ResponseWriter, r *http.Request) error
 
-// ServeHTTP implements http.Handler interface
+// ServeHTTP implements http.Handler interface.
+// It handles all errors directly; no panic propagation is used.
 func (h HandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// For HEAD requests, wrap the response writer to discard body writes.
 	// This prevents HTTP/2 "request body closed" errors when handlers
@@ -32,19 +34,14 @@ func (h HandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h(w, r); err != nil {
-		// Handle validation and binding errors directly
-		// This ensures consistent behavior regardless of Recover middleware
-		if handleHandlerError(w, err) {
-			return
-		}
-		// For other errors, panic to let Recover middleware handle it
-		panic(fmt.Errorf("handler error: %w", err))
+		// Handle all errors directly - no panic propagation
+		handleHandlerError(w, err)
 	}
 }
 
-// handleHandlerError handles validation and binding errors.
-// Returns true if the error was handled, false otherwise.
-func handleHandlerError(w http.ResponseWriter, err error) bool {
+// handleHandlerError handles all handler errors.
+// Returns appropriate HTTP responses for different error types.
+func handleHandlerError(w http.ResponseWriter, err error) {
 	// Check for validation errors (422)
 	var verr ValidationErrorer
 	if errors.As(err, &verr) {
@@ -57,7 +54,7 @@ func handleHandlerError(w http.ResponseWriter, err error) bool {
 			"errors": verr.ValidationErrors(),
 		}
 		_ = json.NewEncoder(w).Encode(response)
-		return true
+		return
 	}
 
 	// Check for binding errors (400)
@@ -70,10 +67,18 @@ func handleHandlerError(w http.ResponseWriter, err error) bool {
 			"detail": "Invalid request body",
 		}
 		_ = json.NewEncoder(w).Encode(response)
-		return true
+		return
 	}
 
-	return false
+	// For all other errors, return 500 Internal Server Error
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(http.StatusInternalServerError)
+	response := map[string]any{
+		"title":  "Internal Server Error",
+		"status": http.StatusInternalServerError,
+		"detail": "An unexpected error occurred",
+	}
+	_ = json.NewEncoder(w).Encode(response)
 }
 
 // headResponseWriter wraps a ResponseWriter and discards body writes for HEAD requests

--- a/router_test.go
+++ b/router_test.go
@@ -46,23 +46,7 @@ func TestHandlerFunc(t *testing.T) {
 	})
 
 	t.Run("error case", func(t *testing.T) {
-		var panicked bool
-		var panicMsg string
-
-		recoveryMW := func(next http.Handler) http.Handler {
-			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				defer func() {
-					if rec := recover(); rec != nil {
-						panicked = true
-						panicMsg = fmt.Sprintf("%v", rec)
-						w.WriteHeader(http.StatusInternalServerError)
-					}
-				}()
-				next.ServeHTTP(w, r)
-			})
-		}
-
-		router := NewRouter(recoveryMW)
+		router := NewRouter()
 		handler := HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 			return fmt.Errorf("test error")
 		})
@@ -72,12 +56,7 @@ func TestHandlerFunc(t *testing.T) {
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 
-		if !panicked {
-			t.Error("Expected handler error to cause panic")
-		}
-		if !strings.Contains(panicMsg, "test error") {
-			t.Errorf("Expected panic message to contain 'test error', got '%s'", panicMsg)
-		}
+		// Errors are now handled directly without panic
 		zhtest.AssertWith(t, w).Status(http.StatusInternalServerError)
 	})
 


### PR DESCRIPTION
Handler errors are now handled directly by the router instead of panicking. Simplifies error flow and removes handler error unwrapping logic from Recover middleware.

Changes:
  - router.ServeHTTP: handle all errors directly, no panic propagation
  - handleHandlerError: return 500 problem detail for unhandled errors
  - Recover middleware: use problem.NewDetail for 500 responses
  - Updated tests to reflect new behavior

The HandlerFunc signature remains unchanged: func(w,r) error