### PR TITLE
feat: add IP allowlist support to pprof

### DIFF
--- a/examples/pprof/main.go
+++ b/examples/pprof/main.go
@@ -42,6 +42,18 @@ func main() {
 	// cfg.EnableMutex = false
 	// pp := pprof.New(app, cfg)
 
+	// Example 5: Allow external access (custom IP allowlist)
+	// By default, pprof is only accessible from localhost (127.0.0.1, ::1)
+	// To allow access from specific IPs or CIDR ranges:
+	// cfg := pprof.DefaultConfig
+	// cfg.AllowedIPs = []string{"10.0.0.0/8", "192.168.1.100"}
+	// pp := pprof.New(app, cfg)
+
+	// Example 6: Allow any IP (disable IP restriction) - use with caution!
+	// cfg := pprof.DefaultConfig
+	// cfg.AllowedIPs = []string{} // empty slice = allow any IP
+	// pp := pprof.New(app, cfg)
+
 	log.Printf("pprof endpoints available at http://localhost:8080%s/", pp.Config.Prefix)
 	log.Fatal(app.Start())
 }

--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -3,8 +3,10 @@ package pprof
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"net"
 	"net/http"
 	stdpprof "net/http/pprof"
+	"strings"
 
 	zh "github.com/alexferl/zerohttp"
 	"github.com/alexferl/zerohttp/log"
@@ -69,6 +71,12 @@ type Config struct {
 	// Set to &AuthConfig{} with empty Username/Password to disable auth.
 	// Default: nil (auto-generates secure password)
 	Auth *AuthConfig
+
+	// AllowedIPs restricts access to specific IPs or CIDR ranges.
+	// Supports IPv4 and IPv6 addresses and CIDR notation (e.g., "10.0.0.0/8", "192.168.1.100").
+	// Default: []string{"127.0.0.1/8", "::1/128"} (localhost only)
+	// Set to empty slice to allow any IP (with auth still required).
+	AllowedIPs []string
 }
 
 // AuthConfig holds basic authentication configuration
@@ -96,16 +104,7 @@ var DefaultConfig = Config{
 	EnableBlock:        true,
 	EnableMutex:        true,
 	Auth:               nil,
-}
-
-// generateRandomPassword generates a secure random password
-func generateRandomPassword() string {
-	b := make([]byte, 24)
-	if _, err := rand.Read(b); err != nil {
-		// Fallback to a default if crypto/rand fails (extremely unlikely)
-		return "pprof-fallback-password-change-me"
-	}
-	return base64.URLEncoding.EncodeToString(b)
+	AllowedIPs:         []string{"127.0.0.1/8", "::1/128"}, // localhost only by default
 }
 
 // New creates and registers all pprof endpoints with the provided configuration.
@@ -146,23 +145,50 @@ func New(app *zh.Server, cfg Config) *PProf {
 		)
 	}
 
+	// Parse allowed IPs (nil means use default localhost-only)
+	allowedIPs := cfg.AllowedIPs
+	if allowedIPs == nil {
+		allowedIPs = []string{"127.0.0.1/8", "::1/128"}
+	}
+
+	var allowedNets []*net.IPNet
+	if len(allowedIPs) > 0 {
+		var err error
+		allowedNets, err = parseAllowedIPs(allowedIPs)
+		if err != nil {
+			logger.Error("failed to parse allowed IPs, falling back to localhost only",
+				log.F("error", err),
+			)
+			allowedNets, _ = parseAllowedIPs([]string{"127.0.0.1/8", "::1/128"})
+		}
+	}
+
 	pp := &PProf{
 		Config: cfg,
 		Auth:   auth,
 	}
 
