### PR TITLE
feat: pluggable rate limit store with secure in-memory backend

### DIFF
--- a/config/rate_limit.go
+++ b/config/rate_limit.go
@@ -1,9 +1,17 @@
 package config
 
 import (
+	"context"
+	"net"
 	"net/http"
+	"strings"
 	"time"
 )
+
+// RateLimitStore defines the interface for rate limit storage backends.
+type RateLimitStore interface {
+	CheckAndRecord(ctx context.Context, key string, now time.Time) (bool, int, time.Time)
+}
 
 // RateLimitAlgorithm defines the rate limiting algorithm
 type RateLimitAlgorithm string
@@ -38,15 +46,35 @@ type RateLimitConfig struct {
 	IncludeHeaders bool
 	// ExemptPaths contains paths to skip rate limiting
 	ExemptPaths []string
+	// Store is the storage backend for rate limiting.
+	// If nil, a secure in-memory store is used.
+	Store RateLimitStore
+	// MaxKeys limits the number of unique keys stored in the default
+	// in-memory store. Defaults to 10000. Set to 0 for unlimited (not recommended).
+	MaxKeys int
 }
 
-// DefaultKeyExtractor extracts IP address as the rate limit key
+// DefaultKeyExtractor extracts IP address as the rate limit key.
+// It strips the port from RemoteAddr so all connections from the same IP
+// share the same rate limit. For X-Forwarded-For, it uses the first IP.
 func DefaultKeyExtractor(r *http.Request) string {
-	// Use X-Forwarded-For if available, otherwise RemoteAddr
+	var ip string
+
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		return xff
+		// X-Forwarded-For can contain multiple IPs: "client, proxy1, proxy2"
+		// Use the first one (client IP)
+		ip, _, _ = strings.Cut(xff, ",")
+		ip = strings.TrimSpace(ip)
+	} else {
+		ip = r.RemoteAddr
 	}
-	return r.RemoteAddr
+
+	if host, _, err := net.SplitHostPort(ip); err == nil {
+		return host
+	}
+
+	// If SplitHostPort fails (no port), return as-is
+	return ip
 }
 
 // DefaultRateLimitConfig contains the default values for rate limit configuration.

--- a/config/rate_limit_test.go
+++ b/config/rate_limit_test.go
@@ -42,11 +42,11 @@ func TestDefaultKeyExtractorFunction(t *testing.T) {
 		xForwardedFor string
 		expectedKey   string
 	}{
-		{"no forwarded header", "192.168.1.1:8080", "", "192.168.1.1:8080"},
+		{"no forwarded header", "192.168.1.1:8080", "", "192.168.1.1"},
 		{"with forwarded header", "192.168.1.1:8080", "203.0.113.1", "203.0.113.1"},
-		{"empty forwarded header", "192.168.1.1:8080", "", "192.168.1.1:8080"},
-		{"forwarded with multiple IPs", "192.168.1.1:8080", "203.0.113.1, 198.51.100.1", "203.0.113.1, 198.51.100.1"},
-		{"IPv6 address", "[::1]:8080", "", "[::1]:8080"},
+		{"empty forwarded header", "192.168.1.1:8080", "", "192.168.1.1"},
+		{"forwarded with multiple IPs", "192.168.1.1:8080", "203.0.113.1, 198.51.100.1", "203.0.113.1"},
+		{"IPv6 address", "[::1]:8080", "", "::1"},
 		{"IPv6 with forwarded", "[::1]:8080", "2001:db8::1", "2001:db8::1"},
 	}
 

