### PR TITLE
fix: use type registry to eliminate reflection overhead in binding

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -129,6 +129,7 @@ func (b *defaultBinder) Query(r *http.Request, dst any) error {
 
 // bindValues binds url.Values to a struct using the specified tag name.
 // The tagName parameter specifies which struct tag to use (e.g., "form", "query").
+// Uses the type registry to cache reflection information for improved performance.
 func bindValues(values url.Values, dst any, tagName string, allowFiles bool) error {
 	v := reflect.ValueOf(dst)
 	if v.Kind() != reflect.Ptr || v.IsNil() {
@@ -142,131 +143,35 @@ func bindValues(values url.Values, dst any, tagName string, allowFiles bool) err
 
 	t := v.Type()
 
-	for i := 0; i < v.NumField(); i++ {
-		field := v.Field(i)
-		fieldType := t.Field(i)
+	// Get cached type information from the registry
+	info, err := globalTypeRegistry.getTypeInfo(t)
+	if err != nil {
+		return err
+	}
 
-		// Handle embedded structs - inline their fields
-		if fieldType.Anonymous && field.Kind() == reflect.Struct {
-			if err := bindEmbeddedStruct(values, field, tagName, allowFiles); err != nil {
-				return err
-			}
-			continue
-		}
+	// Get pre-computed bindable fields for this tag
+	bindableFields := info.getBindableFields(tagName, allowFiles)
 
-		// Skip unexported fields (for non-embedded fields)
-		if !field.CanSet() {
-			continue
-		}
-
-		// Get the tag value
-		tag := fieldType.Tag.Get(tagName)
-		if tag == "-" {
-			continue
-		}
-
-		// Use field name as default
-		if tag == "" {
-			tag = camelToSnake(fieldType.Name)
-		}
-
-		// Check for file uploads first (only in multipart mode)
-		if allowFiles {
-			handled, err := bindFileField(field)
-			if err != nil {
-				return err
-			}
-			if handled {
-				continue
-			}
+	// Bind each field using the pre-computed path
+	for _, bf := range bindableFields {
+		// Get the field value using the cached path
+		field := v.FieldByIndex(bf.path.toSlice())
+		if !field.IsValid() {
+			continue // Skip invalid fields (shouldn't happen with correct paths)
 		}
 
 		// Get value(s) from url.Values
-		fieldValues, exists := values[tag]
+		fieldValues, exists := values[bf.tag]
 		if !exists || len(fieldValues) == 0 {
 			continue
 		}
 
 		if err := setFieldValue(field, fieldValues); err != nil {
-			return fmt.Errorf("field %s: %w", fieldType.Name, err)
+			return fmt.Errorf("field %s: %w", bf.name, err)
 		}
 	}
 
 	return nil
-}
-
-// bindEmbeddedStruct binds values to an embedded struct's fields directly.
-// This avoids the reflection issues with getting an interface from embedded struct fields.
-func bindEmbeddedStruct(values url.Values, structField reflect.Value, tagName string, allowFiles bool) error {
-	structType := structField.Type()
-
-	for j := 0; j < structField.NumField(); j++ {
-		field := structField.Field(j)
-		fieldType := structType.Field(j)
-
-		// Skip unexported fields
-		if !field.CanSet() {
-			continue
-		}
-
-		// Handle nested embedded structs recursively
-		if fieldType.Anonymous && field.Kind() == reflect.Struct {
-			if err := bindEmbeddedStruct(values, field, tagName, allowFiles); err != nil {
-				return err
-			}
-			continue
-		}
-
-		// Get the tag value
-		tag := fieldType.Tag.Get(tagName)
-		if tag == "-" {
-			continue
-		}
-		if tag == "" {
-			tag = camelToSnake(fieldType.Name)
-		}
-
-		// Check for file uploads first (only in multipart mode)
-		if allowFiles {
-			handled, err := bindFileField(field)
-			if err != nil {
-				return err
-			}
-			if handled {
-				continue
-			}
-		}
-
-		// Get value(s) from url.Values
-		fieldValues, exists := values[tag]
-		if !exists || len(fieldValues) == 0 {
-			continue
-		}
-
-		if err := setFieldValue(field, fieldValues); err != nil {
-			return fmt.Errorf("field %s: %w", fieldType.Name, err)
-		}
-	}
-
-	return nil
-}
-
-// bindFileField attempts to bind a file upload to a field.
-// Returns true if the field was handled as a file field.
-func bindFileField(field reflect.Value) (bool, error) {
-	// Check if it's a FileHeader field
-	switch field.Type() {
-	case reflect.TypeOf(&FileHeader{}):
-		// Single file - will be set later when processing multipart form
-		return true, nil
-	case reflect.TypeOf([]*FileHeader{}):
-		// Multiple files - will be set later
-		return true, nil
-	case reflect.TypeOf(FileHeader{}):
-		// Non-pointer FileHeader - not supported for binding
-		return false, fmt.Errorf("FileHeader field must be a pointer (*FileHeader)")
-	}
-	return false, nil
 }
 
 // setFieldValue sets a field's value from form string values.
@@ -371,56 +276,33 @@ func BindMultipartFormFiles(r *http.Request, dst any) error {
 	return bindFilesToStruct(v, r.MultipartForm.File)
 }
 
-// bindFilesToStruct recursively binds multipart files to struct fields.
+// bindFilesToStruct binds multipart files to struct fields using cached type information.
 func bindFilesToStruct(v reflect.Value, files map[string][]*multipart.FileHeader) error {
 	t := v.Type()
 
-	for i := 0; i < v.NumField(); i++ {
-		field := v.Field(i)
-		fieldType := t.Field(i)
+	// Get cached type information from the registry
+	info, err := globalTypeRegistry.getTypeInfo(t)
+	if err != nil {
+		return err
+	}
 
-		if !field.CanSet() {
-			continue
-		}
-
-		// Handle embedded structs
-		if fieldType.Anonymous && field.Kind() == reflect.Struct {
-			if err := bindFilesToStruct(field, files); err != nil {
-				return err
-			}
-			continue
-		}
-
-		// Get form tag
-		tag := fieldType.Tag.Get("form")
-		if tag == "-" || tag == "" {
-			tag = camelToSnake(fieldType.Name)
-		}
-
-		// Check for files with this field name
-		fileHeaders, exists := files[tag]
+	// Use pre-computed file bindable fields
+	for _, fbf := range info.fileBindableFields {
+		// Check for files with this field tag
+		fileHeaders, exists := files[fbf.tag]
 		if !exists {
 			continue
 		}
 
-		// Bind based on field type
-		switch field.Type() {
-		case reflect.TypeOf(&FileHeader{}):
-			if len(fileHeaders) > 0 {
-				fh := fileHeaders[0]
-				file, err := fh.Open()
-				if err != nil {
-					return fmt.Errorf("open file %s: %w", fh.Filename, err)
-				}
-				field.Set(reflect.ValueOf(&FileHeader{
-					Filename: fh.Filename,
-					Size:     fh.Size,
-					Header:   fh.Header,
-					file:     file,
-				}))
-			}
+		// Get the field using the cached path
+		field := v.FieldByIndex(fbf.path.toSlice())
+		if !field.IsValid() {
+			continue
+		}
 
-		case reflect.TypeOf([]*FileHeader{}):
+		// Bind based on field type (single file or slice)
+		if fbf.isSlice {
+			// Slice of files
 			fileList := make([]*FileHeader, len(fileHeaders))
 			for j, fh := range fileHeaders {
 				file, err := fh.Open()
@@ -435,6 +317,21 @@ func bindFilesToStruct(v reflect.Value, files map[string][]*multipart.FileHeader
 				}
 			}
 			field.Set(reflect.ValueOf(fileList))
+		} else {
+			// Single file
+			if len(fileHeaders) > 0 {
+				fh := fileHeaders[0]
+				file, err := fh.Open()
+				if err != nil {
+					return fmt.Errorf("open file %s: %w", fh.Filename, err)
+				}
+				field.Set(reflect.ValueOf(&FileHeader{
+					Filename: fh.Filename,
+					Size:     fh.Size,
+					Header:   fh.Header,
+					file:     file,
+				}))
+			}
 		}
 	}
 

--- a/type_registry.go
+++ b/type_registry.go
@@ -1,0 +1,332 @@
+package zerohttp
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+)
+
+// Pre-computed types for efficient comparison
+var (
+	fileHeaderType      = reflect.TypeOf(FileHeader{})
+	fileHeaderPtrType   = reflect.TypeOf(&FileHeader{})
+	fileHeaderSliceType = reflect.TypeOf([]*FileHeader{})
+)
+
+// fieldPath represents the path to a field, including through embedded structs.
+// For a top-level field, path is []int{index}.
+// For an embedded field, path is []int{embeddedIndex, fieldIndex}.
+// Uses a fixed-size array instead of slice to enforce immutability by value.
+// The len field indicates how many indices are valid (up to 4 levels deep).
+type fieldPath struct {
+	indices [4]int
+	len     int
+}
+
+// toSlice returns the valid portion of the path as a slice for FieldByIndex.
+// This creates a new slice header but shares the underlying array (safe because
+// the array is fixed-size and value-copied).
+func (fp fieldPath) toSlice() []int {
+	return fp.indices[:fp.len]
+}
+
+// append creates a new fieldPath with an additional index.
+// The original path is unchanged (immutability by value).
+func (fp fieldPath) append(idx int) fieldPath {
+	newPath := fieldPath{len: fp.len + 1}
+	copy(newPath.indices[:], fp.indices[:fp.len])
+	newPath.indices[fp.len] = idx
+	return newPath
+}
+
+// single creates a new fieldPath with a single index.
+func singleFieldPath(idx int) fieldPath {
+	return fieldPath{indices: [4]int{idx}, len: 1}
+}
+
+// fieldInfo stores cached reflection information for a single struct field.
+type fieldInfo struct {
+	index      int
+	name       string
+	fieldType  reflect.StructField
+	isEmbedded bool
+	canSet     bool
+}
+
+// bindableField represents a field that can be bound from form/query values.
+type bindableField struct {
+	path fieldPath
+	name string
+	tag  string
+}
+
+// fileBindableField represents a field that can be bound from multipart file uploads.
+type fileBindableField struct {
+	path    fieldPath
+	tag     string
+	isSlice bool // true for []*FileHeader, false for *FileHeader
+}
+
+// typeInfo stores cached reflection information for a struct type.
+// All bindable fields are pre-computed during analysis to avoid lazy writes.
+type typeInfo struct {
+	typ    reflect.Type
+	fields []fieldInfo
+	// Pre-computed bindable fields for all supported tag/allowFiles combinations.
+	// Populated once during analyzeType - read-only after that.
+	formBindableFields  []bindableField // tag="form", allowFiles=false
+	formWithFilesFields []bindableField // tag="form", allowFiles=true
+	queryBindableFields []bindableField // tag="query", allowFiles=false
+	fileBindableFields  []fileBindableField
+}
+
+// typeRegistry caches reflection information for struct types using sync.Map.
+// This avoids repeated reflection overhead during request binding.
+type typeRegistry struct {
+	cache sync.Map // map[reflect.Type]*typeInfo
+}
+
+// globalTypeRegistry is the package-level type registry instance.
+var globalTypeRegistry = &typeRegistry{}
+
+// getTypeInfo retrieves cached type information for the given type.
+// If the type hasn't been analyzed yet, it analyzes and caches it.
+func (tr *typeRegistry) getTypeInfo(t reflect.Type) (*typeInfo, error) {
+	// Fast path: sync.Map Load
+	if info, ok := tr.cache.Load(t); ok {
+		return info.(*typeInfo), nil
+	}
+
+	// Slow path: create type info
+	info, err := tr.analyzeType(t)
+	if err != nil {
+		return nil, err
+	}
+
+	// Store in cache (if another goroutine stored first, use that)
+	if existing, loaded := tr.cache.LoadOrStore(t, info); loaded {
+		return existing.(*typeInfo), nil
+	}
+	return info, nil
+}
+
+// analyzeType analyzes a struct type and extracts all field information.
+// All bindable field slices are pre-computed here to avoid data races.
+func (tr *typeRegistry) analyzeType(t reflect.Type) (*typeInfo, error) {
+	info := &typeInfo{
+		typ: t,
+	}
+
+	// First pass: collect field metadata
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+
+		fi := fieldInfo{
+			index:      i,
+			name:       field.Name,
+			fieldType:  field,
+			isEmbedded: field.Anonymous && field.Type.Kind() == reflect.Struct,
+			canSet:     field.IsExported(),
+		}
+
+		info.fields = append(info.fields, fi)
+	}
+
+	// Second pass: pre-compute all bindable field combinations
+	// This happens during construction, before the typeInfo is visible to other goroutines.
+	info.formBindableFields = info.computeBindableFields("form", false)
+	info.formWithFilesFields = info.computeBindableFields("form", true)
+	info.queryBindableFields = info.computeBindableFields("query", false)
+
+	fileFields, err := info.computeFileBindableFields()
+	if err != nil {
+		return nil, err
+	}
+	info.fileBindableFields = fileFields
+
+	return info, nil
+}
+
+// getBindableFields returns all bindable fields for a given tag name.
+// Uses pre-computed slices - no lazy initialization.
+func (ti *typeInfo) getBindableFields(tagName string, allowFiles bool) []bindableField {
+	switch tagName {
+	case "form":
+		if allowFiles {
+			return ti.formWithFilesFields
+		}
+		return ti.formBindableFields
+	case "query":
+		return ti.queryBindableFields
+	default:
+		// Fallback for unknown tags - compute on the fly (shouldn't happen in practice)
+		return ti.computeBindableFields(tagName, allowFiles)
+	}
+}
+
+// computeBindableFields computes bindable fields for a tag/allowFiles combination.
+func (ti *typeInfo) computeBindableFields(tagName string, allowFiles bool) []bindableField {
+	result := make([]bindableField, 0, len(ti.fields))
+	for i := range ti.fields {
+		result = ti.collectFieldsRecursive(singleFieldPath(i), tagName, allowFiles, result)
+	}
+	return result
+}
+
+// computeFileBindableFields computes file-bindable fields.
+func (ti *typeInfo) computeFileBindableFields() ([]fileBindableField, error) {
+	result := make([]fileBindableField, 0)
+	for i := range ti.fields {
+		var err error
+		result, err = ti.collectFileFieldsRecursive(singleFieldPath(i), result)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+// getTagValue returns the tag value for a specific tag name.
+// No per-field caching - tag resolution is fast enough.
+func (fi *fieldInfo) getTagValue(tagName string) string {
+	return fi.fieldType.Tag.Get(tagName)
+}
+
+// collectFieldsRecursive recursively collects fields, expanding embedded structs.
+// The path accumulates field indices for proper v.FieldByIndex access.
+// Each index in the path is relative to its parent struct type.
+func (ti *typeInfo) collectFieldsRecursive(path fieldPath, tagName string, allowFiles bool, result []bindableField) []bindableField {
+	fieldIdx := path.indices[path.len-1]
+	fi := &ti.fields[fieldIdx]
+
+	// Handle embedded structs recursively BEFORE other checks
+	// This allows embedded structs to be traversed even if they have tags.
+	// Note: We recurse into embedded structs even if they're unexported
+	// because their exported fields are still accessible via reflection.
+	if fi.isEmbedded {
+		embeddedType := fi.fieldType.Type
+		embeddedInfo, _ := globalTypeRegistry.getTypeInfo(embeddedType)
+		for j := range embeddedInfo.fields {
+			// Build path relative to the TOP-LEVEL struct:
+			// []int{topLevelIdx, embeddedFieldIdx, ...}
+			newPath := path.append(j)
+			result = embeddedInfo.collectFieldsRecursive(newPath, tagName, allowFiles, result)
+		}
+		return result
+	}
+
+	// Skip unexported fields (for non-embedded fields)
+	if !fi.canSet {
+		return result
+	}
+
+	// Consolidate tag lookup: single Tag.Get call per field
+	tag := fi.fieldType.Tag.Get(tagName)
+	if tag == "-" {
+		return result
+	}
+
+	// Strip tag options (e.g., "name,omitempty" -> "name")
+	if idx := strings.Index(tag, ","); idx != -1 {
+		tag = tag[:idx]
+	}
+
+	// Check for file fields first (before pointer-to-struct guard)
+	fieldType := fi.fieldType.Type
+	isFileField := fieldType == fileHeaderPtrType || fieldType == fileHeaderSliceType
+
+	// Skip file fields when not allowing files
+	if !allowFiles && isFileField {
+		return result
+	}
+
+	// Skip pointer-to-struct fields (except file fields) — they are not bindable
+	// primitives and pointer embeds are not expanded (Kind() == Ptr bypassed isEmbedded check).
+	if !isFileField && fieldType.Kind() == reflect.Ptr &&
+		fieldType.Elem().Kind() == reflect.Struct {
+		return result
+	}
+
+	// Use field name as default if tag is empty
+	if tag == "" {
+		tag = camelToSnake(fi.name)
+	}
+
+	bf := bindableField{
+		path: path,
+		name: fi.name,
+		tag:  tag,
+	}
+
+	result = append(result, bf)
+	return result
+}
+
+// collectFileFieldsRecursive recursively collects file-bindable fields.
+// The path accumulates field indices for proper v.FieldByIndex access.
+func (ti *typeInfo) collectFileFieldsRecursive(path fieldPath, result []fileBindableField) ([]fileBindableField, error) {
+	fieldIdx := path.indices[path.len-1]
+	fi := &ti.fields[fieldIdx]
+
+	// Handle embedded structs recursively
+	// Note: We recurse into embedded structs even if they're unexported
+	// because their exported fields are still accessible via reflection.
+	if fi.isEmbedded {
+		embeddedType := fi.fieldType.Type
+		embeddedInfo, _ := globalTypeRegistry.getTypeInfo(embeddedType)
+		for j := range embeddedInfo.fields {
+			newPath := path.append(j)
+			var err error
+			result, err = embeddedInfo.collectFileFieldsRecursive(newPath, result)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return result, nil
+	}
+
+	// Skip unexported fields
+	if !fi.canSet {
+		return result, nil
+	}
+
+	// Check if field is a file header type (before pointer-to-struct guard)
+	fieldType := fi.fieldType.Type
+	isFileField := false
+	isSlice := false
+
+	switch fieldType {
+	case fileHeaderPtrType:
+		isFileField = true
+		isSlice = false
+	case fileHeaderSliceType:
+		isFileField = true
+		isSlice = true
+	case fileHeaderType:
+		// Non-pointer FileHeader is a configuration error
+		return nil, fmt.Errorf("field %s: FileHeader must be a pointer (*FileHeader)", fi.name)
+	}
+
+	if !isFileField {
+		return result, nil
+	}
+
+	// Get form tag (file binding only uses "form" tag)
+	tag := fi.getTagValue("form")
+	if tag == "-" {
+		return result, nil
+	}
+	if tag == "" {
+		tag = camelToSnake(fi.name)
+	}
+
+	bff := fileBindableField{
+		path:    path,
+		tag:     tag,
+		isSlice: isSlice,
+	}
+
+	result = append(result, bff)
+	return result, nil
+}

--- a/type_registry_test.go
+++ b/type_registry_test.go
@@ -1,0 +1,713 @@
+package zerohttp
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestFieldPathImmutability(t *testing.T) {
+	type Inner struct {
+		Name string `form:"name"`
+	}
+	type Outer struct {
+		Inner // anonymous/embedded field (field.Anonymous = true), NOT a named field with tag
+	}
+
+	typ := reflect.TypeOf(Outer{})
+	info, err := globalTypeRegistry.getTypeInfo(typ)
+	if err != nil {
+		t.Fatalf("failed to get type info: %v", err)
+	}
+
+	// Get bindable fields
+	fields := info.getBindableFields("form", false)
+	if len(fields) == 0 {
+		t.Fatal("expected bindable fields")
+	}
+
+	// Verify path is a value type (struct with array), not a slice
+	// The fieldPath struct is immutable by value - copying it creates a full copy
+	originalPath := fields[0].path
+
+	// Create a "modified" copy - this does not affect the original
+	modifiedPath := originalPath
+	if modifiedPath.len > 0 {
+		modifiedPath.indices[0] = 99
+	}
+
+	// Get fields again - should be identical to original
+	fields2 := info.getBindableFields("form", false)
+	if len(fields2) == 0 {
+		t.Fatal("expected bindable fields on second call")
+	}
+
+	// Original path should be unchanged (value type semantics)
+	if originalPath != fields2[0].path {
+		t.Error("cached paths were affected by modification of copy")
+	}
+
+	// Verify the modification was isolated to the copy
+	if modifiedPath == originalPath {
+		t.Error("modification should have created a different value")
+	}
+}
+
+func TestEmbeddedStructFieldOrdering(t *testing.T) {
+	type Embedded struct {
+		FieldB string `form:"field_b"`
+		FieldA string `form:"field_a"`
+	}
+	type Outer struct {
+		Embedded // anonymous/embedded field, no tag needed for recursion
+	}
+
+	typ := reflect.TypeOf(Outer{})
+	info, err := globalTypeRegistry.getTypeInfo(typ)
+	if err != nil {
+		t.Fatalf("failed to get type info: %v", err)
+	}
+
+	fields := info.getBindableFields("form", false)
+	if len(fields) != 2 {
+		t.Fatalf("expected 2 bindable fields, got %d", len(fields))
+	}
+
+	// Verify we can access fields by their computed paths
+	outerVal := Outer{
+		Embedded: Embedded{
+			FieldA: "value_a",
+			FieldB: "value_b",
+		},
+	}
+	v := reflect.ValueOf(outerVal)
+
+	// Both fields should be accessible via FieldByIndex
+	for _, f := range fields {
+		fieldVal := v.FieldByIndex(f.path.toSlice())
+		if !fieldVal.IsValid() {
+			t.Errorf("invalid field for path %+v", f.path)
+		}
+	}
+}
+
+func TestTagLookupConsolidation(t *testing.T) {
+	type TestStruct struct {
+		Name     string `form:"name"`
+		Skipped  string `form:"-"`
+		Default  string // no tag
+		Internal string `form:"_"`
+	}
+
+	typ := reflect.TypeOf(TestStruct{})
+	info, err := globalTypeRegistry.getTypeInfo(typ)
+	if err != nil {
+		t.Fatalf("failed to get type info: %v", err)
+	}
+
+	fields := info.getBindableFields("form", false)
+
+	// Should have Name, Default, Internal (3 fields)
+	// Skipped should be excluded
+	if len(fields) != 3 {
+		t.Errorf("expected 3 bindable fields, got %d", len(fields))
+	}
+
+	// Verify correct fields are included
+	fieldNames := make(map[string]bool)
+	for _, f := range fields {
+		fieldNames[f.tag] = true
+	}
+
+	if !fieldNames["name"] {
+		t.Error("expected 'name' field")
+	}
+	if fieldNames["-"] {
+		t.Error("skipped field should not be present")
+	}
+	if !fieldNames["default"] {
+		t.Error("expected 'default' field with snake_case name")
+	}
+	if !fieldNames["_"] {
+		t.Error("expected 'internal' field")
+	}
+}
+
+func TestFileBindableFieldsAccess(t *testing.T) {
+	type TestStruct struct {
+		File  *FileHeader   `form:"file"`
+		Files []*FileHeader `form:"files"`
+		Name  string        `form:"name"`
+	}
+
+	typ := reflect.TypeOf(TestStruct{})
+	info, err := globalTypeRegistry.getTypeInfo(typ)
+	if err != nil {
+		t.Fatalf("failed to get type info: %v", err)
+	}
+
+	fileFields := info.fileBindableFields
+
+	if len(fileFields) != 2 {
+		t.Errorf("expected 2 file bindable fields, got %d", len(fileFields))
+	}
+
+	v := reflect.ValueOf(TestStruct{})
+	for _, ff := range fileFields {
+		fieldVal := v.FieldByIndex(ff.path.toSlice())
+		if !fieldVal.IsValid() {
+			t.Errorf("invalid field for path %+v", ff.path)
+		}
+	}
+}
+
+func TestThreeLevelEmbedding(t *testing.T) {
+	type A struct {
+		X string `form:"x"`
+	}
+	type B struct {
+		A // embedded
+	}
+	type C struct {
+		B // embedded
+	}
+
+	typ := reflect.TypeOf(C{})
+	info, err := globalTypeRegistry.getTypeInfo(typ)
+	if err != nil {
+		t.Fatalf("failed to get type info: %v", err)
+	}
+
+	fields := info.getBindableFields("form", false)
+	if len(fields) != 1 {
+		t.Fatalf("expected 1 bindable field, got %d", len(fields))
+	}
+
+	// Path should be [1, 0, 0]: C.B.A.X (B at index 0 in C, A at index 0 in B, X at index 0 in A)
+	// Actually: C has B at 0, B has A at 0, A has X at 0 -> path [0, 0, 0]
+	if fields[0].path.len != 3 {
+		t.Errorf("expected path length 3, got %d", fields[0].path.len)
+	}
+
+	// Verify FieldByIndex works correctly
+	c := C{
+		B: B{
+			A: A{X: "value_x"},
+		},
+	}
+	v := reflect.ValueOf(c)
+	fieldVal := v.FieldByIndex(fields[0].path.toSlice())
+	if !fieldVal.IsValid() || fieldVal.String() != "value_x" {
+		t.Errorf("FieldByIndex failed: got %v", fieldVal)
+	}
+}
+
+// TestUnexportedEmbeddedWithExportedFields verifies exported fields within
+// unexported embedded structs are still bindable. While the embedded struct
+// field itself is not settable, its exported fields are accessible via
+// FieldByIndex and can be bound correctly.
+func TestUnexportedEmbeddedWithExportedFields(t *testing.T) {
+	type inner struct { // unexported
+		Name string `form:"name"`
+		_    int
+	}
+	type Outer struct {
+		inner // unexported embedded
+	}
+
+	typ := reflect.TypeOf(Outer{})
+	info, err := globalTypeRegistry.getTypeInfo(typ)
+	if err != nil {
+		t.Fatalf("failed to get type info: %v", err)
+	}
+
+	fields := info.getBindableFields("form", false)
+
+	// The exported field "Name" should be bindable, even within unexported embedded struct
+	if len(fields) != 1 {
+		t.Errorf("expected 1 bindable field (Name promoted from inner), got %d", len(fields))
+	}
+
+	// Verify the path works with FieldByIndex
+	outer := Outer{inner: inner{Name: "test_value"}}
+	v := reflect.ValueOf(outer)
+	fieldVal := v.FieldByIndex(fields[0].path.toSlice())
+	if !fieldVal.IsValid() || fieldVal.String() != "test_value" {
+		t.Errorf("FieldByIndex failed: got %v", fieldVal)
+	}
+}
+
+func TestFileFieldsExcludedFromNonFileBinding(t *testing.T) {
+	type TestStruct struct {
+		Name  string        `form:"name"`
+		File  *FileHeader   `form:"file"`
+		Files []*FileHeader `form:"files"`
+	}
+
+	typ := reflect.TypeOf(TestStruct{})
+	info, err := globalTypeRegistry.getTypeInfo(typ)
+	if err != nil {
+		t.Fatalf("failed to get type info: %v", err)
+	}
+
+	// formBindableFields (allowFiles=false) should NOT include file fields
+	formFields := info.formBindableFields
+	for _, f := range formFields {
+		if f.tag == "file" || f.tag == "files" {
+			t.Error("file fields should not appear in formBindableFields")
+		}
+	}
+
+	// queryBindableFields should NOT include file fields
+	queryFields := info.queryBindableFields
+	for _, f := range queryFields {
+		if f.tag == "file" || f.tag == "files" {
+			t.Error("file fields should not appear in queryBindableFields")
+		}
+	}
+
+	// Verify counts
+	if len(formFields) != 1 || formFields[0].tag != "name" {
+		t.Errorf("expected only 'name' in form fields, got %v", formFields)
+	}
+	if len(queryFields) != 1 || queryFields[0].tag != "name" {
+		t.Errorf("expected only 'name' in query fields, got %v", queryFields)
+	}
+
+	// POSITIVE: formWithFilesFields SHOULD include file fields
+	withFilesFields := info.formWithFilesFields
+	if len(withFilesFields) != 3 {
+		t.Errorf("expected 3 fields with files allowed, got %d", len(withFilesFields))
+	}
+	tags := make(map[string]bool)
+	for _, f := range withFilesFields {
+		tags[f.tag] = true
+	}
+	if !tags["file"] || !tags["files"] || !tags["name"] {
+		t.Error("formWithFilesFields should include file, files, and name")
+	}
+}
+
+// TestConcurrentRegistration verifies LoadOrStore works correctly under concurrency.
+// NOTE: This test must be run with `go test -race` to validate the sync.Map guarantee.
+// Without -race, it only tests pointer equality under cooperative scheduling.
+func TestConcurrentRegistration(t *testing.T) {
+	type TestStruct struct {
+		Field string `form:"field"`
+	}
+
+	typ := reflect.TypeOf(TestStruct{})
+
+	// Clear cache first (create fresh registry)
+	freshRegistry := &typeRegistry{}
+
+	const numGoroutines = 100
+	var wg sync.WaitGroup
+	results := make([]*typeInfo, numGoroutines)
+	errChan := make(chan error, numGoroutines)
+
+	wg.Add(numGoroutines)
+	for i := 0; i < numGoroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			info, err := freshRegistry.getTypeInfo(typ)
+			if err != nil {
+				errChan <- err
+				return
+			}
+			results[idx] = info
+		}(i)
+	}
+	wg.Wait()
+	close(errChan)
+
+	for err := range errChan {
+		if err != nil {
+			t.Fatalf("failed to get type info: %v", err)
+		}
+	}
+
+	// All results should be identical (same pointer)
+	first := results[0]
+	if first == nil {
+		t.Fatal("expected non-nil typeInfo")
+	}
+
+	for i, result := range results {
+		if result != first {
+			t.Errorf("goroutine %d: expected same pointer, got different", i)
+		}
+	}
+}
+
+// TestPointerToStructEmbedded verifies pointer-to-struct embeds are excluded.
+// Pointer-to-struct fields are not bindable primitives and pointer embeds
+// are not expanded (Kind() == Ptr bypasses isEmbedded check), so they are skipped.
+func TestPointerToStructEmbedded(t *testing.T) {
+	type Inner struct {
+		Name string `form:"name"`
+	}
+	type Outer struct {
+		*Inner // pointer to struct - should be excluded
+	}
+
+	typ := reflect.TypeOf(Outer{})
+	info, err := globalTypeRegistry.getTypeInfo(typ)
+	if err != nil {
+		t.Fatalf("failed to get type info: %v", err)
+	}
+
+	fields := info.getBindableFields("form", false)
+	if len(fields) != 0 {
+		t.Errorf("expected 0 fields, pointer-to-struct embed should be excluded, got %d", len(fields))
+	}
+}
+
+func TestTagWithOptionsSuffix(t *testing.T) {
+	type TestStruct struct {
+		WithOptions string `form:"name,omitempty"`
+	}
+
+	typ := reflect.TypeOf(TestStruct{})
+	info, err := globalTypeRegistry.getTypeInfo(typ)
+	if err != nil {
+		t.Fatalf("failed to get type info: %v", err)
+	}
+
+	fields := info.getBindableFields("form", false)
+	if len(fields) != 1 {
+		t.Fatalf("expected 1 field, got %d", len(fields))
+	}
+
+	// Tag options should be stripped: "name,omitempty" -> "name"
+	if fields[0].tag != "name" {
+		t.Errorf("expected tag 'name' (options stripped), got '%s'", fields[0].tag)
+	}
+}
+
+func TestQueryTagIndependentFromFormTag(t *testing.T) {
+	type TestStruct struct {
+		OnlyForm  string `form:"form_field"`
+		OnlyQuery string `query:"query_field"`
+		Both      string `form:"form_both" query:"query_both"`
+		Neither   string // should get snake_case for both
+	}
+
+	typ := reflect.TypeOf(TestStruct{})
+	info, err := globalTypeRegistry.getTypeInfo(typ)
+	if err != nil {
+		t.Fatalf("failed to get type info: %v", err)
+	}
+
+	// Form binding
+	formFields := info.getBindableFields("form", false)
+	formTags := make(map[string]bool)
+	for _, f := range formFields {
+		formTags[f.tag] = true
+	}
+
+	// Query binding
+	queryFields := info.getBindableFields("query", false)
+	queryTags := make(map[string]bool)
+	for _, f := range queryFields {
+		queryTags[f.tag] = true
+	}
+
+	// Form tags should use form tag or snake_case
+	if !formTags["form_field"] {
+		t.Error("expected 'form_field' in form tags")
+	}
+	if !formTags["form_both"] {
+		t.Error("expected 'form_both' in form tags")
+	}
+	if !formTags["neither"] { // snake_case
+		t.Error("expected 'neither' in form tags")
+	}
+
+	// Query tags should use query tag or snake_case
+	if !queryTags["query_field"] {
+		t.Error("expected 'query_field' in query tags")
+	}
+	if !queryTags["query_both"] {
+		t.Error("expected 'query_both' in query tags")
+	}
+	if !queryTags["neither"] { // snake_case
+		t.Error("expected 'neither' in query tags")
+	}
+
+	// Verify form-only field uses snake_case for query (no query tag)
+	if queryTags["form_field"] {
+		t.Error("form_field should not appear in query tags (should be 'only_form' via snake_case)")
+	}
+}
+
+func TestAnalyzeTypeDeterministic(t *testing.T) {
+	type TestStruct struct {
+		A string      `form:"a"`
+		B string      `form:"b"`
+		C *FileHeader `form:"c"`
+	}
+
+	typ := reflect.TypeOf(TestStruct{})
+
+	// Call analyzeType multiple times
+	var results []*typeInfo
+	for i := 0; i < 10; i++ {
+		// Create fresh registry to force re-analysis
+		reg := &typeRegistry{}
+		info, err := reg.getTypeInfo(typ)
+		if err != nil {
+			t.Fatalf("failed to get type info: %v", err)
+		}
+		results = append(results, info)
+	}
+
+	// All should have identical field content
+	first := results[0]
+	for i, info := range results {
+		if len(info.formBindableFields) != len(first.formBindableFields) {
+			t.Errorf("run %d: formBindableFields length mismatch", i)
+		}
+		if len(info.fileBindableFields) != len(first.fileBindableFields) {
+			t.Errorf("run %d: fileBindableFields length mismatch", i)
+		}
+		if len(info.fields) != len(first.fields) {
+			t.Errorf("run %d: fields length mismatch", i)
+		}
+
+		// Check field tags are identical
+		for j, f := range info.formBindableFields {
+			if j >= len(first.formBindableFields) {
+				break
+			}
+			if f.tag != first.formBindableFields[j].tag {
+				t.Errorf("run %d: field %d tag mismatch: %s vs %s", i, j, f.tag, first.formBindableFields[j].tag)
+			}
+		}
+	}
+}
+
+func TestEmptyStruct(t *testing.T) {
+	type Empty struct{}
+
+	typ := reflect.TypeOf(Empty{})
+	info, err := globalTypeRegistry.getTypeInfo(typ)
+	if err != nil {
+		t.Fatalf("failed to get type info: %v", err)
+	}
+
+	if len(info.fields) != 0 {
+		t.Errorf("expected 0 fields, got %d", len(info.fields))
+	}
+	if len(info.formBindableFields) != 0 {
+		t.Errorf("expected 0 form bindable fields, got %d", len(info.formBindableFields))
+	}
+	if len(info.fileBindableFields) != 0 {
+		t.Errorf("expected 0 file bindable fields, got %d", len(info.fileBindableFields))
+	}
+}
+
+func TestAllSkippedFields(t *testing.T) {
+	type AllSkipped struct {
+		A string `form:"-"`
+		B string `form:"-"`
+	}
+
+	typ := reflect.TypeOf(AllSkipped{})
+	info, err := globalTypeRegistry.getTypeInfo(typ)
+	if err != nil {
+		t.Fatalf("failed to get type info: %v", err)
+	}
+
+	if len(info.formBindableFields) != 0 {
+		t.Errorf("expected 0 fields when all skipped, got %d", len(info.formBindableFields))
+	}
+}
+
+func TestFieldPathHelpers(t *testing.T) {
+	// singleFieldPath
+	fp := singleFieldPath(5)
+	if fp.len != 1 || fp.indices[0] != 5 {
+		t.Error("singleFieldPath failed")
+	}
+
+	// append
+	fp2 := fp.append(3)
+	if fp2.len != 2 || fp2.indices[0] != 5 || fp2.indices[1] != 3 {
+		t.Error("append failed")
+	}
+
+	// original unchanged
+	if fp.len != 1 {
+		t.Error("original path was modified")
+	}
+
+	// toSlice
+	slice := fp2.toSlice()
+	if len(slice) != 2 || slice[0] != 5 || slice[1] != 3 {
+		t.Errorf("toSlice returned wrong values: %v", slice)
+	}
+
+	// Test chaining up to 4 levels
+	fp3 := fp2.append(7).append(9)
+	if fp3.len != 4 {
+		t.Errorf("chained append failed, expected len 4, got %d", fp3.len)
+	}
+}
+
+func TestFieldPathOverflow(t *testing.T) {
+	// Build a path of length 4 (maximum)
+	fp := singleFieldPath(0).append(1).append(2).append(3)
+	if fp.len != 4 {
+		t.Fatalf("expected len 4, got %d", fp.len)
+	}
+
+	// Next append should panic
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for fieldPath overflow, but didn't panic")
+		}
+	}()
+
+	_ = fp.append(4) // This should panic
+}
+
+// TestSnakeCaseConversion verifies camelToSnake behavior.
+// NOTE: Current implementation doesn't handle consecutive capitals well.
+func TestSnakeCaseConversion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"UserName", "user_name"},
+		{"Simple", "simple"},
+		{"A", "a"},
+		{"", ""},
+		// These demonstrate the current behavior with consecutive capitals:
+		{"UserID", "user_i_d"},           // NOT "user_id" - known limitation
+		{"HTTPServer", "h_t_t_p_server"}, // NOT "http_server" - known limitation
+		{"XMLData", "x_m_l_data"},        // NOT "xml_data" - known limitation
+	}
+
+	for _, tc := range tests {
+		result := camelToSnake(tc.input)
+		if result != tc.expected {
+			t.Errorf("camelToSnake(%q) = %q, expected %q", tc.input, result, tc.expected)
+		}
+	}
+}
+
+func TestEmbeddedWithFormTag(t *testing.T) {
+	type Inner struct {
+		Field string `form:"inner_field"`
+	}
+	type Outer struct {
+		Inner `form:"inner_tag"` // embedded with tag
+	}
+
+	typ := reflect.TypeOf(Outer{})
+	info, err := globalTypeRegistry.getTypeInfo(typ)
+	if err != nil {
+		t.Fatalf("failed to get type info: %v", err)
+	}
+
+	// Should recurse into embedded Inner and find inner_field
+	fields := info.getBindableFields("form", false)
+	if len(fields) != 1 {
+		t.Fatalf("expected 1 field from embedded Inner, got %d", len(fields))
+	}
+	if fields[0].tag != "inner_field" {
+		t.Errorf("expected 'inner_field', got %s", fields[0].tag)
+	}
+}
+
+func TestUnknownTagFallback(t *testing.T) {
+	type TestStruct struct {
+		A string `custom:"custom_a"`
+		B string `custom:"-"`
+		C string // no custom tag
+	}
+
+	typ := reflect.TypeOf(TestStruct{})
+	info, err := globalTypeRegistry.getTypeInfo(typ)
+	if err != nil {
+		t.Fatalf("failed to get type info: %v", err)
+	}
+
+	// Unknown tag triggers computeBindableFields on the fly
+	fields := info.getBindableFields("custom", false)
+
+	// Should find A and C (B is skipped with "-")
+	if len(fields) != 2 {
+		t.Fatalf("expected 2 fields for unknown tag, got %d", len(fields))
+	}
+
+	tags := make(map[string]bool)
+	for _, f := range fields {
+		tags[f.tag] = true
+	}
+	if !tags["custom_a"] {
+		t.Error("expected 'custom_a' field")
+	}
+	if !tags["c"] { // snake_case default
+		t.Error("expected 'c' field (snake_case)")
+	}
+	if tags["-"] {
+		t.Error("skipped field should not be present")
+	}
+}
+
+func TestMixedEmbeddedAndRegular(t *testing.T) {
+	type Inner struct {
+		A string `form:"a"`
+	}
+	type Outer struct {
+		Inner        // embedded - provides A
+		B     string `form:"b"`
+	}
+
+	typ := reflect.TypeOf(Outer{})
+	info, err := globalTypeRegistry.getTypeInfo(typ)
+	if err != nil {
+		t.Fatalf("failed to get type info: %v", err)
+	}
+
+	fields := info.getBindableFields("form", false)
+	if len(fields) != 2 {
+		t.Fatalf("expected 2 fields (a from embedded + b), got %d", len(fields))
+	}
+
+	tags := make(map[string]bool)
+	for _, f := range fields {
+		tags[f.tag] = true
+	}
+	if !tags["a"] || !tags["b"] {
+		t.Errorf("expected both 'a' and 'b', got %v", tags)
+	}
+}
+
+func BenchmarkTagLookup(b *testing.B) {
+	type TestStruct struct {
+		Field1  string `form:"field1"`
+		Field2  string `form:"field2"`
+		Field3  string `form:"field3"`
+		Field4  string `form:"field4"`
+		Field5  string `form:"field5"`
+		Field6  string `form:"field6"`
+		Field7  string `form:"field7"`
+		Field8  string `form:"field8"`
+		Field9  string `form:"field9"`
+		Field10 string `form:"field10"`
+	}
+
+	typ := reflect.TypeOf(TestStruct{})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		info, err := globalTypeRegistry.getTypeInfo(typ)
+		if err != nil {
+			b.Fatalf("failed to get type info: %v", err)
+		}
+		_ = info.getBindableFields("form", false)
+	}
+}


### PR DESCRIPTION
Replace reflection-heavy binding with cached type information:

- Add type registry (type_registry.go) that caches struct field metadata using sync.Map for thread-safe concurrent access
- Pre-compute bindable fields for form/query tags and file uploads
- Use FieldByIndex with cached paths for O(1) field access instead of recursive reflection on each request
- Properly handle unexported embedded structs (their exported fields are still accessible and bindable)
- Return explicit error for non-pointer FileHeader fields

This eliminates repeated reflection overhead during request binding, significantly improving performance on high-throughput endpoints.