### PR TITLE
  fix: add compile-time interface compliance checks

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -45,6 +45,9 @@ type Binder interface {
 	Query(r *http.Request, dst any) error
 }
 
+// Ensure defaultBinder implements Binder
+var _ Binder = (*defaultBinder)(nil)
+
 // defaultBinder implements the Binder interface with standard decoding
 type defaultBinder struct{}
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -49,10 +49,10 @@ func P(value any) Field {
 	return Field{Key: "panic", Value: value}
 }
 
-// DefaultLogger is a simple implementation using Go's standard log package
 // Ensure DefaultLogger implements Logger
 var _ Logger = (*DefaultLogger)(nil)
 
+// DefaultLogger is a simple implementation using Go's standard log package
 type DefaultLogger struct {
 	logger *log.Logger
 	fields []Field

--- a/log/logger.go
+++ b/log/logger.go
@@ -50,6 +50,9 @@ func P(value any) Field {
 }
 
 // DefaultLogger is a simple implementation using Go's standard log package
+// Ensure DefaultLogger implements Logger
+var _ Logger = (*DefaultLogger)(nil)
+
 type DefaultLogger struct {
 	logger *log.Logger
 	fields []Field

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -134,6 +134,9 @@ func SafeRegistry(reg Registry) Registry {
 	return reg
 }
 
+// Ensure nopRegistry implements Registry
+var _ Registry = (*nopRegistry)(nil)
+
 // nopRegistry is a no-op registry that does nothing.
 type nopRegistry struct{}
 
@@ -144,12 +147,18 @@ func (nopRegistry) RegisterCollector(Collector)                      {}
 func (nopRegistry) UnregisterCollector(Collector)                    {}
 func (nopRegistry) Gather() []MetricFamily                           { return nil }
 
+// Ensure nopCounter implements Counter
+var _ Counter = (*nopCounter)(nil)
+
 // nopCounter is a no-op counter.
 type nopCounter struct{}
 
 func (nopCounter) Inc()                              {}
 func (nopCounter) Add(float64)                       {}
 func (nopCounter) WithLabelValues(...string) Counter { return nopCounter{} }
+
+// Ensure nopGauge implements Gauge
+var _ Gauge = (*nopGauge)(nil)
 
 // nopGauge is a no-op gauge.
 type nopGauge struct{}
@@ -160,6 +169,9 @@ func (nopGauge) Set(float64)                     {}
 func (nopGauge) Add(float64)                     {}
 func (nopGauge) Sub(float64)                     {}
 func (nopGauge) WithLabelValues(...string) Gauge { return nopGauge{} }
+
+// Ensure nopHistogram implements Histogram
+var _ Histogram = (*nopHistogram)(nil)
 
 // nopHistogram is a no-op histogram.
 type nopHistogram struct{}
@@ -198,6 +210,9 @@ var DefaultRegistryConfig = RegistryConfig{
 }
 
 // registry is the internal implementation of Registry.
+// Ensure registry implements Registry
+var _ Registry = (*registry)(nil)
+
 type registry struct {
 	mu             sync.RWMutex
 	counters       map[string]*counterVec
@@ -206,6 +221,9 @@ type registry struct {
 	collectors     []Collector
 	maxCardinality int // 0 = unlimited, default 1000
 }
+
+// Ensure counterVec implements Counter
+var _ Counter = (*counterVec)(nil)
 
 // counterVec holds counters with different label values.
 type counterVec struct {
@@ -216,6 +234,9 @@ type counterVec struct {
 	insertOrder    []string // tracks insertion order for LRU eviction
 	maxCardinality int      // 0 = unlimited
 }
+
+// Ensure counter implements Counter
+var _ Counter = (*counter)(nil)
 
 // counter is a single counter instance.
 type counter struct {
@@ -279,6 +300,9 @@ func (cv *counterVec) WithLabelValues(values ...string) Counter {
 	return c
 }
 
+// Ensure gaugeVec implements Gauge
+var _ Gauge = (*gaugeVec)(nil)
+
 // gaugeVec holds gauges with different label values.
 type gaugeVec struct {
 	name           string
@@ -288,6 +312,9 @@ type gaugeVec struct {
 	insertOrder    []string // tracks insertion order for LRU eviction
 	maxCardinality int      // 0 = unlimited
 }
+
+// Ensure gauge implements Gauge
+var _ Gauge = (*gauge)(nil)
 
 // gauge is a single gauge instance.
 // Values are stored with fixed-point precision (3 decimal places) using int64.
@@ -375,6 +402,9 @@ func (gv *gaugeVec) WithLabelValues(values ...string) Gauge {
 	return g
 }
 
+// Ensure histogramVec implements Histogram
+var _ Histogram = (*histogramVec)(nil)
+
 // histogramVec holds histograms with different label values.
 type histogramVec struct {
 	name           string
@@ -385,6 +415,9 @@ type histogramVec struct {
 	insertOrder    []string // tracks insertion order for LRU eviction
 	maxCardinality int      // 0 = unlimited
 }
+
+// Ensure histogram implements Histogram
+var _ Histogram = (*histogram)(nil)
 
 // histogram is a single histogram instance.
 type histogram struct {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -209,10 +209,10 @@ var DefaultRegistryConfig = RegistryConfig{
 	MaxCardinality: 1000,
 }
 
-// registry is the internal implementation of Registry.
 // Ensure registry implements Registry
 var _ Registry = (*registry)(nil)
 
+// registry is the internal implementation of Registry.
 type registry struct {
 	mu             sync.RWMutex
 	counters       map[string]*counterVec

--- a/params.go
+++ b/params.go
@@ -29,10 +29,10 @@ type ParamExtractor interface {
 	ParamOrDefault(r *http.Request, name, defaultVal string) string
 }
 
-// defaultParamsExtractor implements the ParamExtractor interface
 // Ensure defaultParamsExtractor implements ParamExtractor
 var _ ParamExtractor = (*defaultParamsExtractor)(nil)
 
+// defaultParamsExtractor implements the ParamExtractor interface
 type defaultParamsExtractor struct{}
 
 // Param gets a path parameter by name as a string.

--- a/params.go
+++ b/params.go
@@ -30,6 +30,9 @@ type ParamExtractor interface {
 }
 
 // defaultParamsExtractor implements the ParamExtractor interface
+// Ensure defaultParamsExtractor implements ParamExtractor
+var _ ParamExtractor = (*defaultParamsExtractor)(nil)
+
 type defaultParamsExtractor struct{}
 
 // Param gets a path parameter by name as a string.

--- a/query.go
+++ b/query.go
@@ -20,6 +20,9 @@ type QueryExtractor interface {
 }
 
 // defaultQueryExtractor implements the QueryExtractor interface
+// Ensure defaultQueryExtractor implements QueryExtractor
+var _ QueryExtractor = (*defaultQueryExtractor)(nil)
+
 type defaultQueryExtractor struct{}
 
 // QueryParam gets a query parameter by name as a string.

--- a/query.go
+++ b/query.go
@@ -19,10 +19,10 @@ type QueryExtractor interface {
 	QueryParamOrDefault(r *http.Request, name, defaultVal string) string
 }
 
-// defaultQueryExtractor implements the QueryExtractor interface
 // Ensure defaultQueryExtractor implements QueryExtractor
 var _ QueryExtractor = (*defaultQueryExtractor)(nil)
 
+// defaultQueryExtractor implements the QueryExtractor interface
 type defaultQueryExtractor struct{}
 
 // QueryParam gets a query parameter by name as a string.

--- a/render.go
+++ b/render.go
@@ -59,6 +59,9 @@ type Renderer interface {
 }
 
 // defaultRenderer implements the Renderer interface with standard HTTP response handling
+// Ensure defaultRenderer implements Renderer
+var _ Renderer = (*defaultRenderer)(nil)
+
 type defaultRenderer struct{}
 
 // JSON writes a JSON response with the given status code and data

--- a/render.go
+++ b/render.go
@@ -58,10 +58,10 @@ type Renderer interface {
 	ProblemDetail(w http.ResponseWriter, problem *ProblemDetail) error
 }
 
-// defaultRenderer implements the Renderer interface with standard HTTP response handling
 // Ensure defaultRenderer implements Renderer
 var _ Renderer = (*defaultRenderer)(nil)
 
+// defaultRenderer implements the Renderer interface with standard HTTP response handling
 type defaultRenderer struct{}
 
 // JSON writes a JSON response with the given status code and data

--- a/router.go
+++ b/router.go
@@ -92,6 +92,9 @@ type headResponseWriter struct {
 	http.ResponseWriter
 }
 
+// Ensure headResponseWriter implements http.ResponseWriter
+var _ http.ResponseWriter = (*headResponseWriter)(nil)
+
 func (h *headResponseWriter) Write(p []byte) (int, error) {
 	// Discard body writes for HEAD requests
 	return len(p), nil
@@ -203,6 +206,9 @@ type Router interface {
 	// and 404/405 error responses.
 	SetConfig(config config.Config)
 }
+
+// Ensure defaultRouter implements Router
+var _ Router = (*defaultRouter)(nil)
 
 // defaultRouter is the concrete implementation of the Router interface.
 // It wraps Go's standard http.ServeMux and adds method-specific routing,

--- a/sse.go
+++ b/sse.go
@@ -358,6 +358,9 @@ type SSEReplayer interface {
 
 // InMemoryReplayer stores events in memory with a circular buffer.
 // Events can be limited by max count and/or TTL.
+// Ensure InMemoryReplayer implements SSEReplayer
+var _ SSEReplayer = (*InMemoryReplayer)(nil)
+
 type InMemoryReplayer struct {
 	events    []storedEvent
 	maxEvents int

--- a/sse.go
+++ b/sse.go
@@ -356,11 +356,11 @@ type SSEReplayer interface {
 	Replay(afterID string, send func(SSEEvent) error) (int, error)
 }
 
-// InMemoryReplayer stores events in memory with a circular buffer.
-// Events can be limited by max count and/or TTL.
 // Ensure InMemoryReplayer implements SSEReplayer
 var _ SSEReplayer = (*InMemoryReplayer)(nil)
 
+// InMemoryReplayer stores events in memory with a circular buffer.
+// Events can be limited by max count and/or TTL.
 type InMemoryReplayer struct {
 	events    []storedEvent
 	maxEvents int

--- a/template_renderer.go
+++ b/template_renderer.go
@@ -12,6 +12,9 @@ type TemplateRenderer interface {
 }
 
 // TemplateManager implements TemplateRenderer using html/template
+// Ensure TemplateManager implements TemplateRenderer
+var _ TemplateRenderer = (*TemplateManager)(nil)
+
 type TemplateManager struct {
 	templates *template.Template
 }

--- a/template_renderer.go
+++ b/template_renderer.go
@@ -11,10 +11,10 @@ type TemplateRenderer interface {
 	Render(w http.ResponseWriter, code int, name string, data any) error
 }
 
-// TemplateManager implements TemplateRenderer using html/template
 // Ensure TemplateManager implements TemplateRenderer
 var _ TemplateRenderer = (*TemplateManager)(nil)
 
+// TemplateManager implements TemplateRenderer using html/template
 type TemplateManager struct {
 	templates *template.Template
 }

--- a/validate.go
+++ b/validate.go
@@ -43,10 +43,10 @@ type Validator interface {
 	Register(name string, fn ValidationFunc)
 }
 
-// defaultValidator implements the Validator interface
 // Ensure defaultValidator implements Validator
 var _ Validator = (*defaultValidator)(nil)
 
+// defaultValidator implements the Validator interface
 type defaultValidator struct {
 	mu         sync.RWMutex
 	validators map[string]ValidationFunc

--- a/validate.go
+++ b/validate.go
@@ -44,6 +44,9 @@ type Validator interface {
 }
 
 // defaultValidator implements the Validator interface
+// Ensure defaultValidator implements Validator
+var _ Validator = (*defaultValidator)(nil)
+
 type defaultValidator struct {
 	mu         sync.RWMutex
 	validators map[string]ValidationFunc


### PR DESCRIPTION
  Add `var _ Interface = (*Implementation)(nil)` checks to ensure all
  interface implementations are validated at compile time rather than
  failing at runtime.

  Adds checks for:
  - Router, Binder, Validator, Renderer interfaces
  - ParamExtractor, QueryExtractor interfaces
  - SSEReplayer, TemplateRenderer interfaces
  - Logger, Registry, Counter, Gauge, Histogram interfaces