--- a/examples/rate_limit/main.go
+++ b/examples/rate_limit/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/middleware"
+)
+
+func main() {
+	router := zh.New()
+
+	// Example 1: Default rate limiting (token bucket, 100 req/min)
+	router.GET("/api/default", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return responseJSON(w, r)
+	}), middleware.RateLimit())
+
+	// Example 2: Strict rate limiting (10 req/second, sliding window)
+	router.GET("/api/strict", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return responseJSON(w, r)
+	}), middleware.RateLimit(config.RateLimitConfig{
+		Rate:           10,
+		Window:         time.Second,
+		Algorithm:      config.SlidingWindow,
+		IncludeHeaders: true,
+	}))
+
+	// Example 3: Per-user rate limiting (using header)
+	router.GET("/api/user", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return responseJSON(w, r)
+	}), middleware.RateLimit(config.RateLimitConfig{
+		Rate:           5,
+		Window:         time.Minute,
+		IncludeHeaders: true,
+		KeyExtractor: func(r *http.Request) string {
+			// Rate limit per user ID header
+			userID := r.Header.Get("X-User-ID")
+			if userID == "" {
+				return "anonymous"
+			}
+			return userID
+		},
+	}))
+
+	// Example 4: Custom store (in-memory with higher limit)
+	router.GET("/api/high-volume", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return responseJSON(w, r)
+	}), middleware.RateLimit(config.RateLimitConfig{
+		Rate:           1000,
+		Window:         time.Minute,
+		MaxKeys:        100000, // Allow more unique keys
+		IncludeHeaders: true,
+	}))
+
+	// Example 5: Exempt health check from rate limiting
+	router.GET("/health", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return zh.R.JSON(w, http.StatusOK, zh.M{"status": "healthy"})
+	}), middleware.RateLimit(config.RateLimitConfig{
+		Rate:           10,
+		Window:         time.Second,
+		ExemptPaths:    []string{"/health", "/metrics"},
+		IncludeHeaders: true,
+	}))
+
+	fmt.Println("Rate limit examples:")
+	fmt.Println("  Default:       curl http://localhost:8080/api/default")
+	fmt.Println("  Strict:        curl http://localhost:8080/api/strict")
+	fmt.Println("  Per-user:      curl -H 'X-User-ID: user1' http://localhost:8080/api/user")
+	fmt.Println("  High volume:   curl http://localhost:8080/api/high-volume")
+	fmt.Println("  Health (exempt): curl http://localhost:8080/health")
+	fmt.Println()
+	fmt.Println("Server starting on :8080")
+	if err := router.Start(); err != nil {
+		panic(err)
+	}
+}
+
+func responseJSON(w http.ResponseWriter, _ *http.Request) error {
+	// Return rate limit headers if present
+	limit := w.Header().Get("X-RateLimit-Limit")
+	remaining := w.Header().Get("X-RateLimit-Remaining")
+	reset := w.Header().Get("X-RateLimit-Reset")
+
+	return zh.R.JSON(w, http.StatusOK, zh.M{
+		"status":    "ok",
+		"limit":     limit,
+		"remaining": remaining,
+		"reset":     reset,
+	})
+}

--- a/examples/rate_limit/redis.go
+++ b/examples/rate_limit/redis.go
@@ -1,0 +1,150 @@
+//go:build ignore
+
+// This example shows how to implement a custom Redis-backed rate limit store
+// for distributed rate limiting across multiple server instances.
+//
+// To run this example:
+//
+//  1. Start Redis: docker run -d --name redis -p 6379:6379 redis:7-alpine
+//  2. Install dependencies: go get github.com/redis/go-redis/v9
+//  3. Run this example: go run examples/rate_limit/redis.go
+//  4. Make some requests: curl http://localhost:8080/
+//  5. Stop Redis: docker stop redis && docker rm redis
+//
+// Install dependencies:
+//
+//	go get github.com/redis/go-redis/v9
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/middleware"
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisStore implements config.RateLimitStore using Redis for distributed
+// rate limiting across multiple server instances.
+type RedisStore struct {
+	client    *redis.Client
+	window    time.Duration
+	rate      int
+	algorithm config.RateLimitAlgorithm
+	keyPrefix string
+}
+
+// NewRedisStore creates a new Redis-backed rate limit store.
+// This allows rate limiting to work across multiple server instances.
+func NewRedisStore(client *redis.Client, algorithm config.RateLimitAlgorithm, window time.Duration, rate int) *RedisStore {
+	return &RedisStore{
+		client:    client,
+		window:    window,
+		rate:      rate,
+		algorithm: algorithm,
+		keyPrefix: "ratelimit:",
+	}
+}
+
+// CheckAndRecord implements config.RateLimitStore using Redis.
+// Uses sliding window algorithm with Redis sorted sets.
+func (s *RedisStore) CheckAndRecord(ctx context.Context, key string, now time.Time) (bool, int, time.Time) {
+	windowStart := now.Add(-s.window)
+	redisKey := s.keyPrefix + key
+
+	// Remove old entries outside the window
+	s.client.ZRemRangeByScore(ctx, redisKey, "0", fmt.Sprintf("%d", windowStart.UnixMilli()))
+
+	// Count current entries in window
+	count, err := s.client.ZCard(ctx, redisKey).Result()
+	if err != nil {
+		// On error, allow the request (fail open)
+		return true, s.rate - 1, now.Add(s.window)
+	}
+
+	if int(count) >= s.rate {
+		// Rate limit exceeded
+		oldest, _ := s.client.ZRangeWithScores(ctx, redisKey, 0, 0).Result()
+		resetTime := now.Add(s.window)
+		if len(oldest) > 0 {
+			resetTime = time.UnixMilli(int64(oldest[0].Score)).Add(s.window)
+		}
+		return false, 0, resetTime
+	}
+
+	// Add current request to the window
+	err = s.client.ZAdd(ctx, redisKey, redis.Z{
+		Score:  float64(now.UnixMilli()),
+		Member: now.UnixNano(),
+	}).Err()
+	if err != nil {
+		return true, s.rate - 1, now.Add(s.window)
+	}
+
+	// Set expiry on the key to auto-cleanup
+	s.client.Expire(ctx, redisKey, s.window)
+
+	remaining := s.rate - int(count) - 1
+	resetTime := now.Add(s.window)
+
+	return true, remaining, resetTime
+}
+
+func main() {
+	// Create Redis client
+	client := redis.NewClient(&redis.Options{
+		Addr: "localhost:6379",
+	})
+
+	// Test Redis connection
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := client.Ping(ctx).Err(); err != nil {
+		log.Fatalf("Failed to connect to Redis: %v\nMake sure Redis is running: docker run -d --name redis -p 6379:6379 redis:7-alpine", err)
+	}
+
+	// Create Redis-backed rate limit store
+	// IMPORTANT: Rate and Window must match between store and config
+	rate := 10
+	window := time.Minute
+	store := NewRedisStore(client, config.SlidingWindow, window, rate)
+
+	// Configure the server with Redis store
+	app := zh.New()
+	app.Use(middleware.RateLimit(config.RateLimitConfig{
+		Store:          store,
+		Rate:           rate,
+		Window:         window,
+		IncludeHeaders: true,
+	}))
+
+	// Simple endpoint
+	app.GET("/", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		// Return rate limit headers if present
+		limit := w.Header().Get("X-RateLimit-Limit")
+		remaining := w.Header().Get("X-RateLimit-Remaining")
+		reset := w.Header().Get("X-RateLimit-Reset")
+
+		return zh.R.JSON(w, http.StatusOK, zh.M{
+			"message":   "Hello with Redis rate limiting!",
+			"limit":     limit,
+			"remaining": remaining,
+			"reset":     reset,
+		})
+	}))
+
+	fmt.Println("Server starting on http://localhost:8080")
+	fmt.Println()
+	fmt.Println("Try these commands:")
+	fmt.Println("  for i in {1..12}; do curl http://localhost:8080/; done")
+	fmt.Println()
+	fmt.Println("After 10 requests, you should see 'Rate limit exceeded'")
+	fmt.Println()
+
+	log.Fatal(app.Start())
+}

