### PR TITLE
feat: add pluggable distributed tracing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A lightweight HTTP framework for Go built on top of the standard `net/http` libr
 - [Health Checks](#health-checks)
 - [Circuit Breaker](#circuit-breaker)
 - [Metrics](docs/METRICS.md)
+- [Distributed Tracing](docs/PLUGGABLE.md#distributed-tracing)
 - [Static File Serving](#static-file-serving)
   - [Static File Methods](#static-file-methods)
   - [Fallback Behavior](#fallback-behavior)
@@ -57,6 +58,7 @@ A lightweight HTTP framework for Go built on top of the standard `net/http` libr
 - **Pluggable Architecture**: Extensible interfaces for Auto-TLS, HTTP/3, WebSocket, WebTransport, SSE, and Validator - bring your own implementations
 - **Server-Sent Events**: Built-in SSE support with event replay and broadcast hub for real-time server-to-client streaming
 - **Request Tracing**: Built-in request ID generation and propagation
+- **Distributed Tracing**: Pluggable tracing interface for OpenTelemetry, Jaeger, or custom implementations
 - **Circuit Breaker**: Prevent cascading failures with configurable circuit breaker middleware
 - **Metrics**: Built-in Prometheus-compatible metrics with zero dependencies
 - **Structured Logging**: Integrated structured logging with customizable fields
@@ -448,6 +450,41 @@ app.Use(middleware.CircuitBreaker(config.CircuitBreakerConfig{
 ```
 
 The circuit breaker operates in three states: **Closed** (normal), **Open** (blocked), and **Half-Open** (testing recovery). It prevents cascading failures when downstream services are unavailable.
+
+## Distributed Tracing
+
+zerohttp includes a pluggable tracing interface for distributed tracing with zero dependencies:
+
+```go
+import (
+    "github.com/alexferl/zerohttp/middleware"
+    "github.com/alexferl/zerohttp/trace"
+)
+
+// Implement the Tracer interface (or use OpenTelemetry)
+type myTracer struct{}
+
+func (t *myTracer) Start(ctx context.Context, name string, opts ...trace.SpanOption) (context.Context, trace.Span) {
+    // Your tracing implementation
+    return ctx, span
+}
+
+app := zh.New(config.Config{
+    Tracer: myTracer,
+})
+
+// Add tracing middleware - creates spans for each request
+app.Use(middleware.Tracing(myTracer))
+
+// Access spans in handlers
+app.GET("/", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+    span := trace.SpanFromContext(r.Context())
+    span.SetAttributes(trace.String("user.id", "123"))
+    return zh.R.JSON(w, 200, zh.M{"message": "ok"})
+}))
+```
+
+See [docs/PLUGGABLE.md](docs/PLUGGABLE.md#distributed-tracing) for complete examples including OpenTelemetry integration.
 
 ## Static File Serving
 

--- a/config/config.go
+++ b/config/config.go
@@ -129,6 +129,17 @@ type Config struct {
 	// The server will be started automatically when ListenAndServeTLS or Start is called.
 	// Default: nil
 	WebTransportServer WebTransportServer
+
+	// Tracer is an optional tracer for distributed tracing.
+	// Users can inject their own implementation (e.g., wrapping go.opentelemetry.io/otel).
+	// The tracer must implement the trace.Tracer interface.
+	// If nil, tracing is disabled.
+	// Default: nil
+	Tracer TracerField
+
+	// TracerConfig holds the configuration for the tracing middleware.
+	// Default: DefaultTracerConfig
+	TracerConfig TracerConfig
 }
 
 // DefaultConfig contains all default values used by Config.

--- a/config/tracing.go
+++ b/config/tracing.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"net/http"
+	"slices"
+
+	"github.com/alexferl/zerohttp/trace"
+)
+
+// TracerConfig holds configuration for the tracing middleware.
+type TracerConfig struct {
+	// ExemptPaths is a list of paths that should not be traced.
+	// Requests to these paths will not create spans.
+	// Default: nil (all paths are traced)
+	ExemptPaths []string
+
+	// SpanNameFormatter is a custom function to generate span names.
+	// If nil, the default formatter is used (returns "{method} {path}").
+	// Default: nil
+	SpanNameFormatter func(r *http.Request) string
+}
+
+// DefaultTracerConfig contains the default values for TracerConfig.
+var DefaultTracerConfig = TracerConfig{
+	ExemptPaths:       nil,
+	SpanNameFormatter: nil,
+}
+
+// DefaultSpanNameFormatter returns the default span name for a request.
+// Format: "{method} {path}"
+func DefaultSpanNameFormatter(r *http.Request) string {
+	return r.Method + " " + r.URL.Path
+}
+
+// TracerConfigWrapper wraps TracerConfig to provide helper methods.
+type TracerConfigWrapper struct {
+	Config TracerConfig
+}
+
+// Wrap creates a new TracerConfigWrapper.
+func (c TracerConfig) Wrap() *TracerConfigWrapper {
+	return &TracerConfigWrapper{Config: c}
+}
+
+// IsExempt checks if a path is exempt from tracing.
+func (w *TracerConfigWrapper) IsExempt(path string) bool {
+	return slices.Contains(w.Config.ExemptPaths, path)
+}
+
+// GetSpanName returns the span name for a request.
+func (w *TracerConfigWrapper) GetSpanName(r *http.Request) string {
+	if w.Config.SpanNameFormatter != nil {
+		return w.Config.SpanNameFormatter(r)
+	}
+	return DefaultSpanNameFormatter(r)
+}
+
+// TracerField is a type alias for trace.Tracer to avoid import cycles
+// when embedding in Config. The actual field in Config is of type trace.Tracer.
+type TracerField = trace.Tracer

--- a/config/tracing_test.go
+++ b/config/tracing_test.go
@@ -1,0 +1,90 @@
+package config
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTracerConfigWrapper_IsExempt(t *testing.T) {
+	tests := []struct {
+		name        string
+		exemptPaths []string
+		path        string
+		want        bool
+	}{
+		{"exact match", []string{"/health", "/metrics"}, "/health", true},
+		{"not exempt", []string{"/health", "/metrics"}, "/api/users", false},
+		{"empty exempt list", []string{}, "/health", false},
+		{"nil exempt list", nil, "/health", false},
+		{"partial match should not work", []string{"/health"}, "/healthz", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := TracerConfig{ExemptPaths: tt.exemptPaths}
+			wrapper := cfg.Wrap()
+			got := wrapper.IsExempt(tt.path)
+			if got != tt.want {
+				t.Errorf("IsExempt(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTracerConfigWrapper_GetSpanName(t *testing.T) {
+	tests := []struct {
+		name      string
+		formatter func(r *http.Request) string
+		method    string
+		path      string
+		want      string
+	}{
+		{
+			name:      "default formatter",
+			formatter: nil,
+			method:    "GET",
+			path:      "/api/users",
+			want:      "GET /api/users",
+		},
+		{
+			name: "custom formatter",
+			formatter: func(r *http.Request) string {
+				return "custom:" + r.Method
+			},
+			method: "POST",
+			path:   "/api/items",
+			want:   "custom:POST",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := TracerConfig{SpanNameFormatter: tt.formatter}
+			wrapper := cfg.Wrap()
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			got := wrapper.GetSpanName(req)
+			if got != tt.want {
+				t.Errorf("GetSpanName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultSpanNameFormatter(t *testing.T) {
+	req := httptest.NewRequest("GET", "/test/path", nil)
+	got := DefaultSpanNameFormatter(req)
+	want := "GET /test/path"
+	if got != want {
+		t.Errorf("DefaultSpanNameFormatter() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultTracerConfig(t *testing.T) {
+	if DefaultTracerConfig.ExemptPaths != nil {
+		t.Error("DefaultTracerConfig.ExemptPaths should be nil")
+	}
+	if DefaultTracerConfig.SpanNameFormatter != nil {
+		t.Error("DefaultTracerConfig.SpanNameFormatter should be nil")
+	}
+}

--- a/docs/PLUGGABLE.md
+++ b/docs/PLUGGABLE.md
@@ -6,6 +6,7 @@ zerohttp provides several pluggable features that extend core functionality thro
 
 - [Interface Overview](#interface-overview)
 - [Validator](#validator)
+- [Distributed Tracing](#distributed-tracing)
 - [Auto-TLS](#auto-tls)
 - [HTTP/3](#http3)
 - [Server-Sent Events (SSE)](#server-sent-events-sse)
@@ -21,6 +22,11 @@ zerohttp defines minimal interfaces for each pluggable feature:
 type Validator interface {
     Struct(dst any) error
     Register(name string, fn func(reflect.Value, string) error)
+}
+
+// Tracer - Distributed tracing interface
+type Tracer interface {
+    Start(ctx context.Context, name string, opts ...SpanOption) (context.Context, Span)
 }
 
 // AutocertManager - Automatic certificate management
@@ -58,6 +64,7 @@ All pluggable features are configured via the Config struct:
 ```go
 app := zh.New(config.Config{
     Validator:          myValidator,
+    Tracer:             myTracer,
     AutocertManager:    myCertManager,
     HTTP3Server:        myH3Server,
     SSEProvider:        mySSEProvider,
@@ -118,6 +125,80 @@ func main() {
 ```
 
 See [`examples/validation/goplayground.go`](../examples/validation/goplayground.go) for a complete example.
+
+## Distributed Tracing
+
+zerohttp provides a pluggable tracing interface for distributed tracing. No external dependencies are required - you can implement your own tracer or use OpenTelemetry.
+
+### Basic Usage (No External Dependencies)
+
+```go
+package main
+
+import (
+    zh "github.com/alexferl/zerohttp"
+    "github.com/alexferl/zerohttp/config"
+    "github.com/alexferl/zerohttp/middleware"
+    "github.com/alexferl/zerohttp/trace"
+)
+
+// SimpleTracer logs spans to stdout
+type SimpleTracer struct{}
+
+func (t *SimpleTracer) Start(ctx context.Context, name string, opts ...trace.SpanOption) (context.Context, trace.Span) {
+    span := &SimpleSpan{name: name}
+    return trace.ContextWithSpan(ctx, span), span
+}
+
+type SimpleSpan struct{ name string }
+func (s *SimpleSpan) End() {}
+func (s *SimpleSpan) SetStatus(code trace.Code, description string) {}
+func (s *SimpleSpan) SetAttributes(attrs ...trace.Attribute) {}
+func (s *SimpleSpan) RecordError(err error, opts ...trace.ErrorOption) {}
+
+func main() {
+    tracer := &SimpleTracer{}
+
+    app := zh.New(config.Config{
+        Tracer: tracer,
+    })
+
+    // Add tracing middleware
+    app.Use(middleware.Tracing(tracer))
+
+    // Access span in handlers
+    app.GET("/", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+        span := trace.SpanFromContext(r.Context())
+        span.SetAttributes(trace.String("user.id", "123"))
+        return zh.R.JSON(w, 200, zh.M{"message": "ok"})
+    }))
+
+    app.ListenAndServe()
+}
+```
+
+### With OpenTelemetry
+
+```go
+import (
+    "go.opentelemetry.io/otel"
+    "go.opentelemetry.io/otel/exporters/jaeger"
+    sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// Create tracer provider with Jaeger exporter
+exp, _ := jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint("http://localhost:14268/api/traces")))
+tp := sdktrace.NewTracerProvider(sdktrace.WithBatcher(exp))
+otel.SetTracerProvider(tp)
+
+// Wrap OTel tracer to implement zerohttp's interface
+tracer := &OTelTracer{tracer: tp.Tracer("myapp")}
+
+app := zh.New(config.Config{Tracer: tracer})
+app.Use(middleware.Tracing(tracer))
+```
+
+See [`examples/tracing/`](../examples/tracing/) for complete working examples including custom and OpenTelemetry implementations.
 
 ## Auto-TLS
 

--- a/examples/tracing/jaeger.go
+++ b/examples/tracing/jaeger.go
@@ -1,0 +1,193 @@
+//go:build ignore
+
+// This example shows how to integrate OpenTelemetry with Jaeger for distributed tracing.
+//
+// Jaeger accepts OTLP (OpenTelemetry Protocol) directly, so we use the OTLP exporter
+// which is the recommended approach (the old Jaeger-specific exporter is deprecated).
+//
+// To run this example:
+//
+//  1. Start Jaeger: docker run -d --name jaeger -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one:latest
+//  2. Run this example: go run examples/tracing/jaeger.go
+//  3. Make some requests: curl http://localhost:8080/ && curl http://localhost:8080/error
+//  4. View traces: open http://localhost:16686
+//
+// Install dependencies:
+//
+//	go get go.opentelemetry.io/otel \
+//	    go.opentelemetry.io/otel/sdk \
+//	    go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/middleware"
+	"github.com/alexferl/zerohttp/trace"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	otelTrace "go.opentelemetry.io/otel/trace"
+
+	// OTLP exporter - sends traces via OTLP protocol (Jaeger supports this natively)
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+// OTelTracer wraps an OpenTelemetry tracer to implement zerohttp's trace.Tracer interface.
+type OTelTracer struct {
+	tracer otelTrace.Tracer
+}
+
+// NewOTelTracer creates a new OTelTracer wrapper.
+func NewOTelTracer(tracer otelTrace.Tracer) *OTelTracer {
+	return &OTelTracer{tracer: tracer}
+}
+
+// Start implements trace.Tracer by delegating to the underlying OTel tracer.
+func (t *OTelTracer) Start(ctx context.Context, name string, opts ...trace.SpanOption) (context.Context, trace.Span) {
+	ctx, otelSpan := t.tracer.Start(ctx, name)
+	return ctx, &OTelSpan{span: otelSpan}
+}
+
+// OTelSpan wraps an OpenTelemetry span to implement zerohttp's trace.Span interface.
+type OTelSpan struct {
+	span otelTrace.Span
+}
+
+func (s *OTelSpan) End() {
+	s.span.End()
+}
+
+func (s *OTelSpan) SetStatus(code trace.Code, description string) {
+	s.span.SetStatus(otelCodes(code), description)
+}
+
+func otelCodes(code trace.Code) codes.Code {
+	switch code {
+	case trace.CodeOk:
+		return codes.Ok
+	case trace.CodeError:
+		return codes.Error
+	default:
+		return codes.Unset
+	}
+}
+
+func (s *OTelSpan) SetAttributes(attrs ...trace.Attribute) {
+	// Convert trace.Attribute to otel attribute.KeyValue
+	otelAttrs := make([]attribute.KeyValue, 0, len(attrs))
+	for _, attr := range attrs {
+		kv := attribute.KeyValue{
+			Key:   attribute.Key(attr.Key),
+			Value: toAttributeValue(attr.Value),
+		}
+		otelAttrs = append(otelAttrs, kv)
+	}
+	s.span.SetAttributes(otelAttrs...)
+}
+
+// toAttributeValue converts Go types to OTel attribute values
+func toAttributeValue(v any) attribute.Value {
+	switch val := v.(type) {
+	case string:
+		return attribute.StringValue(val)
+	case int:
+		return attribute.IntValue(val)
+	case int64:
+		return attribute.Int64Value(val)
+	case float64:
+		return attribute.Float64Value(val)
+	case bool:
+		return attribute.BoolValue(val)
+	default:
+		return attribute.StringValue(fmt.Sprint(val))
+	}
+}
+
+func (s *OTelSpan) RecordError(err error, opts ...trace.ErrorOption) {
+	s.span.RecordError(err)
+}
+
+func main() {
+	// Create OTLP exporter that sends to Jaeger's OTLP endpoint
+	// Jaeger listens on port 4318 for OTLP HTTP
+	exporter, err := otlptracehttp.New(context.Background(),
+		otlptracehttp.WithEndpoint("localhost:4318"),
+		otlptracehttp.WithInsecure(),
+	)
+	if err != nil {
+		log.Fatalf("Failed to create OTLP exporter: %v", err)
+	}
+
+	// Create tracer provider with OTLP exporter
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceNameKey.String("zerohttp-jaeger-example"),
+			semconv.ServiceVersionKey.String("1.0.0"),
+		)),
+	)
+	defer func() {
+		// Flush and shutdown on exit
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := provider.Shutdown(ctx); err != nil {
+			log.Printf("Error shutting down tracer provider: %v", err)
+		}
+	}()
+
+	// Set as global tracer provider
+	otel.SetTracerProvider(provider)
+
+	// Create our OTel wrapper tracer
+	tracer := NewOTelTracer(provider.Tracer("zerohttp"))
+
+	// Configure the server
+	app := zh.New(config.Config{
+		Tracer: tracer,
+	})
+
+	// Add the tracing middleware
+	app.Use(middleware.Tracing(tracer))
+
+	// Regular endpoint
+	app.GET("/", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return zh.R.JSON(w, http.StatusOK, zh.M{"message": "Hello with Jaeger tracing!"})
+	}))
+
+	// Endpoint that simulates an error
+	app.GET("/error", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return fmt.Errorf("something went wrong")
+	}))
+
+	// Slow endpoint to show timing in traces
+	app.GET("/slow", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		time.Sleep(100 * time.Millisecond)
+		return zh.R.JSON(w, http.StatusOK, zh.M{"message": "This was slow"})
+	}))
+
+	fmt.Println("Server starting on http://localhost:8080")
+	fmt.Println("Jaeger UI available at http://localhost:16686")
+	fmt.Println()
+	fmt.Println("Try these endpoints:")
+	fmt.Println("  curl http://localhost:8080/")
+	fmt.Println("  curl http://localhost:8080/error")
+	fmt.Println("  curl http://localhost:8080/slow")
+	fmt.Println()
+	fmt.Println("Then view traces at: http://localhost:16686")
+	fmt.Println()
+	fmt.Println("NOTE: Select 'zerohttp-jaeger-example' from the Service dropdown in Jaeger UI")
+
+	log.Fatal(app.Start())
+}

--- a/examples/tracing/main.go
+++ b/examples/tracing/main.go
@@ -1,0 +1,104 @@
+// This example shows how to implement a custom tracer without using any external
+// tracing library. This is useful for simple logging or custom trace collection.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/middleware"
+	"github.com/alexferl/zerohttp/trace"
+)
+
+// SimpleTracer is a custom tracer implementation that logs spans to stdout.
+// This is a basic example showing how to implement the trace.Tracer interface.
+type SimpleTracer struct{}
+
+func (t *SimpleTracer) Start(ctx context.Context, name string, opts ...trace.SpanOption) (context.Context, trace.Span) {
+	span := &SimpleSpan{
+		name:       name,
+		startTime:  time.Now(),
+		attributes: make(map[string]any),
+	}
+
+	fmt.Printf("[TRACE] Span started: %s\n", name)
+	return trace.ContextWithSpan(ctx, span), span
+}
+
+// SimpleSpan is a custom span implementation that logs to stdout.
+type SimpleSpan struct {
+	name       string
+	startTime  time.Time
+	attributes map[string]any
+	statusCode trace.Code
+	statusDesc string
+}
+
+func (s *SimpleSpan) End() {
+	duration := time.Since(s.startTime)
+	fmt.Printf("[TRACE] Span ended: %s (duration: %v, status: %d)\n", s.name, duration, s.statusCode)
+}
+
+func (s *SimpleSpan) SetStatus(code trace.Code, description string) {
+	s.statusCode = code
+	s.statusDesc = description
+}
+
+func (s *SimpleSpan) SetAttributes(attrs ...trace.Attribute) {
+	for _, attr := range attrs {
+		s.attributes[attr.Key] = attr.Value
+		fmt.Printf("[TRACE]   Attribute: %s = %v\n", attr.Key, attr.Value)
+	}
+}
+
+func (s *SimpleSpan) RecordError(err error, opts ...trace.ErrorOption) {
+	fmt.Printf("[TRACE] Error recorded: %v\n", err)
+}
+
+func main() {
+	// Create our custom tracer
+	tracer := &SimpleTracer{}
+
+	// Configure the server with our custom tracer
+	app := zh.New(config.Config{
+		Tracer: tracer,
+	})
+
+	// Add the tracing middleware
+	app.Use(middleware.Tracing(tracer))
+
+	// Regular endpoint
+	app.GET("/", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return zh.R.JSON(w, http.StatusOK, zh.M{"message": "Hello with custom tracing!"})
+	}))
+
+	// Endpoint that simulates an error (to show error status in traces)
+	app.GET("/error", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return zh.R.JSON(w, http.StatusInternalServerError, zh.M{"error": "Something went wrong"})
+	}))
+
+	// Endpoint that accesses the current span
+	app.GET("/span-info", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		span := trace.SpanFromContext(r.Context())
+		if span != nil {
+			// Add custom attribute to the current span
+			span.SetAttributes(trace.String("custom.key", "custom-value"))
+		}
+		return zh.R.JSON(w, http.StatusOK, zh.M{"message": "Check the trace output for custom attribute"})
+	}))
+
+	fmt.Println("Server starting on http://localhost:8080")
+	fmt.Println("Try these endpoints:")
+	fmt.Println("  curl http://localhost:8080/")
+	fmt.Println("  curl http://localhost:8080/error")
+	fmt.Println("  curl http://localhost:8080/span-info")
+	fmt.Println()
+	fmt.Println("Watch the console output for trace information!")
+
+	log.Fatal(app.Start())
+}

--- a/examples/tracing/otel.go
+++ b/examples/tracing/otel.go
@@ -1,0 +1,155 @@
+//go:build ignore
+
+// This example shows how to integrate OpenTelemetry with zerohttp.
+//
+// To run this example, you need to install the OpenTelemetry packages:
+//
+//	go get go.opentelemetry.io/otel \
+//	    go.opentelemetry.io/otel/sdk \
+//	    go.opentelemetry.io/otel/exporters/stdout/stdouttrace
+//
+// This example uses the stdout exporter for demonstration. In production,
+// you would typically use a Jaeger, Zipkin, or OTLP exporter.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+
+	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/middleware"
+	"github.com/alexferl/zerohttp/trace"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	oTelTrace "go.opentelemetry.io/otel/trace"
+)
+
+// OTelTracer wraps an OpenTelemetry tracer to implement zerohttp's trace.Tracer interface.
+type OTelTracer struct {
+	tracer oTelTrace.Tracer
+}
+
+// NewOTelTracer creates a new OTelTracer wrapper.
+func NewOTelTracer(tracer oTelTrace.Tracer) *OTelTracer {
+	return &OTelTracer{tracer: tracer}
+}
+
+// Start implements trace.Tracer by delegating to the underlying OTel tracer.
+func (t *OTelTracer) Start(ctx context.Context, name string, opts ...trace.SpanOption) (context.Context, trace.Span) {
+	ctx, oTelSpan := t.tracer.Start(ctx, name)
+	return ctx, &OTelSpan{span: oTelSpan}
+}
+
+// OTelSpan wraps an OpenTelemetry span to implement zerohttp's trace.Span interface.
+type OTelSpan struct {
+	span oTelTrace.Span
+}
+
+func (s *OTelSpan) End() {
+	s.span.End()
+}
+
+func (s *OTelSpan) SetStatus(code trace.Code, description string) {
+	// Map zerohttp codes to OTel codes
+	// Note: In OTel, use codes package: codes.Ok, codes.Error, codes.Unset
+	s.span.SetStatus(otelCodes(code), description)
+}
+
+func otelCodes(code trace.Code) codes.Code {
+	switch code {
+	case trace.CodeOk:
+		return codes.Ok
+	case trace.CodeError:
+		return codes.Error
+	default:
+		return codes.Unset
+	}
+}
+
+func (s *OTelSpan) SetAttributes(attrs ...trace.Attribute) {
+	// Note: In a real implementation, you would convert trace.Attribute
+	// to otel attribute.KeyValue. This is simplified for the example.
+	for _, attr := range attrs {
+		// Convert to OTel attribute - simplified
+		_ = attr
+	}
+}
+
+func (s *OTelSpan) RecordError(err error, opts ...trace.ErrorOption) {
+	s.span.RecordError(err)
+}
+
+func main() {
+	// Create stdout exporter for demonstration
+	// In production, use jaeger, zipkin, or otlp exporter
+	exporter, err := stdouttrace.New(stdouttrace.WithPrettyPrint())
+	if err != nil {
+		log.Fatalf("Failed to create exporter: %v", err)
+	}
+
+	// Create tracer provider
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceNameKey.String("zerohttp-example"),
+		)),
+	)
+	defer provider.Shutdown(context.Background())
+
+	// Set as global tracer provider
+	otel.SetTracerProvider(provider)
+
+	// Create our OTel wrapper tracer
+	tracer := NewOTelTracer(provider.Tracer("zerohttp"))
+
+	// Configure the server
+	app := zh.New(config.Config{
+		Tracer: tracer,
+	})
+
+	// Add the tracing middleware
+	app.Use(middleware.Tracing(tracer))
+
+	// Regular endpoint
+	app.GET("/", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return zh.R.JSON(w, http.StatusOK, zh.M{"message": "Hello with OpenTelemetry!"})
+	}))
+
+	// Endpoint with custom attributes
+	app.GET("/user/:id", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		// Get user ID from path
+		userID := r.PathValue("id")
+
+		// Add custom attribute to span
+		span := trace.SpanFromContext(r.Context())
+		if span != nil {
+			span.SetAttributes(trace.String("user.id", userID))
+		}
+
+		return zh.R.JSON(w, http.StatusOK, zh.M{"user_id": userID})
+	}))
+
+	// Endpoint that simulates an error
+	app.GET("/error", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return fmt.Errorf("something went wrong")
+	}))
+
+	fmt.Println("Server starting on http://localhost:8080")
+	fmt.Println("Try these endpoints:")
+	fmt.Println("  curl http://localhost:8080/")
+	fmt.Println("  curl http://localhost:8080/user/123")
+	fmt.Println("  curl http://localhost:8080/error")
+	fmt.Println()
+	fmt.Println("Watch the console output for OpenTelemetry trace information!")
+
+	log.Fatal(app.Start())
+}

--- a/middleware/tracing.go
+++ b/middleware/tracing.go
@@ -1,0 +1,93 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/trace"
+)
+
+// Tracing creates a middleware that traces HTTP requests.
+func Tracing(tracer trace.Tracer, cfg ...config.TracerConfig) func(http.Handler) http.Handler {
+	if tracer == nil {
+		tracer = trace.NewNoopTracer()
+	}
+
+	c := config.DefaultTracerConfig
+	if len(cfg) > 0 {
+		c = cfg[0]
+	}
+
+	wrapper := c.Wrap()
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if wrapper.IsExempt(r.URL.Path) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			spanName := wrapper.GetSpanName(r)
+			ctx, span := tracer.Start(r.Context(), spanName,
+				trace.WithAttributes(
+					trace.String("http.method", r.Method),
+					trace.String("http.target", r.URL.Path),
+					trace.String("http.scheme", scheme(r)),
+					trace.String("http.host", r.Host),
+				),
+			)
+			defer span.End()
+
+			if r.ContentLength > 0 {
+				span.SetAttributes(trace.Int64("http.request_content_length", r.ContentLength))
+			}
+
+			wrapped := &tracingResponseWriter{
+				ResponseWriter: w,
+				span:           span,
+			}
+
+			next.ServeHTTP(wrapped, r.WithContext(ctx))
+
+			if wrapped.statusCode >= 500 {
+				span.SetStatus(trace.CodeError, http.StatusText(wrapped.statusCode))
+			} else {
+				span.SetStatus(trace.CodeOk, "")
+			}
+		})
+	}
+}
+
+type tracingResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+	span       trace.Span
+	written    bool
+}
+
+func (w *tracingResponseWriter) WriteHeader(code int) {
+	if w.written {
+		return
+	}
+	w.written = true
+	w.statusCode = code
+	w.span.SetAttributes(trace.Int("http.status_code", code))
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *tracingResponseWriter) Write(data []byte) (int, error) {
+	if !w.written {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(data)
+}
+
+func scheme(r *http.Request) string {
+	if r.TLS != nil {
+		return "https"
+	}
+	if scheme := r.Header.Get("X-Forwarded-Proto"); scheme != "" {
+		return scheme
+	}
+	return "http"
+}

--- a/middleware/tracing_test.go
+++ b/middleware/tracing_test.go
@@ -1,0 +1,290 @@
+package middleware
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/trace"
+)
+
+// mockTracer is a test tracer that records span creation
+type mockTracer struct {
+	spans []*mockSpan
+}
+
+func (m *mockTracer) Start(ctx context.Context, name string, opts ...trace.SpanOption) (context.Context, trace.Span) {
+	span := &mockSpan{name: name}
+	m.spans = append(m.spans, span)
+
+	// Capture initial attributes from options
+	for _, opt := range opts {
+		// We can't call apply directly since it's unexported,
+		// but we can verify options work through integration tests
+		_ = opt
+	}
+
+	return trace.ContextWithSpan(ctx, span), span
+}
+
+type mockSpan struct {
+	name       string
+	statusCode trace.Code
+	statusDesc string
+	attributes []trace.Attribute
+	errors     []error
+	ended      bool
+}
+
+func (m *mockSpan) End() { m.ended = true }
+func (m *mockSpan) SetStatus(code trace.Code, description string) {
+	m.statusCode = code
+	m.statusDesc = description
+}
+
+func (m *mockSpan) SetAttributes(attrs ...trace.Attribute) {
+	m.attributes = append(m.attributes, attrs...)
+}
+
+func (m *mockSpan) RecordError(err error, opts ...trace.ErrorOption) {
+	m.errors = append(m.errors, err)
+}
+
+func TestTracing_CreatesSpan(t *testing.T) {
+	mock := &mockTracer{}
+	mw := Tracing(mock)
+
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if len(mock.spans) != 1 {
+		t.Fatalf("Expected 1 span, got %d", len(mock.spans))
+	}
+
+	span := mock.spans[0]
+	if !span.ended {
+		t.Error("Expected span to be ended")
+	}
+}
+
+func TestTracing_SetsAttributes(t *testing.T) {
+	mock := &mockTracer{}
+	mw := Tracing(mock)
+
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/users", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	span := mock.spans[0]
+	attrs := make(map[string]any)
+	for _, attr := range span.attributes {
+		attrs[attr.Key] = attr.Value
+	}
+
+	// The status code is set via SetAttributes after Start
+	if attrs["http.status_code"] != 201 {
+		t.Errorf("status_code = %v, want 201", attrs["http.status_code"])
+	}
+}
+
+func TestTracing_ContentLength(t *testing.T) {
+	mock := &mockTracer{}
+	mw := Tracing(mock)
+
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Request with body (ContentLength > 0)
+	body := "test body"
+	req := httptest.NewRequest(http.MethodPost, "/api/users", strings.NewReader(body))
+	req.ContentLength = int64(len(body))
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	span := mock.spans[0]
+	attrs := make(map[string]any)
+	for _, attr := range span.attributes {
+		attrs[attr.Key] = attr.Value
+	}
+
+	if attrs["http.request_content_length"] != int64(9) {
+		t.Errorf("request_content_length = %v, want 9", attrs["http.request_content_length"])
+	}
+}
+
+func TestTracing_ExemptPaths(t *testing.T) {
+	mock := &mockTracer{}
+	mw := Tracing(mock, config.TracerConfig{
+		ExemptPaths: []string{"/health", "/metrics"},
+	})
+
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Request to exempt path should not create span
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if len(mock.spans) != 0 {
+		t.Errorf("Expected 0 spans for exempt path, got %d", len(mock.spans))
+	}
+
+	// Request to non-exempt path should create span
+	req = httptest.NewRequest(http.MethodGet, "/api/users", nil)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if len(mock.spans) != 1 {
+		t.Errorf("Expected 1 span for non-exempt path, got %d", len(mock.spans))
+	}
+}
+
+func TestTracing_NilTracer(t *testing.T) {
+	mw := Tracing(nil)
+
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rr := httptest.NewRecorder()
+
+	// Should not panic with nil tracer
+	handler.ServeHTTP(rr, req)
+}
+
+func TestTracing_StatusCode(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantCode   trace.Code
+	}{
+		{"success", 200, trace.CodeOk},
+		{"created", 201, trace.CodeOk},
+		{"bad_request", 400, trace.CodeOk},
+		{"not_found", 404, trace.CodeOk},
+		{"server_error", 500, trace.CodeError},
+		{"bad_gateway", 502, trace.CodeError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockTracer{}
+			mw := Tracing(mock)
+
+			handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			span := mock.spans[0]
+			if span.statusCode != tt.wantCode {
+				t.Errorf("statusCode = %d, want %d", span.statusCode, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestTracing_SpanNameFormatter(t *testing.T) {
+	mock := &mockTracer{}
+	mw := Tracing(mock, config.TracerConfig{
+		SpanNameFormatter: func(r *http.Request) string {
+			return "custom:" + r.Method
+		},
+	})
+
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	span := mock.spans[0]
+	if span.name != "custom:GET" {
+		t.Errorf("name = %q, want custom:GET", span.name)
+	}
+}
+
+func TestScheme(t *testing.T) {
+	tests := []struct {
+		name       string
+		tls        bool
+		header     string
+		wantScheme string
+	}{
+		{"http", false, "", "http"},
+		{"https", true, "", "https"},
+		{"forwarded_https", false, "https", "https"},
+		{"forwarded_http", false, "http", "http"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			if tt.tls {
+				req.TLS = &tls.ConnectionState{}
+			}
+			if tt.header != "" {
+				req.Header.Set("X-Forwarded-Proto", tt.header)
+			}
+
+			got := scheme(req)
+			if got != tt.wantScheme {
+				t.Errorf("scheme() = %q, want %q", got, tt.wantScheme)
+			}
+		})
+	}
+}
+
+func TestTracingResponseWriter(t *testing.T) {
+	mock := &mockTracer{}
+	ctx := context.Background()
+	_, span := mock.Start(ctx, "test")
+
+	rr := httptest.NewRecorder()
+	trw := &tracingResponseWriter{
+		ResponseWriter: rr,
+		span:           span,
+	}
+
+	// Write should trigger WriteHeader
+	_, _ = trw.Write([]byte("hello"))
+
+	if trw.statusCode != 200 {
+		t.Errorf("statusCode = %d, want 200", trw.statusCode)
+	}
+
+	if rr.Code != 200 {
+		t.Errorf("recorder code = %d, want 200", rr.Code)
+	}
+
+	// Multiple WriteHeader calls should be safe
+	trw.WriteHeader(500)
+	if trw.statusCode != 200 {
+		t.Error("WriteHeader should not change status after already written")
+	}
+}

--- a/trace/noop.go
+++ b/trace/noop.go
@@ -1,0 +1,33 @@
+package trace
+
+import "context"
+
+// NoopTracer is a Tracer implementation that does nothing.
+// It is used as the default when no tracer is configured.
+type NoopTracer struct{}
+
+// NewNoopTracer creates a new no-op tracer.
+func NewNoopTracer() Tracer {
+	return &NoopTracer{}
+}
+
+// Start returns the context unchanged and a no-op span.
+func (n *NoopTracer) Start(ctx context.Context, name string, opts ...SpanOption) (context.Context, Span) {
+	return ctx, &noopSpan{}
+}
+
+// Ensure NoopTracer implements Tracer
+var _ Tracer = (*NoopTracer)(nil)
+
+type noopSpan struct{}
+
+func (n *noopSpan) End() {}
+
+func (n *noopSpan) SetStatus(code Code, description string) {}
+
+func (n *noopSpan) SetAttributes(attrs ...Attribute) {}
+
+func (n *noopSpan) RecordError(err error, opts ...ErrorOption) {}
+
+// Ensure noopSpan implements Span
+var _ Span = (*noopSpan)(nil)

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -1,0 +1,165 @@
+// Package trace provides interfaces for distributed tracing.
+//
+// This package defines a pluggable tracing interface that allows users to integrate
+// their preferred tracing implementation (e.g., OpenTelemetry, Jaeger, Zipkin) without
+// forcing dependencies on the core framework.
+//
+// Usage:
+//
+//	// No tracing (default)
+//	app := zerohttp.New()
+//
+//	// With custom tracer
+//	app := zerohttp.New(config.Config{
+//	    Tracer: myTracer,
+//	})
+//
+//	// In handlers, access the current span:
+//	span := trace.SpanFromContext(r.Context())
+//	span.SetAttributes(trace.Attribute{Key: "user.id", Value: userID})
+package trace
+
+import "context"
+
+// Tracer is the interface for creating spans in distributed traces.
+// Implementations should be safe for concurrent use.
+type Tracer interface {
+	// Start creates a new span and returns the updated context containing the span.
+	// The span becomes the "current" span in the returned context.
+	//
+	// The parent span is determined from ctx using SpanFromContext.
+	// If no parent span exists in ctx, the new span is a root span.
+	//
+	// The span must be ended by calling End() on the returned Span.
+	Start(ctx context.Context, name string, opts ...SpanOption) (context.Context, Span)
+}
+
+// Span represents a single operation within a trace.
+type Span interface {
+	// End completes the span. No further operations should be performed on the span
+	// after End is called. End is safe to call multiple times; subsequent calls
+	// are no-ops.
+	End()
+
+	// SetStatus sets the status of the span. If used, this should be called before End.
+	// code indicates whether the span completed successfully (CodeOk) or with an error (CodeError).
+	// description provides additional details when code is CodeError.
+	SetStatus(code Code, description string)
+
+	// SetAttributes adds attributes to the span.
+	// Attributes are key-value pairs that provide additional context about the span.
+	// Duplicate keys overwrite existing values.
+	SetAttributes(attrs ...Attribute)
+
+	// RecordError records an error as an exception on the span.
+	// This indicates that the operation represented by the span encountered an error.
+	RecordError(err error, opts ...ErrorOption)
+}
+
+// Code represents the status code of a span.
+type Code uint32
+
+const (
+	// CodeUnset is the default status code, indicating the span status was not set.
+	CodeUnset Code = 0
+
+	// CodeOk indicates the span completed successfully.
+	CodeOk Code = 1
+
+	// CodeError indicates the span completed with an error.
+	CodeError Code = 2
+)
+
+// Attribute is a key-value pair that provides metadata about a span.
+type Attribute struct {
+	Key   string
+	Value any
+}
+
+// String creates a string attribute.
+func String(key, value string) Attribute {
+	return Attribute{Key: key, Value: value}
+}
+
+// Int creates an int attribute.
+func Int(key string, value int) Attribute {
+	return Attribute{Key: key, Value: value}
+}
+
+// Int64 creates an int64 attribute.
+func Int64(key string, value int64) Attribute {
+	return Attribute{Key: key, Value: value}
+}
+
+// Float64 creates a float64 attribute.
+func Float64(key string, value float64) Attribute {
+	return Attribute{Key: key, Value: value}
+}
+
+// Bool creates a bool attribute.
+func Bool(key string, value bool) Attribute {
+	return Attribute{Key: key, Value: value}
+}
+
+// SpanOption applies a configuration to a span.
+type SpanOption interface {
+	apply(*spanConfig)
+}
+
+type spanConfig struct {
+	attributes []Attribute
+}
+
+// WithAttributes returns a SpanOption that sets attributes on the span.
+func WithAttributes(attrs ...Attribute) SpanOption {
+	return withAttributes(attrs)
+}
+
+type withAttributes []Attribute
+
+func (w withAttributes) apply(cfg *spanConfig) {
+	cfg.attributes = append(cfg.attributes, w...)
+}
+
+// ErrorOption applies a configuration when recording an error.
+type ErrorOption interface {
+	applyError(*errorConfig)
+}
+
+type errorConfig struct {
+	attributes []Attribute
+}
+
+// WithErrorAttributes returns an ErrorOption that sets attributes on the error.
+func WithErrorAttributes(attrs ...Attribute) ErrorOption {
+	return withErrorAttributes(attrs)
+}
+
+type withErrorAttributes []Attribute
+
+func (w withErrorAttributes) applyError(cfg *errorConfig) {
+	cfg.attributes = append(cfg.attributes, w...)
+}
+
+// contextKey is the type for context keys used by this package.
+type contextKey int
+
+const spanKey contextKey = 0
+
+// ContextWithSpan returns a new context containing the provided span.
+// This is useful for passing spans through context to child operations.
+func ContextWithSpan(ctx context.Context, span Span) context.Context {
+	return context.WithValue(ctx, spanKey, span)
+}
+
+// SpanFromContext returns the span contained in the context, if any.
+// Returns nil if no span is found in the context.
+func SpanFromContext(ctx context.Context) Span {
+	if ctx == nil {
+		return nil
+	}
+	if s, ok := ctx.Value(spanKey).(Span); ok {
+		return s
+	}
+	return nil
+}

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -1,0 +1,202 @@
+package trace
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestAttributeHelpers(t *testing.T) {
+	tests := []struct {
+		name    string
+		attr    Attribute
+		wantKey string
+		wantVal any
+	}{
+		{"String", String("key", "value"), "key", "value"},
+		{"Int", Int("count", 42), "count", 42},
+		{"Int64", Int64("size", 9223372036854775807), "size", int64(9223372036854775807)},
+		{"Float64", Float64("pi", 3.14), "pi", 3.14},
+		{"Bool", Bool("active", true), "active", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.attr.Key != tt.wantKey {
+				t.Errorf("Key = %q, want %q", tt.attr.Key, tt.wantKey)
+			}
+			if tt.attr.Value != tt.wantVal {
+				t.Errorf("Value = %v, want %v", tt.attr.Value, tt.wantVal)
+			}
+		})
+	}
+}
+
+func TestNoopTracer(t *testing.T) {
+	tracer := NewNoopTracer()
+
+	ctx := context.Background()
+	ctx, span := tracer.Start(ctx, "test-span",
+		WithAttributes(String("key", "value")),
+	)
+
+	// No-op should not panic
+	span.SetAttributes(String("another", "attr"))
+	span.SetStatus(CodeOk, "success")
+	span.RecordError(errors.New("test error"))
+	span.End()
+
+	// Context should be unchanged
+	if ctx == nil {
+		t.Error("Expected non-nil context")
+	}
+}
+
+func TestContextWithSpan(t *testing.T) {
+	tracer := NewNoopTracer()
+
+	ctx := context.Background()
+	_, span := tracer.Start(ctx, "test")
+
+	// Store span in context
+	ctx = ContextWithSpan(ctx, span)
+
+	// Retrieve span from context
+	retrieved := SpanFromContext(ctx)
+	if retrieved == nil {
+		t.Error("Expected to retrieve span from context")
+	}
+
+	// Nil context should return nil
+	if SpanFromContext(context.TODO()) != nil {
+		t.Error("Expected nil from context without span")
+	}
+
+	// Context without span should return nil
+	emptyCtx := context.Background()
+	if SpanFromContext(emptyCtx) != nil {
+		t.Error("Expected nil from context without span")
+	}
+}
+
+func TestSpanConfig(t *testing.T) {
+	cfg := &spanConfig{}
+
+	// Apply WithAttributes
+	opt := WithAttributes(
+		String("key1", "val1"),
+		Int("key2", 42),
+	)
+	opt.apply(cfg)
+
+	if len(cfg.attributes) != 2 {
+		t.Errorf("Expected 2 attributes, got %d", len(cfg.attributes))
+	}
+}
+
+func TestErrorConfig(t *testing.T) {
+	cfg := &errorConfig{}
+
+	// Apply WithErrorAttributes
+	opt := WithErrorAttributes(String("error.type", "test"))
+	opt.applyError(cfg)
+
+	if len(cfg.attributes) != 1 {
+		t.Errorf("Expected 1 attribute, got %d", len(cfg.attributes))
+	}
+}
+
+func TestCodeConstants(t *testing.T) {
+	if CodeUnset != 0 {
+		t.Errorf("CodeUnset = %d, want 0", CodeUnset)
+	}
+	if CodeOk != 1 {
+		t.Errorf("CodeOk = %d, want 1", CodeOk)
+	}
+	if CodeError != 2 {
+		t.Errorf("CodeError = %d, want 2", CodeError)
+	}
+}
+
+// mockTracer is a test tracer that records span creation
+type mockTracer struct {
+	spans []*mockSpan
+}
+
+func (m *mockTracer) Start(ctx context.Context, name string, opts ...SpanOption) (context.Context, Span) {
+	span := &mockSpan{name: name}
+	m.spans = append(m.spans, span)
+
+	// Apply options
+	cfg := &spanConfig{}
+	for _, opt := range opts {
+		opt.apply(cfg)
+	}
+	span.attributes = cfg.attributes
+
+	return ContextWithSpan(ctx, span), span
+}
+
+type mockSpan struct {
+	name       string
+	statusCode Code
+	statusDesc string
+	attributes []Attribute
+	errors     []error
+	ended      bool
+}
+
+func (m *mockSpan) End() {
+	m.ended = true
+}
+
+func (m *mockSpan) SetStatus(code Code, description string) {
+	m.statusCode = code
+	m.statusDesc = description
+}
+
+func (m *mockSpan) SetAttributes(attrs ...Attribute) {
+	m.attributes = append(m.attributes, attrs...)
+}
+
+func (m *mockSpan) RecordError(err error, opts ...ErrorOption) {
+	m.errors = append(m.errors, err)
+}
+
+func TestMockTracer(t *testing.T) {
+	mock := &mockTracer{}
+	ctx := context.Background()
+
+	ctx, span := mock.Start(ctx, "test-operation",
+		WithAttributes(String("service", "test")),
+	)
+
+	if len(mock.spans) != 1 {
+		t.Fatalf("Expected 1 span, got %d", len(mock.spans))
+	}
+
+	mockSpan := mock.spans[0]
+	if mockSpan.name != "test-operation" {
+		t.Errorf("Name = %q, want %q", mockSpan.name, "test-operation")
+	}
+
+	if len(mockSpan.attributes) != 1 {
+		t.Errorf("Expected 1 attribute, got %d", len(mockSpan.attributes))
+	}
+
+	// Test span methods
+	span.SetStatus(CodeOk, "success")
+	if mockSpan.statusCode != CodeOk {
+		t.Errorf("Status code = %d, want %d", mockSpan.statusCode, CodeOk)
+	}
+
+	span.End()
+	if !mockSpan.ended {
+		t.Error("Expected span to be ended")
+	}
+
+	// Verify context has span
+	if SpanFromContext(ctx) == nil {
+		t.Error("Expected span in context")
+	}
+}


### PR DESCRIPTION
- Add trace package with Tracer and Span interfaces
- Add Tracing middleware for HTTP request tracing
- Add TracerConfig for exempt paths and span naming
- No external dependencies - bring your own implementation
- Examples: custom logger, OpenTelemetry, Jaeger