### PR TITLE
fix: security headers, error handling, and performance optimizations

### DIFF
--- a/internal/rwutil/rwutil.go
+++ b/internal/rwutil/rwutil.go
@@ -27,6 +27,9 @@ func (rw *ResponseWriter) WriteHeader(code int) {
 	}
 	rw.statusCode = code
 	rw.headerWritten = true
+	// WriteHeader does not return an error per http.ResponseWriter interface.
+	// Once headers are written, the connection is committed and errors cannot
+	// be handled meaningfully at this layer.
 	rw.ResponseWriter.WriteHeader(code)
 }
 

--- a/middleware/request_logger.go
+++ b/middleware/request_logger.go
@@ -41,16 +41,19 @@ func RequestLogger(logger log.Logger, cfg ...config.RequestLoggerConfig) func(ht
 
 			duration := time.Since(start)
 
-			LogRequest(logger, c, r, wrapped.StatusCode(), duration)
+			LogRequest(logger, c, fieldMap, r, wrapped.StatusCode(), duration)
 		})
 	}
 }
 
 // LogRequest logs an HTTP request with consistent formatting.
-func LogRequest(logger log.Logger, cfg config.RequestLoggerConfig, r *http.Request, statusCode int, duration time.Duration) {
-	fieldMap := make(map[config.LogField]bool)
-	for _, field := range cfg.Fields {
-		fieldMap[field] = true
+// If fieldMap is nil, it will be computed from cfg.Fields.
+func LogRequest(logger log.Logger, cfg config.RequestLoggerConfig, fieldMap map[config.LogField]bool, r *http.Request, statusCode int, duration time.Duration) {
+	if fieldMap == nil {
+		fieldMap = make(map[config.LogField]bool)
+		for _, field := range cfg.Fields {
+			fieldMap[field] = true
+		}
 	}
 
 	var logFields []log.Field

--- a/middleware/security_headers.go
+++ b/middleware/security_headers.go
@@ -41,7 +41,7 @@ func SecurityHeaders(cfg ...config.SecurityHeadersConfig) func(http.Handler) htt
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			for _, exemptPath := range c.ExemptPaths {
-				if r.URL.Path == exemptPath {
+				if pathMatches(r.URL.Path, exemptPath) {
 					next.ServeHTTP(w, r)
 					return
 				}

--- a/render.go
+++ b/render.go
@@ -114,7 +114,7 @@ func (r *defaultRenderer) Stream(w http.ResponseWriter, statusCode int, contentT
 // File sends the contents of a file as the response.
 // It automatically sets the Content-Type header based on the file extension
 // and handles file opening/closing. Also sets ETag and Content-Length headers.
-func (r *defaultRenderer) File(w http.ResponseWriter, req *http.Request, filename string) error {
+func (r *defaultRenderer) File(w http.ResponseWriter, req *http.Request, filename string) (err error) {
 	file, err := os.Open(filename)
 	if err != nil {
 		return err
@@ -158,7 +158,7 @@ func (r *defaultRenderer) File(w http.ResponseWriter, req *http.Request, filenam
 	w.Header().Set(HeaderContentLength, strconv.FormatInt(fileInfo.Size(), 10))
 
 	http.ServeContent(w, req, filepath.Base(filename), fileInfo.ModTime(), file)
-	return err
+	return
 }
 
 // NoContent writes a 204 No Content response with no body

--- a/router.go
+++ b/router.go
@@ -443,7 +443,7 @@ func (r *defaultRouter) createStaticHandler(filesystem fs.FS, fallback bool, api
 		for _, prefix := range apiPrefixes {
 			if strings.HasPrefix(cleanPath, prefix) {
 				r.notFoundHandler.ServeHTTP(w, req)
-				middleware.LogRequest(r.logger, r.config.RequestLogger, req, http.StatusNotFound, time.Since(start))
+				middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusNotFound, time.Since(start))
 				return
 			}
 		}
@@ -458,7 +458,7 @@ func (r *defaultRouter) createStaticHandler(filesystem fs.FS, fallback bool, api
 			stat, err := file.Stat()
 			if err == nil && !stat.IsDir() {
 				http.FileServer(http.FS(filesystem)).ServeHTTP(w, req)
-				middleware.LogRequest(r.logger, r.config.RequestLogger, req, http.StatusOK, time.Since(start))
+				middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusOK, time.Since(start))
 				return
 			}
 		}
@@ -467,11 +467,11 @@ func (r *defaultRouter) createStaticHandler(filesystem fs.FS, fallback bool, api
 			// Fallback to index.html for client-side routing
 			req.URL.Path = "/"
 			http.FileServer(http.FS(filesystem)).ServeHTTP(w, req)
-			middleware.LogRequest(r.logger, r.config.RequestLogger, req, http.StatusOK, time.Since(start))
+			middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusOK, time.Since(start))
 		} else {
 			// Use custom 404 handler for missing files
 			r.notFoundHandler.ServeHTTP(w, req)
-			middleware.LogRequest(r.logger, r.config.RequestLogger, req, http.StatusNotFound, time.Since(start))
+			middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusNotFound, time.Since(start))
 		}
 	})
 }
@@ -591,13 +591,13 @@ func (r *defaultRouter) catchAllHandler() http.HandlerFunc {
 			if !methods[req.Method] {
 				w.Header().Set(HeaderAllow, allowedMethods(methods))
 				r.methodNotAllowedHandler.ServeHTTP(w, req)
-				middleware.LogRequest(r.logger, r.config.RequestLogger, req, http.StatusMethodNotAllowed, time.Since(start))
+				middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusMethodNotAllowed, time.Since(start))
 				return
 			}
 		}
 
 		r.notFoundHandler.ServeHTTP(w, req)
-		middleware.LogRequest(r.logger, r.config.RequestLogger, req, http.StatusNotFound, time.Since(start))
+		middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusNotFound, time.Since(start))
 	}
 }
 


### PR DESCRIPTION
- Use pattern matching for security headers exempt paths
- Fix Render.File to properly capture close errors via named return
- Pre-compute request logger field map to reduce allocations
- Document why WriteHeader errors are intentionally ignored