### PR TITLE
fix: SSE goroutine cleanup and hub auto-unregister

### DIFF
--- a/sse.go
+++ b/sse.go
@@ -30,6 +30,7 @@ type SSE struct {
 	ctx     context.Context
 	cancel  context.CancelFunc
 	closed  chan struct{}
+	done    chan struct{} // Closed when monitor goroutine exits
 	mu      sync.Mutex
 	retry   time.Duration
 }
@@ -61,10 +62,12 @@ func NewSSE(w http.ResponseWriter, r *http.Request) (*SSE, error) {
 		ctx:     ctx,
 		cancel:  cancel,
 		closed:  make(chan struct{}),
+		done:    make(chan struct{}),
 	}
 
 	// Monitor context cancellation
 	go func() {
+		defer close(stream.done) // Signal goroutine exit
 		select {
 		case <-ctx.Done():
 			_ = stream.Close()
@@ -176,9 +179,17 @@ func (s *SSE) Close() error {
 		return nil
 	default:
 		close(s.closed)
-		s.cancel()
+		if s.cancel != nil {
+			s.cancel()
+		}
 		return nil
 	}
+}
+
+// WaitDone blocks until the monitor goroutine exits.
+// This is primarily used for testing to verify goroutine cleanup.
+func (s *SSE) WaitDone() {
+	<-s.done
 }
 
 // SetRetry sets the default reconnection time for this connection.
@@ -503,24 +514,53 @@ func (h *SSEHub) Unsubscribe(s *SSE, topic string) {
 }
 
 // Broadcast sends an event to all registered connections.
+// Connections that fail to receive the event are automatically unregistered.
 func (h *SSEHub) Broadcast(event SSEEvent) {
 	h.mu.RLock()
-	defer h.mu.RUnlock()
-
+	connections := make([]*SSE, 0, len(h.connections))
 	for conn := range h.connections {
-		_ = conn.Send(event)
+		connections = append(connections, conn)
+	}
+	h.mu.RUnlock()
+
+	var failed []*SSE
+	for _, conn := range connections {
+		if err := conn.Send(event); err != nil {
+			failed = append(failed, conn)
+		}
+	}
+
+	// Unregister failed connections
+	for _, conn := range failed {
+		h.Unregister(conn)
+		_ = conn.Close()
 	}
 }
 
 // BroadcastTo sends an event to all connections subscribed to a topic.
+// Connections that fail to receive the event are automatically unregistered.
 func (h *SSEHub) BroadcastTo(topic string, event SSEEvent) {
 	h.mu.RLock()
-	defer h.mu.RUnlock()
-
+	var connections []*SSE
 	if subs, ok := h.topics[topic]; ok {
+		connections = make([]*SSE, 0, len(subs))
 		for conn := range subs {
-			_ = conn.Send(event)
+			connections = append(connections, conn)
 		}
+	}
+	h.mu.RUnlock()
+
+	var failed []*SSE
+	for _, conn := range connections {
+		if err := conn.Send(event); err != nil {
+			failed = append(failed, conn)
+		}
+	}
+
+	// Unregister failed connections
+	for _, conn := range failed {
+		h.Unregister(conn)
+		_ = conn.Close()
 	}
 }
 

--- a/sse_test.go
+++ b/sse_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
 	"time"
 
@@ -661,6 +662,204 @@ func TestSSEHub(t *testing.T) {
 		}
 		if hub.TopicCount("topic2") != 0 {
 			t.Error("expected stream to be removed from topic2")
+		}
+	})
+
+	t.Run("auto-unregisters failed connections on broadcast", func(t *testing.T) {
+		hub := NewSSEHub()
+
+		// Create a working stream
+		w1 := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+		stream1, _ := NewSSE(w1, r)
+		hub.Register(stream1)
+
+		// Create a stream with an error writer that will fail on send
+		header := make(http.Header)
+		ew := &errorWriter{header: header}
+		fw := &flusherWriter{ResponseWriter: ew, header: header}
+		badStream := &SSE{
+			w:       fw,
+			flusher: fw,
+			ctx:     r.Context(),
+			closed:  make(chan struct{}),
+			done:    make(chan struct{}),
+		}
+		hub.Register(badStream)
+
+		if hub.ConnectionCount() != 2 {
+			t.Errorf("expected 2 connections, got %d", hub.ConnectionCount())
+		}
+
+		// Broadcast should auto-unregister the failed connection
+		hub.Broadcast(SSEEvent{Data: []byte("test")})
+
+		if hub.ConnectionCount() != 1 {
+			t.Errorf("expected 1 connection after broadcast, got %d", hub.ConnectionCount())
+		}
+	})
+
+	t.Run("auto-unregisters failed connections on broadcast to topic", func(t *testing.T) {
+		hub := NewSSEHub()
+
+		// Create a working stream
+		w1 := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+		stream1, _ := NewSSE(w1, r)
+		hub.Subscribe(stream1, "test-topic")
+
+		// Create a stream with an error writer
+		header := make(http.Header)
+		ew := &errorWriter{header: header}
+		fw := &flusherWriter{ResponseWriter: ew, header: header}
+		badStream := &SSE{
+			w:       fw,
+			flusher: fw,
+			ctx:     r.Context(),
+			closed:  make(chan struct{}),
+			done:    make(chan struct{}),
+		}
+		hub.Subscribe(badStream, "test-topic")
+
+		if hub.TopicCount("test-topic") != 2 {
+			t.Errorf("expected 2 subscribers, got %d", hub.TopicCount("test-topic"))
+		}
+
+		// Broadcast should auto-unregister the failed connection
+		hub.BroadcastTo("test-topic", SSEEvent{Data: []byte("test")})
+
+		if hub.TopicCount("test-topic") != 1 {
+			t.Errorf("expected 1 subscriber after broadcast, got %d", hub.TopicCount("test-topic"))
+		}
+	})
+}
+
+// Goroutine cleanup tests
+
+func TestSSE_GoroutineCleanup(t *testing.T) {
+	t.Run("monitor goroutine exits on close", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		stream, err := NewSSE(w, r)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Close the stream
+		err = stream.Close()
+		if err != nil {
+			t.Fatalf("expected no error on close, got %v", err)
+		}
+
+		// Wait for monitor goroutine to exit
+		done := make(chan struct{})
+		go func() {
+			stream.WaitDone()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			// Goroutine exited successfully
+		case <-time.After(time.Second):
+			t.Error("monitor goroutine did not exit within timeout")
+		}
+	})
+
+	t.Run("monitor goroutine exits on context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil).WithContext(ctx)
+
+		stream, err := NewSSE(w, r)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Cancel the context
+		cancel()
+
+		// Wait for monitor goroutine to exit
+		done := make(chan struct{})
+		go func() {
+			stream.WaitDone()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			// Goroutine exited successfully
+		case <-time.After(time.Second):
+			t.Error("monitor goroutine did not exit within timeout")
+		}
+	})
+
+	t.Run("no goroutine leak on multiple create/close cycles", func(t *testing.T) {
+		// Get initial goroutine count
+		runtime.GC()
+		time.Sleep(100 * time.Millisecond)
+		initial := runtime.NumGoroutine()
+
+		// Create and close many SSE connections
+		for i := 0; i < 50; i++ {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+			stream, err := NewSSE(w, r)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			// Send an event
+			_ = stream.Send(SSEEvent{Data: []byte("test")})
+
+			// Close and wait for cleanup
+			_ = stream.Close()
+			stream.WaitDone()
+		}
+
+		// Give goroutines time to exit
+		runtime.GC()
+		time.Sleep(100 * time.Millisecond)
+
+		final := runtime.NumGoroutine()
+
+		if final != initial {
+			t.Errorf("goroutine leak detected: started with %d, ended with %d", initial, final)
+		}
+	})
+
+	t.Run("no goroutine leak on context cancellation", func(t *testing.T) {
+		// Get initial goroutine count
+		runtime.GC()
+		time.Sleep(100 * time.Millisecond)
+		initial := runtime.NumGoroutine()
+
+		// Create and cancel many contexts
+		for i := 0; i < 50; i++ {
+			ctx, cancel := context.WithCancel(context.Background())
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/sse", nil).WithContext(ctx)
+
+			stream, err := NewSSE(w, r)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			// Cancel context and wait for cleanup
+			cancel()
+			stream.WaitDone()
+		}
+
+		// Give goroutines time to exit
+		runtime.GC()
+		time.Sleep(100 * time.Millisecond)
+
+		final := runtime.NumGoroutine()
+
+		if final != initial {
+			t.Errorf("goroutine leak detected on cancellation: started with %d, ended with %d", initial, final)
 		}
 	})
 }


### PR DESCRIPTION
Add done channel to verify monitor goroutine exits. Auto-unregister failed connections in Broadcast/BroadcastTo. Add goroutine leak tests.