--- a/middleware/rate_limit.go
+++ b/middleware/rate_limit.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"net/http"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/alexferl/zerohttp/config"
@@ -11,23 +10,7 @@ import (
 	"github.com/alexferl/zerohttp/metrics"
 )
 
-// Bucket represents a token bucket for rate limiting
-type Bucket struct {
-	tokens     float64
-	capacity   float64
-	rate       float64
-	lastRefill time.Time
-	mutex      sync.Mutex
-}
-
-// WindowCounter represents a counter for window-based rate limiting
-type WindowCounter struct {
-	count       int
-	windowStart time.Time
-	mutex       sync.Mutex
-}
-
-// RateLimit creates a rate limiting middleware
+// RateLimit creates a rate limiting middleware.
 func RateLimit(cfg ...config.RateLimitConfig) func(http.Handler) http.Handler {
 	c := config.DefaultRateLimitConfig
 	if len(cfg) > 0 {
@@ -53,10 +36,17 @@ func RateLimit(cfg ...config.RateLimitConfig) func(http.Handler) http.Handler {
 		c.Message = config.DefaultRateLimitConfig.Message
 	}
 
-	buckets := make(map[string]*Bucket)
-	counters := make(map[string]*WindowCounter)
-	slidingWindows := make(map[string][]time.Time)
-	mu := sync.RWMutex{}
+	// Use provided store or create default in-memory store
+	var store RateLimitStore
+	if c.Store != nil {
+		store = c.Store
+	} else {
+		maxKeys := c.MaxKeys
+		if maxKeys == 0 {
+			maxKeys = 10000
+		}
+		store = NewInMemoryStore(c.Algorithm, c.Window, c.Rate, maxKeys)
+	}
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -71,90 +61,7 @@ func RateLimit(cfg ...config.RateLimitConfig) func(http.Handler) http.Handler {
 
 			key := c.KeyExtractor(r)
 			now := time.Now()
-			allowed := false
-			remaining := 0
-			resetTime := now.Add(c.Window)
-
-			mu.Lock()
-			defer mu.Unlock()
-
-			switch c.Algorithm {
-			case config.TokenBucket:
-				bucket, exists := buckets[key]
-				if !exists {
-					bucket = &Bucket{
-						tokens:     float64(c.Rate),
-						capacity:   float64(c.Rate),
-						rate:       float64(c.Rate) / c.Window.Seconds(),
-						lastRefill: now,
-					}
-					buckets[key] = bucket
-				}
-
-				bucket.mutex.Lock()
-				// Refill tokens based on elapsed time
-				elapsed := now.Sub(bucket.lastRefill).Seconds()
-				bucket.tokens = min(bucket.capacity, bucket.tokens+elapsed*bucket.rate)
-				bucket.lastRefill = now
-
-				if bucket.tokens >= 1.0 {
-					bucket.tokens--
-					allowed = true
-					remaining = int(bucket.tokens)
-				} else {
-					remaining = 0
-				}
-				bucket.mutex.Unlock()
-
-			case config.FixedWindow:
-				counter, exists := counters[key]
-				if !exists || now.Sub(counter.windowStart) >= c.Window {
-					counter = &WindowCounter{
-						count:       0,
-						windowStart: now,
-					}
-					counters[key] = counter
-				}
-
-				counter.mutex.Lock()
-				if counter.count < c.Rate {
-					counter.count++
-					allowed = true
-					remaining = c.Rate - counter.count
-				} else {
-					remaining = 0
-				}
-				resetTime = counter.windowStart.Add(c.Window)
-				counter.mutex.Unlock()
-
-			case config.SlidingWindow:
-				window, exists := slidingWindows[key]
-				if !exists {
-					window = []time.Time{}
-				}
-
-				// Remove expired entries
-				cutoff := now.Add(-c.Window)
-				newWindow := window[:0]
-				for _, t := range window {
-					if t.After(cutoff) {
-						newWindow = append(newWindow, t)
-					}
-				}
-
-				if len(newWindow) < c.Rate {
-					newWindow = append(newWindow, now)
-					allowed = true
-					remaining = c.Rate - len(newWindow)
-				} else {
-					remaining = 0
-				}
-
-				slidingWindows[key] = newWindow
-				if len(newWindow) > 0 {
-					resetTime = newWindow[0].Add(c.Window)
-				}
-			}
+			allowed, remaining, resetTime := store.CheckAndRecord(r.Context(), key, now)
 
 			if c.IncludeHeaders {
 				w.Header().Set("X-RateLimit-Limit", strconv.Itoa(c.Rate))
@@ -169,12 +76,11 @@ func RateLimit(cfg ...config.RateLimitConfig) func(http.Handler) http.Handler {
 				reg.Counter("ratelimit_rejected_total", "key").WithLabelValues(key).Inc()
 				w.Header().Set("Retry-After", strconv.Itoa(int(time.Until(resetTime).Seconds())))
 				detail := problem.NewDetail(c.StatusCode, c.Message)
-				_ = detail.Render(w) // Best effort - client may have disconnected
+				_ = detail.Render(w)
 				return
 			}
 
 			reg.Counter("ratelimit_allowed_total", "key").WithLabelValues(key).Inc()
-
 			next.ServeHTTP(w, r)
 		})
 	}

--- a/middleware/rate_limit_store.go
+++ b/middleware/rate_limit_store.go
@@ -1,0 +1,244 @@
+package middleware
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/alexferl/zerohttp/config"
+)
+
+// RateLimitStore is an alias for config.RateLimitStore.
+type RateLimitStore = config.RateLimitStore
+
+// bucketEntry represents a token bucket for rate limiting.
+type bucketEntry struct {
+	tokens     float64
+	capacity   float64
+	rate       float64
+	lastRefill time.Time
+	lastAccess time.Time
+	mutex      sync.Mutex
+}
+
+// counterEntry represents a fixed window counter.
+type counterEntry struct {
+	count       int
+	windowStart time.Time
+	lastAccess  time.Time
+	mutex       sync.Mutex
+}
+
+// windowEntry represents a sliding window with timestamps.
+type windowEntry struct {
+	timestamps []time.Time
+	lastAccess time.Time
+	mutex      sync.Mutex
+}
+
+// InMemoryStore is a secure in-memory implementation of RateLimitStore
+// with automatic expiration and max keys limit.
+type InMemoryStore struct {
+	algorithm config.RateLimitAlgorithm
+	window    time.Duration
+	rate      int
+	maxKeys   int
+
+	buckets  map[string]*bucketEntry
+	counters map[string]*counterEntry
+	windows  map[string]*windowEntry
+
+	mu sync.RWMutex
+}
+
+// NewInMemoryStore creates a new in-memory rate limit store.
+// If maxKeys is 0, a default of 10000 is used.
+func NewInMemoryStore(algorithm config.RateLimitAlgorithm, window time.Duration, rate, maxKeys int) *InMemoryStore {
+	if maxKeys <= 0 {
+		maxKeys = 10000
+	}
+
+	return &InMemoryStore{
+		algorithm: algorithm,
+		window:    window,
+		rate:      rate,
+		maxKeys:   maxKeys,
+		buckets:   make(map[string]*bucketEntry),
+		counters:  make(map[string]*counterEntry),
+		windows:   make(map[string]*windowEntry),
+	}
+}
+
+// CheckAndRecord implements RateLimitStore.
+func (s *InMemoryStore) CheckAndRecord(ctx context.Context, key string, now time.Time) (bool, int, time.Time) {
+	switch s.algorithm {
+	case config.TokenBucket:
+		return s.checkTokenBucket(key, now)
+	case config.FixedWindow:
+		return s.checkFixedWindow(key, now)
+	case config.SlidingWindow:
+		return s.checkSlidingWindow(key, now)
+	default:
+		return s.checkTokenBucket(key, now)
+	}
+}
+
+func (s *InMemoryStore) checkTokenBucket(key string, now time.Time) (bool, int, time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, exists := s.buckets[key]
+	if !exists || now.Sub(entry.lastAccess) > s.window {
+		// Entry doesn't exist or expired - create new
+		if exists {
+			delete(s.buckets, key)
+		}
+		if len(s.buckets) >= s.maxKeys {
+			s.evictOldestBucket()
+		}
+		entry = &bucketEntry{
+			tokens:     float64(s.rate),
+			capacity:   float64(s.rate),
+			rate:       float64(s.rate) / s.window.Seconds(),
+			lastRefill: now,
+			lastAccess: now,
+		}
+		s.buckets[key] = entry
+	} else {
+		entry.lastAccess = now
+	}
+
+	entry.mutex.Lock()
+	defer entry.mutex.Unlock()
+
+	elapsed := now.Sub(entry.lastRefill).Seconds()
+	entry.tokens = min(entry.capacity, entry.tokens+elapsed*entry.rate)
+	entry.lastRefill = now
+
+	resetTime := now.Add(time.Duration((entry.capacity-entry.tokens)/entry.rate) * time.Second)
+
+	if entry.tokens >= 1.0 {
+		entry.tokens--
+		return true, int(entry.tokens), resetTime
+	}
+
+	return false, 0, resetTime
+}
+
+func (s *InMemoryStore) checkFixedWindow(key string, now time.Time) (bool, int, time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, exists := s.counters[key]
+	if !exists || now.Sub(entry.windowStart) >= s.window {
+		// Window expired or new entry
+		if exists {
+			delete(s.counters, key)
+		}
+		if len(s.counters) >= s.maxKeys {
+			s.evictOldestCounter()
+		}
+		entry = &counterEntry{
+			count:       1,
+			windowStart: now,
+			lastAccess:  now,
+		}
+		s.counters[key] = entry
+		return true, s.rate - 1, now.Add(s.window)
+	}
+
+	entry.lastAccess = now
+	entry.mutex.Lock()
+	defer entry.mutex.Unlock()
+
+	if entry.count < s.rate {
+		entry.count++
+		return true, s.rate - entry.count, entry.windowStart.Add(s.window)
+	}
+
+	return false, 0, entry.windowStart.Add(s.window)
+}
+
+func (s *InMemoryStore) checkSlidingWindow(key string, now time.Time) (bool, int, time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, exists := s.windows[key]
+	if !exists || now.Sub(entry.lastAccess) > s.window {
+		// Entry expired or new
+		if exists {
+			delete(s.windows, key)
+		}
+		if len(s.windows) >= s.maxKeys {
+			s.evictOldestWindow()
+		}
+		entry = &windowEntry{
+			timestamps: []time.Time{now},
+			lastAccess: now,
+		}
+		s.windows[key] = entry
+		return true, s.rate - 1, now.Add(s.window)
+	}
+
+	entry.mutex.Lock()
+	entry.lastAccess = now
+	defer entry.mutex.Unlock()
+
+	// Remove expired timestamps
+	cutoff := now.Add(-s.window)
+	newTimestamps := entry.timestamps[:0]
+	for _, t := range entry.timestamps {
+		if t.After(cutoff) {
+			newTimestamps = append(newTimestamps, t)
+		}
+	}
+
+	if len(newTimestamps) < s.rate {
+		newTimestamps = append(newTimestamps, now)
+		entry.timestamps = newTimestamps
+		remaining := s.rate - len(newTimestamps)
+		resetTime := now.Add(s.window)
+		if len(newTimestamps) > 0 {
+			resetTime = newTimestamps[0].Add(s.window)
+		}
+		return true, remaining, resetTime
+	}
+
+	entry.timestamps = newTimestamps
+	resetTime := newTimestamps[0].Add(s.window)
+	return false, 0, resetTime
+}
+
+// entryWithLastAccess is an interface for entries that have a lastAccess field.
+type entryWithLastAccess interface {
+	getLastAccess() time.Time
+}
+
+func (e *bucketEntry) getLastAccess() time.Time  { return e.lastAccess }
+func (e *counterEntry) getLastAccess() time.Time { return e.lastAccess }
+func (e *windowEntry) getLastAccess() time.Time  { return e.lastAccess }
+
+// evictOldest removes the entry with the oldest lastAccess time from the map.
+// If multiple entries have the same lastAccess, the lexicographically smaller key is chosen.
+func evictOldest[M ~map[string]E, E entryWithLastAccess](m M) {
+	var oldestKey string
+	var oldestTime time.Time
+	first := true
+
+	for key, entry := range m {
+		accessTime := entry.getLastAccess()
+		if first || accessTime.Before(oldestTime) || (accessTime.Equal(oldestTime) && key < oldestKey) {
+			oldestKey = key
+			oldestTime = accessTime
+			first = false
+		}
+	}
+
+	if oldestKey != "" {
+		delete(m, oldestKey)
+	}
+}
+
+func (s *InMemoryStore) evictOldestBucket()  { evictOldest(s.buckets) }
+func (s *InMemoryStore) evictOldestCounter() { evictOldest(s.counters) }
+func (s *InMemoryStore) evictOldestWindow()  { evictOldest(s.windows) }

