### PR TITLE
feat: create shared response writer utility package

### DIFF
--- a/internal/rwutil/rwutil.go
+++ b/internal/rwutil/rwutil.go
@@ -1,0 +1,85 @@
+package rwutil
+
+import "net/http"
+
+// ResponseWriter wraps http.ResponseWriter to capture status code and
+// track whether the header has been written. This is a reusable component
+// used by multiple middlewares instead of duplicating the same code.
+type ResponseWriter struct {
+	http.ResponseWriter
+	statusCode    int
+	headerWritten bool
+}
+
+// NewResponseWriter creates a new ResponseWriter with default status code 200.
+func NewResponseWriter(w http.ResponseWriter) *ResponseWriter {
+	return &ResponseWriter{
+		ResponseWriter: w,
+		statusCode:     http.StatusOK,
+	}
+}
+
+// WriteHeader captures the status code and forwards to the underlying ResponseWriter.
+// It ensures the header is only written once.
+func (rw *ResponseWriter) WriteHeader(code int) {
+	if rw.headerWritten {
+		return // Prevent multiple WriteHeader calls
+	}
+	rw.statusCode = code
+	rw.headerWritten = true
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+// Write writes the data to the connection, writing the header first if needed.
+func (rw *ResponseWriter) Write(data []byte) (int, error) {
+	if !rw.headerWritten {
+		rw.WriteHeader(http.StatusOK)
+	}
+	return rw.ResponseWriter.Write(data)
+}
+
+// StatusCode returns the captured status code.
+// If WriteHeader was never called, it returns the default 200.
+func (rw *ResponseWriter) StatusCode() int {
+	return rw.statusCode
+}
+
+// HeaderWritten returns true if WriteHeader has been called.
+func (rw *ResponseWriter) HeaderWritten() bool {
+	return rw.headerWritten
+}
+
+// FlusherResponseWriter wraps ResponseWriter and implements http.Flusher.
+// Use this when the underlying ResponseWriter may support flushing.
+type FlusherResponseWriter struct {
+	*ResponseWriter
+	flusher http.Flusher
+}
+
+// NewFlusherResponseWriter creates a new FlusherResponseWriter.
+// It checks if the underlying writer implements http.Flusher.
+func NewFlusherResponseWriter(w http.ResponseWriter) *FlusherResponseWriter {
+	rw := NewResponseWriter(w)
+	var flusher http.Flusher
+	if f, ok := w.(http.Flusher); ok {
+		flusher = f
+	}
+	return &FlusherResponseWriter{
+		ResponseWriter: rw,
+		flusher:        flusher,
+	}
+}
+
+// Flush implements http.Flusher. If the underlying ResponseWriter does not
+// support flushing, this is a no-op.
+func (frw *FlusherResponseWriter) Flush() {
+	if frw.flusher != nil {
+		frw.flusher.Flush()
+	}
+}
+
+// Ensure interface compliance at compile time.
+var (
+	_ http.ResponseWriter = (*ResponseWriter)(nil)
+	_ http.Flusher        = (*FlusherResponseWriter)(nil)
+)

--- a/internal/rwutil/rwutil_test.go
+++ b/internal/rwutil/rwutil_test.go
@@ -1,0 +1,138 @@
+package rwutil
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewResponseWriter(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := NewResponseWriter(rec)
+
+	if rw.StatusCode() != http.StatusOK {
+		t.Errorf("expected default status code %d, got %d", http.StatusOK, rw.StatusCode())
+	}
+
+	if rw.HeaderWritten() {
+		t.Error("expected HeaderWritten to be false initially")
+	}
+}
+
+func TestResponseWriter_WriteHeader(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := NewResponseWriter(rec)
+
+	rw.WriteHeader(http.StatusNotFound)
+
+	if rw.StatusCode() != http.StatusNotFound {
+		t.Errorf("expected status code %d, got %d", http.StatusNotFound, rw.StatusCode())
+	}
+
+	if !rw.HeaderWritten() {
+		t.Error("expected HeaderWritten to be true after WriteHeader")
+	}
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected recorder code %d, got %d", http.StatusNotFound, rec.Code)
+	}
+}
+
+func TestResponseWriter_WriteHeader_MultipleCalls(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := NewResponseWriter(rec)
+
+	rw.WriteHeader(http.StatusNotFound)
+	rw.WriteHeader(http.StatusInternalServerError) // Should be ignored
+
+	if rw.StatusCode() != http.StatusNotFound {
+		t.Errorf("expected status code to remain %d, got %d", http.StatusNotFound, rw.StatusCode())
+	}
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected recorder code to remain %d, got %d", http.StatusNotFound, rec.Code)
+	}
+}
+
+func TestResponseWriter_Write(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := NewResponseWriter(rec)
+
+	data := []byte("hello world")
+	n, err := rw.Write(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if n != len(data) {
+		t.Errorf("expected to write %d bytes, wrote %d", len(data), n)
+	}
+
+	if rw.StatusCode() != http.StatusOK {
+		t.Errorf("expected status code %d after Write, got %d", http.StatusOK, rw.StatusCode())
+	}
+
+	if !rw.HeaderWritten() {
+		t.Error("expected HeaderWritten to be true after Write")
+	}
+
+	if rec.Body.String() != "hello world" {
+		t.Errorf("expected body %q, got %q", "hello world", rec.Body.String())
+	}
+}
+
+func TestResponseWriter_Write_WithHeader(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := NewResponseWriter(rec)
+
+	rw.WriteHeader(http.StatusCreated)
+	n, err := rw.Write([]byte("created"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if n != 7 {
+		t.Errorf("expected to write 7 bytes, wrote %d", n)
+	}
+
+	if rw.StatusCode() != http.StatusCreated {
+		t.Errorf("expected status code %d, got %d", http.StatusCreated, rw.StatusCode())
+	}
+}
+
+func TestResponseWriter_Header(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := NewResponseWriter(rec)
+
+	rw.Header().Set("X-Custom-Header", "value")
+
+	if rec.Header().Get("X-Custom-Header") != "value" {
+		t.Error("expected header to be set on underlying recorder")
+	}
+}
+
+func TestNewFlusherResponseWriter(t *testing.T) {
+	rec := httptest.NewRecorder()
+	frw := NewFlusherResponseWriter(rec)
+
+	if frw.StatusCode() != http.StatusOK {
+		t.Errorf("expected default status code %d, got %d", http.StatusOK, frw.StatusCode())
+	}
+
+	// Should not panic
+	frw.Flush()
+}
+
+func TestFlusherResponseWriter_Flush(t *testing.T) {
+	rec := httptest.NewRecorder()
+	frw := NewFlusherResponseWriter(rec)
+
+	// Write some data and flush
+	_, _ = frw.Write([]byte("data"))
+	frw.Flush()
+
+	// The recorder should have the data
+	if rec.Body.String() != "data" {
+		t.Errorf("expected body %q, got %q", "data", rec.Body.String())
+	}
+}

--- a/middleware/circuit_breaker.go
+++ b/middleware/circuit_breaker.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/alexferl/zerohttp/config"
 	"github.com/alexferl/zerohttp/internal/problem"
+	"github.com/alexferl/zerohttp/internal/rwutil"
 	"github.com/alexferl/zerohttp/metrics"
 )
 
@@ -34,28 +35,6 @@ type circuitBreakerMiddleware struct {
 	circuits map[string]*circuit
 	config   config.CircuitBreakerConfig
 	mu       sync.RWMutex
-}
-
-// responseWriter wraps http.ResponseWriter to capture status code
-type circuitResponseWriter struct {
-	http.ResponseWriter
-	statusCode int
-	written    bool
-}
-
-func (w *circuitResponseWriter) WriteHeader(code int) {
-	if !w.written {
-		w.statusCode = code
-		w.written = true
-		w.ResponseWriter.WriteHeader(code)
-	}
-}
-
-func (w *circuitResponseWriter) Write(data []byte) (int, error) {
-	if !w.written {
-		w.WriteHeader(http.StatusOK)
-	}
-	return w.ResponseWriter.Write(data)
 }
 
 // CircuitBreaker creates a circuit breaker middleware
@@ -108,14 +87,11 @@ func CircuitBreaker(cfg ...config.CircuitBreakerConfig) func(http.Handler) http.
 				return
 			}
 
-			wrapped := &circuitResponseWriter{
-				ResponseWriter: w,
-				statusCode:     http.StatusOK,
-			}
+			wrapped := rwutil.NewResponseWriter(w)
 
 			next.ServeHTTP(wrapped, r)
 
-			circ.recordResult(r, wrapped.statusCode, reg, key)
+			circ.recordResult(r, wrapped.StatusCode(), reg, key)
 		})
 	}
 }

