### PR TITLE
fix: enforce minimum HMAC secret length to prevent brute-force attacks

### DIFF
--- a/middleware/hmac_auth.go
+++ b/middleware/hmac_auth.go
@@ -266,7 +266,22 @@ func HMACAuth(cfg ...config.HMACAuthConfig) func(http.Handler) http.Handler {
 			}
 
 			secretKeys := c.CredentialStore(parsed.AccessKeyID)
-			if len(secretKeys) == 0 {
+			// Filter secrets by minimum length based on algorithm
+			// Short secrets can be brute-forced
+			minLength := 32 // HMAC-SHA256 requires 32 bytes
+			switch c.Algorithm {
+			case config.HMACSHA384:
+				minLength = 48
+			case config.HMACSHA512:
+				minLength = 64
+			}
+			var validSecretKeys []string
+			for _, secret := range secretKeys {
+				if len(secret) >= minLength {
+					validSecretKeys = append(validSecretKeys, secret)
+				}
+			}
+			if len(validSecretKeys) == 0 {
 				if auditLogger != nil {
 					auditLogger(parsed.AccessKeyID, parsed.Timestamp, false, "invalid_credentials")
 				}
@@ -274,6 +289,7 @@ func HMACAuth(cfg ...config.HMACAuthConfig) func(http.Handler) http.Handler {
 				handleHMACError(w, r, errInvalidCredentials, errorHandler)
 				return
 			}
+			secretKeys = validSecretKeys
 
 			var bodyHash string
 			if c.AllowUnsignedPayload {

--- a/middleware/hmac_auth_test.go
+++ b/middleware/hmac_auth_test.go
@@ -1033,8 +1033,9 @@ func TestHMACAuth_CustomErrorHandlerWithSignatureMismatch(t *testing.T) {
 
 func TestHMACAuth_KeyRotation(t *testing.T) {
 	// Simulate key rotation scenario with old and new secrets
-	oldSecret := "old-secret-key-for-test"
-	newSecret := "new-secret-key-for-test"
+	// Secrets must be at least 32 bytes for security
+	oldSecret := "old-secret-key-for-test-32bytes!"
+	newSecret := "new-secret-key-for-test-32bytes!"
 
 	// Credential store returns both secrets during rotation
 	mw := HMACAuth(config.HMACAuthConfig{
@@ -1114,7 +1115,7 @@ func TestHMACAuth_NoSecrets(t *testing.T) {
 	// Test that empty secrets slice returns invalid credentials
 	mw := HMACAuth(config.HMACAuthConfig{
 		CredentialStore: func(id string) []string {
-			return nil // No secrets for any key
+			return nil // no secrets for any key
 		},
 	})
 
@@ -1122,7 +1123,7 @@ func TestHMACAuth_NoSecrets(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	signer := NewHMACSigner("any-key", "any-secret")
+	signer := NewHMACSigner("any-key", "this-secret-is-32-bytes-long!!")
 	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
 	if err := signer.SignRequest(req); err != nil {
 		t.Fatalf("failed to sign request: %v", err)
@@ -1133,6 +1134,138 @@ func TestHMACAuth_NoSecrets(t *testing.T) {
 
 	if rr.Code != http.StatusUnauthorized {
 		t.Errorf("expected 401 for unknown access key, got %d", rr.Code)
+	}
+}
+
+func TestHMACAuth_ShortSecretRejected(t *testing.T) {
+	// Test that secrets shorter than minimum length are rejected
+	// This is a security measure to prevent brute-force attacks
+	creds := map[string]string{"test-key": "short-secret"} // Only 12 bytes
+	mw := HMACAuth(config.HMACAuthConfig{
+		CredentialStore: func(id string) []string {
+			if secret, ok := creds[id]; ok {
+				return []string{secret}
+			}
+			return nil
+		},
+	})
+
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Sign with short secret - should be rejected by middleware
+	signer := NewHMACSigner("test-key", "short-secret")
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	if err := signer.SignRequest(req); err != nil {
+		t.Fatalf("failed to sign request: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for short secret, got %d", rr.Code)
+	}
+}
+
+func TestHMACAuth_ShortSecretRejected_AllAlgorithms(t *testing.T) {
+	// Test minimum secret length enforcement for all HMAC algorithms
+	// The middleware filters out secrets that don't meet the minimum length
+	tests := []struct {
+		name         string
+		algorithm    config.HMACHashAlgorithm
+		storeSecrets []string // secrets returned by credential store
+		validSecret  string   // secret used to sign (must meet min length)
+		shouldPass   bool
+	}{
+		{
+			name:         "SHA256 with only short secrets in store",
+			algorithm:    config.HMACSHA256,
+			storeSecrets: []string{"short-secret-12", "another-short-15"},
+			validSecret:  "this-is-exactly-32-bytes-!!!!!!!",
+			shouldPass:   false,
+		},
+		{
+			name:         "SHA256 with valid secret in store",
+			algorithm:    config.HMACSHA256,
+			storeSecrets: []string{"this-is-exactly-32-bytes-!!!!!!!"},
+			validSecret:  "this-is-exactly-32-bytes-!!!!!!!",
+			shouldPass:   true,
+		},
+		{
+			name:         "SHA384 with only short secrets in store",
+			algorithm:    config.HMACSHA384,
+			storeSecrets: []string{"short-secret-12", "this-secret-is-exactly-31-bytes"},
+			validSecret:  "this-is-exactly-48-bytes-for-sha384-tests!!!!!!!",
+			shouldPass:   false,
+		},
+		{
+			name:         "SHA384 with valid secret in store",
+			algorithm:    config.HMACSHA384,
+			storeSecrets: []string{"this-is-exactly-48-bytes-for-sha384-tests!!!!!!!"},
+			validSecret:  "this-is-exactly-48-bytes-for-sha384-tests!!!!!!!",
+			shouldPass:   true,
+		},
+		{
+			name:         "SHA512 with only short secrets in store",
+			algorithm:    config.HMACSHA512,
+			storeSecrets: []string{"short-secret-12", "this-secret-is-exactly-47-bytes-long-enough!!"},
+			validSecret:  "this-is-exactly-64-bytes-for-sha512-tests-in-middleware-!!!!!!!!",
+			shouldPass:   false,
+		},
+		{
+			name:         "SHA512 with valid secret in store",
+			algorithm:    config.HMACSHA512,
+			storeSecrets: []string{"this-is-exactly-64-bytes-for-sha512-tests-in-middleware-!!!!!!!!"},
+			validSecret:  "this-is-exactly-64-bytes-for-sha512-tests-in-middleware-!!!!!!!!",
+			shouldPass:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mw := HMACAuth(config.HMACAuthConfig{
+				Algorithm: tt.algorithm,
+				CredentialStore: func(id string) []string {
+					if id == "test-key" {
+						return tt.storeSecrets
+					}
+					return nil
+				},
+			})
+
+			handlerCalled := false
+			handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				handlerCalled = true
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			signer := NewHMACSignerWithAlgorithm("test-key", tt.validSecret, tt.algorithm)
+			req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+			if err := signer.SignRequest(req); err != nil {
+				t.Fatalf("failed to sign request: %v", err)
+			}
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if tt.shouldPass {
+				if rr.Code != http.StatusOK {
+					t.Errorf("expected 200 for valid secret length, got %d", rr.Code)
+				}
+				if !handlerCalled {
+					t.Error("handler was not called for valid secret")
+				}
+			} else {
+				if rr.Code != http.StatusUnauthorized {
+					t.Errorf("expected 401 for short secret, got %d", rr.Code)
+				}
+				if handlerCalled {
+					t.Error("handler was called for invalid secret")
+				}
+			}
+		})
 	}
 }
 

--- a/middleware/hmac_signer_test.go
+++ b/middleware/hmac_signer_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestNewHMACSigner(t *testing.T) {
-	signer := NewHMACSigner("test-key", "test-secret-that-is-32-bytes!")
+	signer := NewHMACSigner("test-key", "test-secret-that-is-32-bytes-long!!")
 
 	if signer.AccessKeyID() != "test-key" {
 		t.Errorf("expected access key ID 'test-key', got %s", signer.AccessKeyID())
@@ -116,7 +116,7 @@ func TestHMACSigner_Algorithm(t *testing.T) {
 }
 
 func TestHMACSigner_SignRequest(t *testing.T) {
-	signer := NewHMACSigner("test-key", "test-secret-that-is-32-bytes!")
+	signer := NewHMACSigner("test-key", "test-secret-that-is-32-bytes-long!!")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
 	err := signer.SignRequest(req)
@@ -143,7 +143,7 @@ func TestHMACSigner_SignRequest(t *testing.T) {
 }
 
 func TestHMACSigner_SignRequestWithTime(t *testing.T) {
-	signer := NewHMACSigner("test-key", "test-secret-that-is-32-bytes!")
+	signer := NewHMACSigner("test-key", "test-secret-that-is-32-bytes-long!!")
 
 	fixedTime := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
 
@@ -161,7 +161,7 @@ func TestHMACSigner_SignRequestWithTime(t *testing.T) {
 }
 
 func TestHMACSigner_SignRequestWithBody(t *testing.T) {
-	signer := NewHMACSigner("test-key", "test-secret-that-is-32-bytes!")
+	signer := NewHMACSigner("test-key", "test-secret-that-is-32-bytes-long!!")
 
 	body := `{"test":"data"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/test", strings.NewReader(body))
@@ -184,7 +184,7 @@ func TestHMACSigner_SignRequestWithBody(t *testing.T) {
 }
 
 func TestHMACSigner_SetAllowUnsignedPayload(t *testing.T) {
-	signer := NewHMACSigner("test-key", "test-secret-that-is-32-bytes!")
+	signer := NewHMACSigner("test-key", "test-secret-that-is-32-bytes-long!!")
 	signer.SetAllowUnsignedPayload(true)
 
 	body := `{"test":"data"}`
@@ -258,7 +258,7 @@ func TestHMACSigner_SetHeadersToSign(t *testing.T) {
 }
 
 func TestHMACSigner_CustomHeadersRoundTrip(t *testing.T) {
-	creds := map[string]string{"test-key": "test-secret-that-is-32-bytes!"}
+	creds := map[string]string{"test-key": "test-secret-that-is-32-bytes-long!!"}
 	mw := HMACAuth(config.HMACAuthConfig{
 		CredentialStore: func(id string) []string {
 			if secret, ok := creds[id]; ok {
@@ -276,7 +276,7 @@ func TestHMACSigner_CustomHeadersRoundTrip(t *testing.T) {
 	}))
 
 	// Create signer with custom headers
-	signer := NewHMACSigner("test-key", "test-secret-that-is-32-bytes!")
+	signer := NewHMACSigner("test-key", "test-secret-that-is-32-bytes-long!!")
 	signer.SetHeadersToSign([]string{"host", "x-timestamp", "x-request-id"})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
@@ -297,7 +297,7 @@ func TestHMACSigner_CustomHeadersRoundTrip(t *testing.T) {
 }
 
 func TestHMACSigner_GenerateSignature(t *testing.T) {
-	signer := NewHMACSigner("test-key", "test-secret-that-is-32-bytes!")
+	signer := NewHMACSigner("test-key", "test-secret-that-is-32-bytes-long!!")
 	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
 
 	timestamp := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
@@ -317,7 +317,7 @@ func TestHMACSigner_GenerateSignature(t *testing.T) {
 }
 
 func TestHMACSigner_PresignURL(t *testing.T) {
-	signer := NewHMACSigner("test-key", "test-secret-that-is-32-bytes!")
+	signer := NewHMACSigner("test-key", "test-secret-that-is-32-bytes-long!!")
 	req := httptest.NewRequest(http.MethodGet, "https://api.example.com/data?foo=bar", nil)
 
 	presignedURL, err := signer.PresignURL(req, 5*time.Minute)
@@ -345,7 +345,7 @@ func TestHMACSigner_PresignURL(t *testing.T) {
 }
 
 func TestHMACSigner_PresignURLWithTime(t *testing.T) {
-	signer := NewHMACSigner("test-key", "test-secret-that-is-32-bytes!")
+	signer := NewHMACSigner("test-key", "test-secret-that-is-32-bytes-long!!")
 	req := httptest.NewRequest(http.MethodGet, "https://api.example.com/data", nil)
 
 	expiresAt := time.Date(2026, 3, 7, 13, 0, 0, 0, time.UTC)


### PR DESCRIPTION
Add hardcoded minimum length validation: 32 bytes for SHA256, 48 bytes for SHA384, 64 bytes for SHA512. Short secrets are filtered out from credential store results.