+	// Build middleware chain: IP check -> Auth -> Handler
 	wrapFunc := func(fn http.HandlerFunc) zh.HandlerFunc {
+		handler := adaptHandlerFunc(fn)
 		if auth != nil {
-			return authHandlerFunc(auth, fn)
+			handler = authHandlerFunc(auth, fn)
 		}
-		return adaptHandlerFunc(fn)
+		if len(allowedNets) > 0 {
+			handler = ipCheckHandler(handler, allowedNets, logger, prefix)
+		}
+		return handler
 	}
 
 	wrapHandler := func(h http.Handler) zh.HandlerFunc {
+		handler := adaptHandler(h)
 		if auth != nil {
-			return authHandler(auth, h)
+			handler = authHandler(auth, h)
 		}
-		return adaptHandler(h)
+		if len(allowedNets) > 0 {
+			handler = ipCheckHandler(handler, allowedNets, logger, prefix)
+		}
+		return handler
 	}
 
 	if cfg.EnableIndex {
@@ -198,6 +224,16 @@ func New(app *zh.Server, cfg Config) *PProf {
 	}
 
 	return pp
+}
+
+// generateRandomPassword generates a secure random password
+func generateRandomPassword() string {
+	b := make([]byte, 24)
+	if _, err := rand.Read(b); err != nil {
+		// Fallback to a default if crypto/rand fails (extremely unlikely)
+		return "pprof-fallback-password-change-me"
+	}
+	return base64.URLEncoding.EncodeToString(b)
 }
 
 // adaptHandler adapts a standard http.Handler to zerohttp's HandlerFunc
@@ -242,4 +278,101 @@ func authHandlerFunc(auth *AuthConfig, fn http.HandlerFunc) zh.HandlerFunc {
 		fn(w, r)
 		return nil
 	}
+}
+
+// ipCheckHandler wraps a handler with IP allowlist checking
+func ipCheckHandler(next zh.HandlerFunc, allowedNets []*net.IPNet, logger log.Logger, prefix string) zh.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		clientIP := extractClientIP(r, false)
+
+		if !isIPAllowed(clientIP, allowedNets) {
+			logger.Warn("pprof access denied: IP not in allowlist",
+				log.F("client_ip", clientIP),
+				log.F("endpoint", prefix),
+			)
+			w.WriteHeader(http.StatusForbidden)
+			return nil
+		}
+
+		return next(w, r)
+	}
+}
+
+// parseAllowedIPs parses a list of IP addresses or CIDR ranges.
+// Returns a slice of *net.IPNet for CIDR matching.
+func parseAllowedIPs(ips []string) ([]*net.IPNet, error) {
+	nets := make([]*net.IPNet, 0, len(ips))
+	for _, ipStr := range ips {
+		ipStr = strings.TrimSpace(ipStr)
+		if ipStr == "" {
+			continue
+		}
+
+		// Try parsing as CIDR first
+		_, ipNet, err := net.ParseCIDR(ipStr)
+		if err == nil {
+			nets = append(nets, ipNet)
+			continue
+		}
+
+		// Try parsing as single IP
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			return nil, err
+		}
+
+		// Convert single IP to /32 (IPv4) or /128 (IPv6)
+		var mask net.IPMask
+		if ip.To4() != nil {
+			mask = net.CIDRMask(32, 32)
+		} else {
+			mask = net.CIDRMask(128, 128)
+		}
+		nets = append(nets, &net.IPNet{IP: ip, Mask: mask})
+	}
+	return nets, nil
+}
+
+// isIPAllowed checks if the given IP is in the allowed list.
+func isIPAllowed(clientIP string, allowedNets []*net.IPNet) bool {
+	// Parse the client IP
+	ip := net.ParseIP(clientIP)
+	if ip == nil {
+		return false
+	}
+
+	// Check if IP matches any allowed network
+	for _, ipNet := range allowedNets {
+		if ipNet.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// extractClientIP extracts the client IP from the request.
+// It handles X-Forwarded-For and X-Real-IP headers when behind a proxy.
+func extractClientIP(r *http.Request, trustProxy bool) string {
+	if trustProxy {
+		// Check X-Forwarded-For header (may contain multiple IPs, use the first)
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			ips := strings.Split(xff, ",")
+			if len(ips) > 0 {
+				return strings.TrimSpace(ips[0])
+			}
+		}
+
+		// Check X-Real-IP header
+		if xri := r.Header.Get("X-Real-Ip"); xri != "" {
+			return xri
+		}
+	}
+
+	// Fall back to RemoteAddr
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		// If SplitHostPort fails, RemoteAddr might not have a port
+		return r.RemoteAddr
+	}
+	return host
 }