--- a/middleware/request_logger.go
+++ b/middleware/request_logger.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/internal/rwutil"
 	"github.com/alexferl/zerohttp/log"
 )
 
@@ -34,17 +35,13 @@ func RequestLogger(logger log.Logger, cfg ...config.RequestLoggerConfig) func(ht
 
 			start := time.Now()
 
-			wrapped := &responseWriter{
-				ResponseWriter: w,
-				statusCode:     http.StatusOK,
-				headerWritten:  false,
-			}
+			wrapped := rwutil.NewResponseWriter(w)
 
 			next.ServeHTTP(wrapped, r)
 
 			duration := time.Since(start)
 
-			LogRequest(logger, c, r, wrapped.statusCode, duration)
+			LogRequest(logger, c, r, wrapped.StatusCode(), duration)
 		})
 	}
 }
@@ -114,27 +111,4 @@ func LogRequest(logger log.Logger, cfg config.RequestLoggerConfig, r *http.Reque
 	} else {
 		logger.Info(msg, logFields...)
 	}
-}
-
-// responseWriter wraps http.ResponseWriter to capture status code.
-type responseWriter struct {
-	http.ResponseWriter
-	statusCode    int
-	headerWritten bool
-}
-
-func (rw *responseWriter) WriteHeader(code int) {
-	if rw.headerWritten {
-		return // Prevent multiple WriteHeader calls
-	}
-	rw.statusCode = code
-	rw.headerWritten = true
-	rw.ResponseWriter.WriteHeader(code)
-}
-
-func (rw *responseWriter) Write(data []byte) (int, error) {
-	if !rw.headerWritten {
-		rw.WriteHeader(http.StatusOK)
-	}
-	return rw.ResponseWriter.Write(data)
 }