--- a/middleware/rate_limit_store_test.go
+++ b/middleware/rate_limit_store_test.go
@@ -1,0 +1,376 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/zhtest"
+)
+
+// TestInMemoryStore_TokenBucket tests token bucket algorithm in InMemoryStore
+func TestInMemoryStore_TokenBucket(t *testing.T) {
+	store := NewInMemoryStore(config.TokenBucket, time.Second, 2, 100)
+	ctx := context.Background()
+	now := time.Now()
+
+	// First request allowed
+	allowed, remaining, _ := store.CheckAndRecord(ctx, "key1", now)
+	if !allowed {
+		t.Error("first request should be allowed")
+	}
+	if remaining != 1 {
+		t.Errorf("expected remaining=1, got %d", remaining)
+	}
+
+	// Second request allowed
+	allowed, remaining, _ = store.CheckAndRecord(ctx, "key1", now)
+	if !allowed {
+		t.Error("second request should be allowed")
+	}
+	if remaining != 0 {
+		t.Errorf("expected remaining=0, got %d", remaining)
+	}
+
+	// Third request denied
+	allowed, remaining, _ = store.CheckAndRecord(ctx, "key1", now)
+	if allowed {
+		t.Error("third request should be denied")
+	}
+	if remaining != 0 {
+		t.Errorf("expected remaining=0, got %d", remaining)
+	}
+}
+
+// TestInMemoryStore_FixedWindow tests fixed window algorithm in InMemoryStore
+func TestInMemoryStore_FixedWindow(t *testing.T) {
+	store := NewInMemoryStore(config.FixedWindow, time.Second, 3, 100)
+	ctx := context.Background()
+	now := time.Now()
+
+	// Three requests allowed
+	for i := 0; i < 3; i++ {
+		allowed, _, _ := store.CheckAndRecord(ctx, "key1", now)
+		if !allowed {
+			t.Errorf("request %d should be allowed", i+1)
+		}
+	}
+
+	// Fourth request denied
+	allowed, _, _ := store.CheckAndRecord(ctx, "key1", now)
+	if allowed {
+		t.Error("fourth request should be denied")
+	}
+}
+
+// TestInMemoryStore_SlidingWindow tests sliding window algorithm in InMemoryStore
+func TestInMemoryStore_SlidingWindow(t *testing.T) {
+	store := NewInMemoryStore(config.SlidingWindow, 100*time.Millisecond, 2, 100)
+	ctx := context.Background()
+	now := time.Now()
+
+	// Two requests allowed
+	for i := 0; i < 2; i++ {
+		allowed, _, _ := store.CheckAndRecord(ctx, "key1", now)
+		if !allowed {
+			t.Errorf("request %d should be allowed", i+1)
+		}
+	}
+
+	// Third request denied
+	allowed, _, _ := store.CheckAndRecord(ctx, "key1", now)
+	if allowed {
+		t.Error("third request should be denied")
+	}
+
+	// Wait for window to expire
+	time.Sleep(110 * time.Millisecond)
+
+	// After expiration, request allowed again
+	allowed, _, _ = store.CheckAndRecord(ctx, "key1", time.Now())
+	if !allowed {
+		t.Error("request after window expiry should be allowed")
+	}
+}
+
+// TestInMemoryStore_MaxKeysEviction tests that oldest entries are evicted at limit
+func TestInMemoryStore_MaxKeysEviction(t *testing.T) {
+	store := NewInMemoryStore(config.TokenBucket, time.Minute, 10, 5)
+	ctx := context.Background()
+	now := time.Now()
+
+	// Create 5 entries (at limit)
+	for i := 0; i < 5; i++ {
+		key := string(rune('a' + i))
+		allowed, _, _ := store.CheckAndRecord(ctx, key, now)
+		if !allowed {
+			t.Errorf("initial request for key %s should be allowed", key)
+		}
+	}
+
+	// Wait a bit and access first key to update its lastAccess
+	time.Sleep(10 * time.Millisecond)
+	now = now.Add(10 * time.Millisecond)
+	store.CheckAndRecord(ctx, "a", now)
+
+	// Add 6th key - should evict the oldest (b, since a was just accessed)
+	allowed, _, _ := store.CheckAndRecord(ctx, "f", now.Add(10*time.Millisecond))
+	if !allowed {
+		t.Error("request for new key should be allowed (eviction should happen)")
+	}
+
+	// Key "b" should have been evicted and treated as new
+	allowed, _, _ = store.CheckAndRecord(ctx, "b", now.Add(20*time.Millisecond))
+	if !allowed {
+		t.Error("key 'b' should have been evicted and treated as new")
+	}
+}
+
+// TestInMemoryStore_Expiration tests that expired entries are cleaned up
+func TestInMemoryStore_Expiration(t *testing.T) {
+	window := 100 * time.Millisecond
+	store := NewInMemoryStore(config.TokenBucket, window, 2, 100)
+	ctx := context.Background()
+	now := time.Now()
+
+	// Use up tokens
+	store.CheckAndRecord(ctx, "key1", now)
+	store.CheckAndRecord(ctx, "key1", now)
+
+	// Request denied
+	allowed, _, _ := store.CheckAndRecord(ctx, "key1", now)
+	if allowed {
+		t.Error("request should be denied (no tokens)")
+	}
+
+	// Wait for entry to expire
+	time.Sleep(110 * time.Millisecond)
+
+	// After expiration, should be treated as new entry with fresh tokens
+	allowed, remaining, _ := store.CheckAndRecord(ctx, "key1", time.Now())
+	if !allowed {
+		t.Error("request after expiration should be allowed (new entry)")
+	}
+	if remaining != 1 {
+		t.Errorf("expected remaining=1 after expiration, got %d", remaining)
+	}
+}
+
+// TestInMemoryStore_MultipleKeys tests isolation between keys
+func TestInMemoryStore_MultipleKeys(t *testing.T) {
+	store := NewInMemoryStore(config.TokenBucket, time.Second, 2, 100)
+	ctx := context.Background()
+	now := time.Now()
+
+	// Exhaust tokens for key1
+	store.CheckAndRecord(ctx, "key1", now)
+	store.CheckAndRecord(ctx, "key1", now)
+
+	// key2 should still have tokens
+	allowed, remaining, _ := store.CheckAndRecord(ctx, "key2", now)
+	if !allowed {
+		t.Error("key2 first request should be allowed")
+	}
+	if remaining != 1 {
+		t.Errorf("expected remaining=1 for key2, got %d", remaining)
+	}
+
+	// key1 should still be denied
+	allowed, _, _ = store.CheckAndRecord(ctx, "key1", now)
+	if allowed {
+		t.Error("key1 should still be denied")
+	}
+}
+
+// TestInMemoryStore_DefaultMaxKeys tests default max keys (0 = 10000)
+func TestInMemoryStore_DefaultMaxKeys(t *testing.T) {
+	store := NewInMemoryStore(config.TokenBucket, time.Second, 10, 0)
+
+	if store.maxKeys != 10000 {
+		t.Errorf("expected default maxKeys=10000, got %d", store.maxKeys)
+	}
+}
+
+// mockStore is a test implementation of RateLimitStore
+type mockStore struct {
+	checkFunc func(ctx context.Context, key string, now time.Time) (bool, int, time.Time)
+}
+
+func (m *mockStore) CheckAndRecord(ctx context.Context, key string, now time.Time) (bool, int, time.Time) {
+	return m.checkFunc(ctx, key, now)
+}
+
+// TestCustomStore tests using a custom store implementation
+func TestCustomStore(t *testing.T) {
+	resetTime := time.Now().Add(time.Minute)
+	mock := &mockStore{
+		checkFunc: func(ctx context.Context, key string, now time.Time) (bool, int, time.Time) {
+			if key == "allowed" {
+				return true, 5, resetTime
+			}
+			return false, 0, resetTime
+		},
+	}
+
+	mw := RateLimit(config.RateLimitConfig{
+		Store:      mock,
+		Rate:       10,
+		Window:     time.Minute,
+		StatusCode: http.StatusTooManyRequests,
+		Message:    "rate limited",
+	})
+
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Test allowed key
+	req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req1.RemoteAddr = "allowed"
+	w1 := httptest.NewRecorder()
+	handler.ServeHTTP(w1, req1)
+	if w1.Code != http.StatusOK {
+		t.Errorf("expected 200 for allowed key, got %d", w1.Code)
+	}
+
+	// Test denied key
+	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req2.RemoteAddr = "denied"
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusTooManyRequests {
+		t.Errorf("expected 429 for denied key, got %d", w2.Code)
+	}
+}
+
+// TestInMemoryStore_ResetTime tests that reset time is calculated correctly
+func TestInMemoryStore_ResetTime(t *testing.T) {
+	store := NewInMemoryStore(config.TokenBucket, time.Minute, 60, 100)
+	ctx := context.Background()
+	now := time.Now()
+
+	// Use up half the tokens
+	for i := 0; i < 30; i++ {
+		store.CheckAndRecord(ctx, "key1", now)
+	}
+
+	// Get reset time for remaining tokens
+	_, remaining, resetTime := store.CheckAndRecord(ctx, "key1", now)
+	if remaining != 29 {
+		t.Errorf("expected remaining=29, got %d", remaining)
+	}
+
+	// Reset time should be in the future
+	if !resetTime.After(now) {
+		t.Error("resetTime should be after now")
+	}
+}
+
+// TestRateLimit_WithMaxKeysConfig tests MaxKeys config option
+func TestRateLimit_WithMaxKeysConfig(t *testing.T) {
+	mw := RateLimit(config.RateLimitConfig{
+		Rate:      10,
+		Window:    time.Minute,
+		Algorithm: config.TokenBucket,
+		MaxKeys:   3,
+	})
+
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Create 3 different keys
+	for i := 0; i < 3; i++ {
+		req := zhtest.NewRequest(http.MethodGet, "/test").Build()
+		req.RemoteAddr = "192.168.1." + string(rune('1'+i)) + ":12345"
+		w := zhtest.Serve(handler, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("request %d should be allowed", i+1)
+		}
+	}
+
+	// Create 4th key - should still work (eviction happens)
+	req := zhtest.NewRequest(http.MethodGet, "/test").Build()
+	req.RemoteAddr = "192.168.1.100:12345"
+	w := zhtest.Serve(handler, req)
+	if w.Code != http.StatusOK {
+		t.Error("4th key should be allowed (eviction)")
+	}
+}
+
+// TestInMemoryStore_MaxKeysEviction_FixedWindow tests eviction for fixed window
+func TestInMemoryStore_MaxKeysEviction_FixedWindow(t *testing.T) {
+	store := NewInMemoryStore(config.FixedWindow, time.Minute, 100, 3)
+	ctx := context.Background()
+	now := time.Now()
+
+	// Create 3 entries (each uses 1 token)
+	for i := 0; i < 3; i++ {
+		key := string(rune('a' + i))
+		store.CheckAndRecord(ctx, key, now)
+	}
+
+	// Wait and access first key to update lastAccess (uses another token)
+	time.Sleep(10 * time.Millisecond)
+	now = now.Add(10 * time.Millisecond)
+	store.CheckAndRecord(ctx, "a", now)
+
+	// Add 4th key - should evict oldest (b)
+	store.CheckAndRecord(ctx, "d", now.Add(10*time.Millisecond))
+
+	// Key "b" should have been evicted
+	// Check by seeing if it's treated as new (allowed with full count)
+	allowed, remaining, _ := store.CheckAndRecord(ctx, "b", now.Add(20*time.Millisecond))
+	if !allowed {
+		t.Error("key 'b' should have been evicted and treated as new")
+	}
+	// After eviction, key 'b' is recreated with count=1, so remaining = 100 - 1 = 99
+	// Even if key 'a' was accessed twice (count=2), its lastAccess is updated so 'b' is evicted
+	if remaining != 99 {
+		t.Errorf("expected remaining=99 for evicted key, got %d", remaining)
+	}
+}
+
+// TestInMemoryStore_MaxKeysEviction_SlidingWindow tests eviction for sliding window
+func TestInMemoryStore_MaxKeysEviction_SlidingWindow(t *testing.T) {
+	store := NewInMemoryStore(config.SlidingWindow, time.Minute, 100, 3)
+	ctx := context.Background()
+	now := time.Now()
+
+	// Create 3 entries
+	for i := 0; i < 3; i++ {
+		key := string(rune('a' + i))
+		store.CheckAndRecord(ctx, key, now)
+	}
+
+	// Wait and access first key to update lastAccess
+	time.Sleep(10 * time.Millisecond)
+	now = now.Add(10 * time.Millisecond)
+	store.CheckAndRecord(ctx, "a", now)
+
+	// Add 4th key - should evict oldest (b)
+	store.CheckAndRecord(ctx, "d", now.Add(10*time.Millisecond))
+
+	// Key "b" should have been evicted
+	// Just check that it's allowed (not rate limited)
+	allowed, _, _ := store.CheckAndRecord(ctx, "b", now.Add(20*time.Millisecond))
+	if !allowed {
+		t.Error("key 'b' should have been evicted and treated as new")
+	}
+}
+
+// BenchmarkInMemoryStore_CheckAndRecord benchmarks the store
+func BenchmarkInMemoryStore_CheckAndRecord(b *testing.B) {
+	store := NewInMemoryStore(config.TokenBucket, time.Minute, 1000, 10000)
+	ctx := context.Background()
+	now := time.Now()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		key := string(rune('a' + (i % 26)))
+		store.CheckAndRecord(ctx, key, now)
+	}
+}

--- a/middleware/rate_limit_test.go
+++ b/middleware/rate_limit_test.go
@@ -283,8 +283,8 @@ func TestRateLimitDefaultKeyExtractor(t *testing.T) {
 	req = zhtest.NewRequest(http.MethodGet, "/test").Build()
 	req.RemoteAddr = "127.0.0.1:12345"
 	key = config.DefaultKeyExtractor(req)
-	if key != "127.0.0.1:12345" {
-		t.Errorf("expected key '127.0.0.1:12345', got '%s'", key)
+	if key != "127.0.0.1" {
+		t.Errorf("expected key '127.0.0.1', got '%s'", key)
 	}
 }
 


### PR DESCRIPTION
- Add RateLimitStore interface for custom backends (Redis, etc.)
- Add secure in-memory store with lazy expiration and LRU eviction
- Fix DefaultKeyExtractor to strip ports using net.SplitHostPort
- Add context support to store interface
- Move store implementation to middleware/rate_limit_store.go