--- a/pprof/pprof_test.go
+++ b/pprof/pprof_test.go
@@ -389,7 +389,7 @@ func TestIPAllowlistDisabled(t *testing.T) {
 	// Empty slice disables IP checking
 	app := zh.New()
 	cfg := DefaultConfig
-	cfg.Auth = &AuthConfig{} // disable auth for this test
+	cfg.Auth = &AuthConfig{}    // disable auth for this test
 	cfg.AllowedIPs = []string{} // empty = allow any IP
 	New(app, cfg)
 

--- a/pprof/pprof_test.go
+++ b/pprof/pprof_test.go
@@ -3,6 +3,7 @@ package pprof
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	zh "github.com/alexferl/zerohttp"
@@ -44,9 +45,33 @@ func setupPProfWithAuth(t *testing.T, username, password string) (*zh.Server, *P
 }
 
 // makeRequest makes an HTTP request to the test server and returns the response.
+// Requests come from localhost (127.0.0.1) by default to pass IP allowlist checks.
 func makeRequest(t *testing.T, app *zh.Server, method, path string, username, password string) *httptest.ResponseRecorder {
 	t.Helper()
 	req := httptest.NewRequest(method, path, nil)
+	// Set RemoteAddr to localhost to pass default IP allowlist
+	req.RemoteAddr = "127.0.0.1:1234"
+	if username != "" || password != "" {
+		req.SetBasicAuth(username, password)
+	}
+	rec := httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+	return rec
+}
+
+// makeRequestFromIP makes an HTTP request from a specific IP address.
+// For IPv6 addresses, use the bracket notation like "[::1]".
+func makeRequestFromIP(t *testing.T, app *zh.Server, method, path, clientIP, username, password string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	// Format RemoteAddr properly for IPv4 and IPv6
+	if strings.Contains(clientIP, ":") {
+		// IPv6 - needs brackets
+		req.RemoteAddr = "[" + clientIP + "]:1234"
+	} else {
+		// IPv4
+		req.RemoteAddr = clientIP + ":1234"
+	}
 	if username != "" || password != "" {
 		req.SetBasicAuth(username, password)
 	}
@@ -91,6 +116,9 @@ func TestDefaultConfig(t *testing.T) {
 	}
 	if DefaultConfig.Auth != nil {
 		t.Error("expected Auth to be nil")
+	}
+	if len(DefaultConfig.AllowedIPs) != 2 {
+		t.Errorf("expected AllowedIPs to have 2 entries (localhost only), got %d", len(DefaultConfig.AllowedIPs))
 	}
 }
 
@@ -304,9 +332,123 @@ func TestDisabledAuth(t *testing.T) {
 		t.Error("expected Auth to be nil when disabled")
 	}
 
-	// Test without auth - should succeed
+	// Test without auth - should succeed (from localhost)
 	rec := makeRequest(t, app, http.MethodGet, "/debug/pprof/", "", "")
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected status %d with auth disabled, got %d", http.StatusOK, rec.Code)
+	}
+}
+
+func TestIPAllowlistDefault(t *testing.T) {
+	// Default config should only allow localhost
+	app := zh.New()
+	cfg := DefaultConfig
+	cfg.Auth = &AuthConfig{} // disable auth for this test
+	New(app, cfg)
+
+	// Request from localhost should succeed
+	rec := makeRequestFromIP(t, app, http.MethodGet, "/debug/pprof/", "127.0.0.1", "", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d from localhost, got %d", http.StatusOK, rec.Code)
+	}
+
+	// Request from external IP should be forbidden
+	rec = makeRequestFromIP(t, app, http.MethodGet, "/debug/pprof/", "192.168.1.100", "", "")
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected status %d from external IP, got %d", http.StatusForbidden, rec.Code)
+	}
+}
+
+func TestIPAllowlistCustom(t *testing.T) {
+	app := zh.New()
+	cfg := DefaultConfig
+	cfg.Auth = &AuthConfig{} // disable auth for this test
+	cfg.AllowedIPs = []string{"192.168.1.0/24", "10.0.0.100"}
+	New(app, cfg)
+
+	// Request from allowed CIDR should succeed
+	rec := makeRequestFromIP(t, app, http.MethodGet, "/debug/pprof/", "192.168.1.50", "", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d from allowed CIDR, got %d", http.StatusOK, rec.Code)
+	}
+
+	// Request from allowed single IP should succeed
+	rec = makeRequestFromIP(t, app, http.MethodGet, "/debug/pprof/", "10.0.0.100", "", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d from allowed IP, got %d", http.StatusOK, rec.Code)
+	}
+
+	// Request from disallowed IP should be forbidden
+	rec = makeRequestFromIP(t, app, http.MethodGet, "/debug/pprof/", "192.168.2.1", "", "")
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected status %d from disallowed IP, got %d", http.StatusForbidden, rec.Code)
+	}
+}
+
+func TestIPAllowlistDisabled(t *testing.T) {
+	// Empty slice disables IP checking
+	app := zh.New()
+	cfg := DefaultConfig
+	cfg.Auth = &AuthConfig{} // disable auth for this test
+	cfg.AllowedIPs = []string{} // empty = allow any IP
+	New(app, cfg)
+
+	// Request from any IP should succeed
+	rec := makeRequestFromIP(t, app, http.MethodGet, "/debug/pprof/", "8.8.8.8", "", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d when IP allowlist disabled, got %d", http.StatusOK, rec.Code)
+	}
+}
+
+func TestIPAllowlistWithAuth(t *testing.T) {
+	// Test that IP check happens before auth
+	app := zh.New()
+	cfg := DefaultConfig
+	cfg.Auth = &AuthConfig{Username: "admin", Password: "secret"}
+	cfg.AllowedIPs = []string{"127.0.0.1/32"}
+	New(app, cfg)
+
+	// Request from disallowed IP should get 403 before auth check
+	rec := makeRequestFromIP(t, app, http.MethodGet, "/debug/pprof/", "192.168.1.1", "admin", "secret")
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected status %d from disallowed IP, got %d", http.StatusForbidden, rec.Code)
+	}
+
+	// Request from allowed IP with wrong auth should get 401
+	rec = makeRequestFromIP(t, app, http.MethodGet, "/debug/pprof/", "127.0.0.1", "wrong", "wrong")
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d with wrong auth, got %d", http.StatusUnauthorized, rec.Code)
+	}
+
+	// Request from allowed IP with correct auth should succeed
+	rec = makeRequestFromIP(t, app, http.MethodGet, "/debug/pprof/", "127.0.0.1", "admin", "secret")
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d with correct auth, got %d", http.StatusOK, rec.Code)
+	}
+}
+
+func TestIPAllowlistIPv6(t *testing.T) {
+	app := zh.New()
+	cfg := DefaultConfig
+	cfg.Auth = &AuthConfig{} // disable auth for this test
+	cfg.AllowedIPs = []string{"::1/128", "2001:db8::/32"}
+	New(app, cfg)
+
+	// Request from localhost IPv6 should succeed
+	rec := makeRequestFromIP(t, app, http.MethodGet, "/debug/pprof/", "::1", "", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d from ::1, got %d", http.StatusOK, rec.Code)
+	}
+
+	// Request from allowed IPv6 CIDR should succeed
+	rec = makeRequestFromIP(t, app, http.MethodGet, "/debug/pprof/", "2001:db8::1", "", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d from allowed IPv6, got %d", http.StatusOK, rec.Code)
+	}
+
+	// Request from disallowed IPv6 should be forbidden
+	rec = makeRequestFromIP(t, app, http.MethodGet, "/debug/pprof/", "2001:db9::1", "", "")
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected status %d from disallowed IPv6, got %d", http.StatusForbidden, rec.Code)
 	}
 }


### PR DESCRIPTION
Add AllowedIPs config to restrict pprof access by source IP. Defaults to localhost-only (127.0.0.1/8, ::1/128) for security. Supports CIDR notation and IPv6. IP check runs before auth.