### PR TITLE
feat: add cardinality limits to metrics registry

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -168,30 +168,53 @@ func (nopHistogram) Observe(float64)                     {}
 func (nopHistogram) WithLabelValues(...string) Histogram { return nopHistogram{} }
 
 // NewRegistry creates a new metrics registry.
-func NewRegistry() Registry {
-	return &registry{
-		counters:   make(map[string]*counterVec),
-		gauges:     make(map[string]*gaugeVec),
-		histograms: make(map[string]*histogramVec),
-		collectors: make([]Collector, 0),
+// Default max cardinality is 1000 unique label combinations per metric.
+// Pass RegistryConfig{MaxCardinality: N} to customize.
+func NewRegistry(cfg ...RegistryConfig) Registry {
+	c := DefaultRegistryConfig
+	if len(cfg) > 0 {
+		c = cfg[0]
 	}
+	return &registry{
+		counters:       make(map[string]*counterVec),
+		gauges:         make(map[string]*gaugeVec),
+		histograms:     make(map[string]*histogramVec),
+		collectors:     make([]Collector, 0),
+		maxCardinality: c.MaxCardinality,
+	}
+}
+
+// RegistryConfig holds optional configuration for the registry.
+type RegistryConfig struct {
+	// MaxCardinality limits the number of unique label combinations per metric.
+	// When exceeded, oldest entries are evicted (FIFO).
+	// Default: 1000. Set to 0 for unlimited (not recommended with user-controlled labels).
+	MaxCardinality int
+}
+
+// DefaultRegistryConfig is the default registry configuration.
+var DefaultRegistryConfig = RegistryConfig{
+	MaxCardinality: 1000,
 }
 
 // registry is the internal implementation of Registry.
 type registry struct {
-	mu         sync.RWMutex
-	counters   map[string]*counterVec
-	gauges     map[string]*gaugeVec
-	histograms map[string]*histogramVec
-	collectors []Collector
+	mu             sync.RWMutex
+	counters       map[string]*counterVec
+	gauges         map[string]*gaugeVec
+	histograms     map[string]*histogramVec
+	collectors     []Collector
+	maxCardinality int // 0 = unlimited, default 1000
 }
 
 // counterVec holds counters with different label values.
 type counterVec struct {
-	name   string
-	labels []string
-	mu     sync.RWMutex
-	values map[string]*counter
+	name           string
+	labels         []string
+	mu             sync.RWMutex
+	values         map[string]*counter
+	insertOrder    []string // tracks insertion order for LRU eviction
+	maxCardinality int      // 0 = unlimited
 }
 
 // counter is a single counter instance.
@@ -242,17 +265,28 @@ func (cv *counterVec) WithLabelValues(values ...string) Counter {
 		return c
 	}
 
+	// Check cardinality limit
+	if cv.maxCardinality > 0 && len(cv.values) >= cv.maxCardinality {
+		// Evict oldest entry (FIFO)
+		oldestKey := cv.insertOrder[0]
+		delete(cv.values, oldestKey)
+		cv.insertOrder = cv.insertOrder[1:]
+	}
+
 	c := &counter{}
 	cv.values[key] = c
+	cv.insertOrder = append(cv.insertOrder, key)
 	return c
 }
 
 // gaugeVec holds gauges with different label values.
 type gaugeVec struct {
-	name   string
-	labels []string
-	mu     sync.RWMutex
-	values map[string]*gauge
+	name           string
+	labels         []string
+	mu             sync.RWMutex
+	values         map[string]*gauge
+	insertOrder    []string // tracks insertion order for LRU eviction
+	maxCardinality int      // 0 = unlimited
 }
 
 // gauge is a single gauge instance.
@@ -327,18 +361,29 @@ func (gv *gaugeVec) WithLabelValues(values ...string) Gauge {
 		return g
 	}
 
+	// Check cardinality limit
+	if gv.maxCardinality > 0 && len(gv.values) >= gv.maxCardinality {
+		// Evict oldest entry (FIFO)
+		oldestKey := gv.insertOrder[0]
+		delete(gv.values, oldestKey)
+		gv.insertOrder = gv.insertOrder[1:]
+	}
+
 	g := &gauge{}
 	gv.values[key] = g
+	gv.insertOrder = append(gv.insertOrder, key)
 	return g
 }
 
 // histogramVec holds histograms with different label values.
 type histogramVec struct {
-	name    string
-	labels  []string
-	buckets []float64
-	mu      sync.RWMutex
-	values  map[string]*histogram
+	name           string
+	labels         []string
+	buckets        []float64
+	mu             sync.RWMutex
+	values         map[string]*histogram
+	insertOrder    []string // tracks insertion order for LRU eviction
+	maxCardinality int      // 0 = unlimited
 }
 
 // histogram is a single histogram instance.
