### PR TITLE
fix: log JSON encoding errors instead of silently ignoring them

### DIFF
--- a/log/global.go
+++ b/log/global.go
@@ -1,0 +1,42 @@
+package log
+
+import (
+	"context"
+	"sync"
+)
+
+// globalLogger is the package-level logger used when a logger cannot be passed.
+// It defaults to a no-op logger to avoid nil pointer issues.
+var (
+	globalLogger   Logger = &NoopLogger{}
+	globalLoggerMu sync.RWMutex
+)
+
+// SetGlobalLogger sets the package-level logger.
+// This should be called during application initialization.
+func SetGlobalLogger(l Logger) {
+	globalLoggerMu.Lock()
+	defer globalLoggerMu.Unlock()
+	globalLogger = l
+}
+
+// GetGlobalLogger returns the current package-level logger.
+// Returns a no-op logger if none has been set.
+func GetGlobalLogger() Logger {
+	globalLoggerMu.RLock()
+	defer globalLoggerMu.RUnlock()
+	return globalLogger
+}
+
+// NoopLogger is a no-op implementation of Logger.
+// Used as a safe default when no logger is configured.
+type NoopLogger struct{}
+
+func (n *NoopLogger) Debug(string, ...Field)             {}
+func (n *NoopLogger) Info(string, ...Field)              {}
+func (n *NoopLogger) Warn(string, ...Field)              {}
+func (n *NoopLogger) Error(string, ...Field)             {}
+func (n *NoopLogger) Panic(msg string, fields ...Field)  { panic(msg) }
+func (n *NoopLogger) Fatal(string, ...Field)             {}
+func (n *NoopLogger) WithFields(...Field) Logger         { return n }
+func (n *NoopLogger) WithContext(context.Context) Logger { return n }

--- a/log/global_test.go
+++ b/log/global_test.go
@@ -1,0 +1,130 @@
+package log
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNoopLoggerMethods(t *testing.T) {
+	logger := &NoopLogger{}
+
+	// All these should execute without panic
+	logger.Debug("debug message", F("key", "value"))
+	logger.Info("info message", F("key", "value"))
+	logger.Warn("warn message", F("key", "value"))
+	logger.Error("error message", F("key", "value"))
+
+	// Test WithFields returns a logger
+	newLogger := logger.WithFields(F("newKey", "newValue"))
+	if newLogger == nil {
+		t.Error("WithFields should not return nil")
+	}
+
+	// Test WithContext returns a logger
+	ctxLogger := logger.WithContext(context.Background())
+	if ctxLogger == nil {
+		t.Error("WithContext should not return nil")
+	}
+
+	// Test that chained calls work
+	chainedLogger := logger.WithFields(F("key", "value")).WithContext(context.Background())
+	if chainedLogger == nil {
+		t.Error("Chained calls should not return nil")
+	}
+	chainedLogger.Info("test message")
+}
+
+func TestNoopLoggerPanic(t *testing.T) {
+	logger := &NoopLogger{}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Panic method should have panicked")
+		}
+	}()
+
+	logger.Panic("panic message", F("key", "value"))
+}
+
+func TestGlobalLoggerDefaultsToNoop(t *testing.T) {
+	// Reset to default state
+	SetGlobalLogger(&NoopLogger{})
+
+	logger := GetGlobalLogger()
+	if logger == nil {
+		t.Fatal("GetGlobalLogger should not return nil")
+	}
+
+	// Should be able to call methods without panic
+	logger.Info("test message")
+}
+
+func TestSetAndGetGlobalLogger(t *testing.T) {
+	// Save original logger to restore later
+	originalLogger := GetGlobalLogger()
+	defer SetGlobalLogger(originalLogger)
+
+	// Set a new logger
+	newLogger := NewDefaultLogger()
+	SetGlobalLogger(newLogger)
+
+	// Retrieve it
+	retrievedLogger := GetGlobalLogger()
+	if retrievedLogger != newLogger {
+		t.Error("GetGlobalLogger should return the logger set by SetGlobalLogger")
+	}
+}
+
+func TestGlobalLoggerThreadSafety(t *testing.T) {
+	// Save original logger to restore later
+	originalLogger := GetGlobalLogger()
+	defer SetGlobalLogger(originalLogger)
+
+	// Run concurrent operations
+	done := make(chan bool)
+
+	// Multiple goroutines setting the logger
+	for range 10 {
+		go func() {
+			SetGlobalLogger(NewDefaultLogger())
+			done <- true
+		}()
+	}
+
+	// Multiple goroutines getting and using the logger
+	for range 10 {
+		go func() {
+			logger := GetGlobalLogger()
+			logger.Info("concurrent test message")
+			done <- true
+		}()
+	}
+
+	// Wait for all goroutines
+	for range 20 {
+		<-done
+	}
+}
+
+func TestNoopLoggerWithFieldsChaining(t *testing.T) {
+	logger := &NoopLogger{}
+
+	// WithFields should return the same instance for NoopLogger
+	// (since there's nothing to track)
+	newLogger := logger.WithFields(F("key", "value"))
+
+	// It should not panic
+	newLogger.Info("test")
+}
+
+type testContextKey string
+
+func TestNoopLoggerWithContextChaining(t *testing.T) {
+	logger := &NoopLogger{}
+	ctx := context.WithValue(context.Background(), testContextKey("testKey"), "testValue")
+
+	newLogger := logger.WithContext(ctx)
+
+	// It should not panic
+	newLogger.Info("test")
+}