--- a/middleware/request_logger_test.go
+++ b/middleware/request_logger_test.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -321,33 +320,5 @@ func TestDefaultRequestLoggerConfig(t *testing.T) {
 	}
 	if len(cfg.ExemptPaths) != 0 {
 		t.Errorf("Expected default exempt paths to be empty, got %d", len(cfg.ExemptPaths))
-	}
-}
-
-func TestResponseWriter_MultipleWriteHeader(t *testing.T) {
-	w := httptest.NewRecorder()
-	rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK, headerWritten: false}
-	rw.WriteHeader(http.StatusNotFound)
-	if rw.statusCode != http.StatusNotFound {
-		t.Errorf("Expected status code 404, got %d", rw.statusCode)
-	}
-	rw.WriteHeader(http.StatusInternalServerError)
-	if rw.statusCode != http.StatusNotFound {
-		t.Errorf("Expected status code to remain 404, got %d", rw.statusCode)
-	}
-}
-
-func TestResponseWriter_WriteWithoutHeader(t *testing.T) {
-	w := httptest.NewRecorder()
-	rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK, headerWritten: false}
-	_, err := rw.Write([]byte("test"))
-	if err != nil {
-		t.Fatalf("failed to write response: %v", err)
-	}
-	if rw.statusCode != http.StatusOK {
-		t.Errorf("Expected status code 200, got %d", rw.statusCode)
-	}
-	if !rw.headerWritten {
-		t.Error("Expected headerWritten to be true after Write")
 	}
 }

