### PR TITLE
refactor: extract Bool helper to config/util.go

### DIFF
--- a/config/csrf.go
+++ b/config/csrf.go
@@ -57,11 +57,6 @@ type CSRFConfig struct {
 	TokenGenerator func(key []byte) (string, error)
 }
 
-// Bool returns a pointer to a bool value
-func Bool(b bool) *bool {
-	return &b
-}
-
 // DefaultCSRFConfig contains the default values for CSRF configuration
 var DefaultCSRFConfig = CSRFConfig{
 	CookieName:     "csrf_token",

--- a/config/util.go
+++ b/config/util.go
@@ -1,0 +1,8 @@
+package config
+
+// Bool returns a pointer to a bool value.
+// Needed because Go doesn't allow &true. Used for *bool config fields that
+// distinguish "not set" (nil) from "explicitly false".
+func Bool(b bool) *bool {
+	return &b
+}


### PR DESCRIPTION
  Move Bool() from csrf.go to a dedicated file with documentation
  explaining its purpose (Go doesn't allow &true for pointer bools).