--- a/router.go
+++ b/router.go
@@ -53,7 +53,9 @@ func handleHandlerError(w http.ResponseWriter, err error) {
 			"detail": "Validation failed",
 			"errors": verr.ValidationErrors(),
 		}
-		_ = json.NewEncoder(w).Encode(response)
+		if encErr := json.NewEncoder(w).Encode(response); encErr != nil {
+			log.GetGlobalLogger().Error("Failed to encode validation error response", log.E(encErr))
+		}
 		return
 	}
 
@@ -66,7 +68,9 @@ func handleHandlerError(w http.ResponseWriter, err error) {
 			"status": http.StatusBadRequest,
 			"detail": "Invalid request body",
 		}
-		_ = json.NewEncoder(w).Encode(response)
+		if encErr := json.NewEncoder(w).Encode(response); encErr != nil {
+			log.GetGlobalLogger().Error("Failed to encode binding error response", log.E(encErr))
+		}
 		return
 	}
 
@@ -78,7 +82,9 @@ func handleHandlerError(w http.ResponseWriter, err error) {
 		"status": http.StatusInternalServerError,
 		"detail": "An unexpected error occurred",
 	}
-	_ = json.NewEncoder(w).Encode(response)
+	if encErr := json.NewEncoder(w).Encode(response); encErr != nil {
+		log.GetGlobalLogger().Error("Failed to encode internal server error response", log.E(encErr))
+	}
 }
 
 // headResponseWriter wraps a ResponseWriter and discards body writes for HEAD requests
@@ -240,6 +246,10 @@ type defaultRouter struct {
 //	router := NewRouter(loggingMiddleware, authMiddleware)
 func NewRouter(mw ...func(http.Handler) http.Handler) Router {
 	cfg := config.DefaultConfig
+	logger := log.NewDefaultLogger()
+
+	// Initialize the package-level logger for error handling
+	log.SetGlobalLogger(logger)
 
 	r := &defaultRouter{
 		mux:                     &http.ServeMux{},
@@ -247,7 +257,7 @@ func NewRouter(mw ...func(http.Handler) http.Handler) Router {
 		notFoundHandler:         defaultNotFoundHandler,
 		methodNotAllowedHandler: defaultMethodNotAllowedHandler,
 		registeredRoutes:        make(map[string]map[string]bool),
-		logger:                  log.NewDefaultLogger(),
+		logger:                  logger,
 		config:                  cfg,
 	}
 	return r
@@ -496,6 +506,8 @@ func (r *defaultRouter) Logger() log.Logger {
 // and ensures consistent logging across the application.
 func (r *defaultRouter) SetLogger(logger log.Logger) {
 	r.logger = logger
+	// Also update the global logger for error handling
+	log.SetGlobalLogger(logger)
 }
 
 // Config returns the current configuration used by the router.

--- a/router_test.go
+++ b/router_test.go
@@ -170,6 +170,78 @@ func TestHandlerFunc(t *testing.T) {
 	})
 }
 
+func TestJSONEncodingErrorLogged(t *testing.T) {
+	testCases := []struct {
+		name           string
+		errorType      string
+		handlerError   error
+		expectedStatus int
+	}{
+		{
+			name:           "validation error encoding failure",
+			errorType:      "validation",
+			handlerError:   &testValidationError{errors: map[string][]string{"field": {"invalid"}}},
+			expectedStatus: http.StatusUnprocessableEntity,
+		},
+		{
+			name:           "binding error encoding failure",
+			errorType:      "binding",
+			handlerError:   &BindError{Err: fmt.Errorf("invalid JSON")},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "generic error encoding failure",
+			errorType:      "generic",
+			handlerError:   fmt.Errorf("some internal error"),
+			expectedStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a test logger that captures log output
+			testLogger := log.NewDefaultLogger()
+
+			// Save original logger and restore after test
+			originalLogger := log.GetGlobalLogger()
+			log.SetGlobalLogger(testLogger)
+			defer log.SetGlobalLogger(originalLogger)
+
+			// Create a response recorder that fails on write
+			recorder := &failWriteRecorder{
+				ResponseRecorder: httptest.NewRecorder(),
+				failWrite:        true,
+			}
+
+			// Call handleHandlerError directly
+			handleHandlerError(recorder, tc.handlerError)
+
+			// Verify the status was written before the write failure
+			if recorder.Code != tc.expectedStatus {
+				t.Errorf("Expected status %d, got %d", tc.expectedStatus, recorder.Code)
+			}
+
+			// Note: We can't easily capture the log output from DefaultLogger
+			// since it writes to stdout, but we verify the code path doesn't panic
+			// and the status header was written. In a real scenario, the error
+			// would be logged to stdout.
+		})
+	}
+}
+
+// testValidationError is a test implementation of ValidationErrorer
+type testValidationError struct {
+	errors map[string][]string
+}
+
+func (e *testValidationError) Error() string {
+	return "validation failed"
+}
+
+func (e *testValidationError) ValidationErrors() map[string][]string {
+	return e.errors
+}
+
 func TestNewRouter(t *testing.T) {
 	t.Run("without middleware", func(t *testing.T) {
 		router := NewRouter()


### PR DESCRIPTION
Previously, handleHandlerError() in router.go was silently ignoring JSON encoding errors using _ = json.NewEncoder(w).Encode(response).

Changes:
- Added log/global.go with GetGlobalLogger/SetGlobalLogger and NoopLogger
- Updated handleHandlerError to log encoding errors via global logger
- Added tests for global logger and JSON encoding error handling