### PR TITLE
fix: use pathMatches for exempt paths in rate limit and request logger

### DIFF
--- a/middleware/rate_limit.go
+++ b/middleware/rate_limit.go
@@ -53,7 +53,7 @@ func RateLimit(cfg ...config.RateLimitConfig) func(http.Handler) http.Handler {
 			reg := metrics.SafeRegistry(metrics.GetRegistry(r.Context()))
 
 			for _, exemptPath := range c.ExemptPaths {
-				if r.URL.Path == exemptPath {
+				if pathMatches(r.URL.Path, exemptPath) {
 					next.ServeHTTP(w, r)
 					return
 				}

--- a/middleware/request_logger.go
+++ b/middleware/request_logger.go
@@ -27,7 +27,7 @@ func RequestLogger(logger log.Logger, cfg ...config.RequestLoggerConfig) func(ht
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			for _, exemptPath := range c.ExemptPaths {
-				if r.URL.Path == exemptPath {
+				if pathMatches(r.URL.Path, exemptPath) {
 					next.ServeHTTP(w, r)
 					return
 				}


### PR DESCRIPTION
Change exact string comparison to pathMatches() for consistency with other middleware (BasicAuth, CORS, CSRF, SecurityHeaders). This allows wildcard patterns to work in exempt path configuration.