@@ -388,11 +433,20 @@ func (hv *histogramVec) WithLabelValues(values ...string) Histogram {
 		return h
 	}
 
+	// Check cardinality limit
+	if hv.maxCardinality > 0 && len(hv.values) >= hv.maxCardinality {
+		// Evict oldest entry (FIFO)
+		oldestKey := hv.insertOrder[0]
+		delete(hv.values, oldestKey)
+		hv.insertOrder = hv.insertOrder[1:]
+	}
+
 	h := &histogram{
 		buckets: hv.buckets,
 		counts:  make([]uint64, len(hv.buckets)),
 	}
 	hv.values[key] = h
+	hv.insertOrder = append(hv.insertOrder, key)
 	return h
 }
 
@@ -405,9 +459,11 @@ func (r *registry) Counter(name string, labels ...string) Counter {
 	}
 
 	vec := &counterVec{
-		name:   name,
-		labels: labels,
-		values: make(map[string]*counter),
+		name:           name,
+		labels:         labels,
+		values:         make(map[string]*counter),
+		insertOrder:    make([]string, 0),
+		maxCardinality: r.maxCardinality,
 	}
 	r.counters[name] = vec
 	return vec
@@ -422,9 +478,11 @@ func (r *registry) Gauge(name string, labels ...string) Gauge {
 	}
 
 	vec := &gaugeVec{
-		name:   name,
-		labels: labels,
-		values: make(map[string]*gauge),
+		name:           name,
+		labels:         labels,
+		values:         make(map[string]*gauge),
+		insertOrder:    make([]string, 0),
+		maxCardinality: r.maxCardinality,
 	}
 	r.gauges[name] = vec
 	return vec