--- a/middleware/tracing.go
+++ b/middleware/tracing.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/internal/rwutil"
 	"github.com/alexferl/zerohttp/trace"
 )
 
@@ -42,15 +43,16 @@ func Tracing(tracer trace.Tracer, cfg ...config.TracerConfig) func(http.Handler)
 				span.SetAttributes(trace.Int64("http.request_content_length", r.ContentLength))
 			}
 
+			rw := rwutil.NewResponseWriter(w)
 			wrapped := &tracingResponseWriter{
-				ResponseWriter: w,
+				ResponseWriter: rw,
 				span:           span,
 			}
 
 			next.ServeHTTP(wrapped, r.WithContext(ctx))
 
-			if wrapped.statusCode >= 500 {
-				span.SetStatus(trace.CodeError, http.StatusText(wrapped.statusCode))
+			if wrapped.StatusCode() >= 500 {
+				span.SetStatus(trace.CodeError, http.StatusText(wrapped.StatusCode()))
 			} else {
 				span.SetStatus(trace.CodeOk, "")
 			}
@@ -59,27 +61,13 @@ func Tracing(tracer trace.Tracer, cfg ...config.TracerConfig) func(http.Handler)
 }
 
 type tracingResponseWriter struct {
-	http.ResponseWriter
-	statusCode int
-	span       trace.Span
-	written    bool
+	*rwutil.ResponseWriter
+	span trace.Span
 }
 
 func (w *tracingResponseWriter) WriteHeader(code int) {
-	if w.written {
-		return
-	}
-	w.written = true
-	w.statusCode = code
-	w.span.SetAttributes(trace.Int("http.status_code", code))
 	w.ResponseWriter.WriteHeader(code)
-}
-
-func (w *tracingResponseWriter) Write(data []byte) (int, error) {
-	if !w.written {
-		w.WriteHeader(http.StatusOK)
-	}
-	return w.ResponseWriter.Write(data)
+	w.span.SetAttributes(trace.Int("http.status_code", code))
 }
 
 func scheme(r *http.Request) string {

--- a/middleware/tracing_test.go
+++ b/middleware/tracing_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/internal/rwutil"
 	"github.com/alexferl/zerohttp/trace"
 )
 
@@ -266,16 +267,17 @@ func TestTracingResponseWriter(t *testing.T) {
 	_, span := mock.Start(ctx, "test")
 
 	rr := httptest.NewRecorder()
+	rw := rwutil.NewResponseWriter(rr)
 	trw := &tracingResponseWriter{
-		ResponseWriter: rr,
+		ResponseWriter: rw,
 		span:           span,
 	}
 
 	// Write should trigger WriteHeader
 	_, _ = trw.Write([]byte("hello"))
 
-	if trw.statusCode != 200 {
-		t.Errorf("statusCode = %d, want 200", trw.statusCode)
+	if trw.StatusCode() != 200 {
+		t.Errorf("statusCode = %d, want 200", trw.StatusCode())
 	}
 
 	if rr.Code != 200 {
@@ -284,7 +286,7 @@ func TestTracingResponseWriter(t *testing.T) {
 
 	// Multiple WriteHeader calls should be safe
 	trw.WriteHeader(500)
-	if trw.statusCode != 200 {
+	if trw.StatusCode() != 200 {
 		t.Error("WriteHeader should not change status after already written")
 	}
 }


### PR DESCRIPTION
Add internal/rwutil package with ResponseWriter and FlusherResponseWriter types to consolidate duplicate response writer wrappers across middleware. Update request_logger, circuit_breaker, and tracing middleware to use the shared implementation. Add comprehensive tests for the new package.