@@ -443,10 +501,12 @@ func (r *registry) Histogram(name string, buckets []float64, labels ...string) H
 	}
 
 	vec := &histogramVec{
-		name:    name,
-		labels:  labels,
-		buckets: buckets,
-		values:  make(map[string]*histogram),
+		name:           name,
+		labels:         labels,
+		buckets:        buckets,
+		values:         make(map[string]*histogram),
+		insertOrder:    make([]string, 0),
+		maxCardinality: r.maxCardinality,
 	}
 	r.histograms[name] = vec
 	return vec

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 )
@@ -553,5 +554,179 @@ func TestHistogramVec_Concurrent(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected to find concurrent_histogram metric family")
+	}
+}
+
+func TestCounter_CardinalityLimit(t *testing.T) {
+	reg := NewRegistry(RegistryConfig{MaxCardinality: 3}).(*registry)
+	c := reg.Counter("limited_counter", "label")
+
+	// Add 3 unique values (at limit)
+	c.WithLabelValues("a").Inc()
+	c.WithLabelValues("b").Inc()
+	c.WithLabelValues("c").Inc()
+
+	families := reg.Gather()
+	var initialCount int
+	for _, f := range families {
+		if f.Name == "limited_counter" {
+			initialCount = len(f.Metrics)
+		}
+	}
+	if initialCount != 3 {
+		t.Errorf("expected 3 metrics, got %d", initialCount)
+	}
+
+	// Add 4th value - should evict oldest ("a")
+	c.WithLabelValues("d").Inc()
+
+	families = reg.Gather()
+	var finalCount int
+	var hasA, hasD bool
+	for _, f := range families {
+		if f.Name == "limited_counter" {
+			finalCount = len(f.Metrics)
+			for _, m := range f.Metrics {
+				if m.Labels["label"] == "a" {
+					hasA = true
+				}
+				if m.Labels["label"] == "d" {
+					hasD = true
+				}
+			}
+		}
+	}
+	if finalCount != 3 {
+		t.Errorf("expected 3 metrics after eviction, got %d", finalCount)
+	}
+	if hasA {
+		t.Error("expected 'a' to be evicted (oldest)")
+	}
+	if !hasD {
+		t.Error("expected 'd' to exist")
+	}
+}
+
+func TestGauge_CardinalityLimit(t *testing.T) {
+	reg := NewRegistry(RegistryConfig{MaxCardinality: 2}).(*registry)
+	g := reg.Gauge("limited_gauge", "label")
+
+	// Add 2 unique values (at limit)
+	g.WithLabelValues("x").Set(1)
+	g.WithLabelValues("y").Set(2)
+
+	// Add 3rd value - should evict oldest ("x")
+	g.WithLabelValues("z").Set(3)
+
+	families := reg.Gather()
+	var hasX, hasZ bool
+	for _, f := range families {
+		if f.Name == "limited_gauge" {
+			for _, m := range f.Metrics {
+				if m.Labels["label"] == "x" {
+					hasX = true
+				}
+				if m.Labels["label"] == "z" {
+					hasZ = true
+				}
+			}
+		}
+	}
+	if hasX {
+		t.Error("expected 'x' to be evicted (oldest)")
+	}
+	if !hasZ {
+		t.Error("expected 'z' to exist")
+	}
+}
+
+func TestHistogram_CardinalityLimit(t *testing.T) {
+	reg := NewRegistry(RegistryConfig{MaxCardinality: 2}).(*registry)
+	h := reg.Histogram("limited_histogram", []float64{0.1, 0.5}, "method")
+
+	// Add 2 unique values (at limit)
+	h.WithLabelValues("GET").Observe(0.05)
+	h.WithLabelValues("POST").Observe(0.3)
+
+	// Add 3rd value - should evict oldest ("GET")
+	h.WithLabelValues("PUT").Observe(0.2)
+
+	families := reg.Gather()
+	var hasGet, hasPut bool
+	for _, f := range families {
+		if f.Name == "limited_histogram" {
+			for _, m := range f.Metrics {
+				if m.Labels["method"] == "GET" {
+					hasGet = true
+				}
+				if m.Labels["method"] == "PUT" {
+					hasPut = true
+				}
+			}
+		}
+	}
+	if hasGet {
+		t.Error("expected 'GET' to be evicted (oldest)")
+	}
+	if !hasPut {
+		t.Error("expected 'PUT' to exist")
+	}
+}
+
+func TestRegistry_DifferentMetricsDifferentLimits(t *testing.T) {
+	// Create two registries with different cardinality limits
+	reg1 := NewRegistry(RegistryConfig{MaxCardinality: 5}).(*registry)
+	reg2 := NewRegistry(RegistryConfig{MaxCardinality: 2}).(*registry)
+
+	c1 := reg1.Counter("test_counter", "label")
+	c2 := reg2.Counter("test_counter", "label")
+
+	c1.WithLabelValues("a").Inc()
+	c1.WithLabelValues("b").Inc()
+	c1.WithLabelValues("c").Inc()
+
+	c2.WithLabelValues("x").Inc()
+	c2.WithLabelValues("y").Inc()
+	c2.WithLabelValues("z").Inc()
+
+	// Both should respect their respective limits
+	families1 := reg1.Gather()
+	families2 := reg2.Gather()
+
+	for _, f := range families1 {
+		if f.Name == "test_counter" {
+			// reg1 has limit 5, should have 3 metrics
+			if len(f.Metrics) != 3 {
+				t.Errorf("expected 3 metrics for reg1 test_counter, got %d", len(f.Metrics))
+			}
+		}
+	}
+	for _, f := range families2 {
+		if f.Name == "test_counter" {
+			// reg2 has limit 2, should have 2 metrics (evicted oldest)
+			if len(f.Metrics) != 2 {
+				t.Errorf("expected 2 metrics for reg2 test_counter, got %d", len(f.Metrics))
+			}
+		}
+	}
+}
+
+func TestCounter_CardinalityUnlimited(t *testing.T) {
+	// maxCardinality = 0 means unlimited
+	reg := NewRegistry(RegistryConfig{MaxCardinality: 0}).(*registry)
+	c := reg.Counter("unlimited_counter", "label")
+
+	// Add many values
+	for i := 0; i < 100; i++ {
+		c.WithLabelValues(fmt.Sprintf("value%d", i)).Inc()
+	}
+
+	families := reg.Gather()
+	for _, f := range families {
+		if f.Name == "unlimited_counter" {
+			if len(f.Metrics) != 100 {
+				t.Errorf("expected 100 metrics with unlimited cardinality, got %d", len(f.Metrics))
+			}
+		}
 	}
 }


### PR DESCRIPTION
Add MaxCardinality config (default 1000) to prevent memory exhaustion from unbounded label values. When limit is exceeded, oldest entries are evicted using FIFO policy. Applies to counters, gauges, and histograms.