### PR TITLE
fix: add cleanup function for reverse proxy health checks

### DIFF
--- a/examples/reverse_proxy/main.go
+++ b/examples/reverse_proxy/main.go
@@ -17,17 +17,19 @@ func main() {
 	// Example 1: Simple API proxy with path stripping
 	// Requests to /api/users go to http://localhost:8081/users
 	app.Group(func(api zh.Router) {
-		api.Use(middleware.ReverseProxy(config.ReverseProxyConfig{
+		rp, cleanup := middleware.ReverseProxy(config.ReverseProxyConfig{
 			Target:      "http://localhost:8081",
 			StripPrefix: "/api",
-		}))
+		})
+		defer cleanup() // Stop health checks on shutdown
+		api.Use(rp)
 		api.GET("/api/{path...}", nil)
 	})
 
 	// Example 2: Load balancer with health checks
 	// Distributes requests across multiple backends
 	app.Group(func(lb zh.Router) {
-		lb.Use(middleware.ReverseProxy(config.ReverseProxyConfig{
+		rp, cleanup := middleware.ReverseProxy(config.ReverseProxyConfig{
 			Targets: []config.Backend{
 				{Target: "http://backend1:8081", Weight: 1, Healthy: true},
 				{Target: "http://backend2:8081", Weight: 1, Healthy: true},
@@ -36,26 +38,30 @@ func main() {
 			LoadBalancer:        config.RoundRobin,
 			HealthCheckInterval: 10 * time.Second,
 			HealthCheckPath:     "/health",
-		}))
+		})
+		defer cleanup() // Stop health checks on shutdown
+		lb.Use(rp)
 		lb.GET("/lb/{path...}", nil)
 	})
 
 	// Example 3: With custom headers and X-Forwarded-* injection
 	app.Group(func(fwd zh.Router) {
-		fwd.Use(middleware.ReverseProxy(config.ReverseProxyConfig{
+		rp, cleanup := middleware.ReverseProxy(config.ReverseProxyConfig{
 			Target: "http://api.example.com",
 			SetHeaders: map[string]string{
 				"X-Proxy-By": "zerohttp",
 			},
 			RemoveHeaders:  []string{"X-Internal-Token"},
-			ForwardHeaders: true, // Adds X-Forwarded-For, X-Forwarded-Proto, X-Forwarded-Host
-		}))
+			ForwardHeaders: true,
+		})
+		defer cleanup()
+		fwd.Use(rp)
 		fwd.GET("/forward/{path...}", nil)
 	})
 
 	// Example 4: With fallback for when all backends are down
 	app.Group(func(crit zh.Router) {
-		crit.Use(middleware.ReverseProxy(config.ReverseProxyConfig{
+		rp, cleanup := middleware.ReverseProxy(config.ReverseProxyConfig{
 			Targets: []config.Backend{
 				{Target: "http://backend1:8081", Healthy: true},
 				{Target: "http://backend2:8081", Healthy: true},
@@ -65,20 +71,23 @@ func main() {
 				w.WriteHeader(http.StatusServiceUnavailable)
 				_, _ = w.Write([]byte(`{"error": "Service temporarily unavailable"}`))
 			}),
-		}))
+		})
+		defer cleanup()
+		crit.Use(rp)
 		crit.GET("/critical/{path...}", nil)
 	})
 
 	// Example 5: Path rewriting
 	app.Group(func(rw zh.Router) {
-		rw.Use(middleware.ReverseProxy(config.ReverseProxyConfig{
+		rp, cleanup := middleware.ReverseProxy(config.ReverseProxyConfig{
 			Target:      "http://api.example.com",
 			StripPrefix: "/rewrite",
 			Rewrites: []config.RewriteRule{
-				// Rewrite /rewrite/v1/* to /v2/*
 				{Pattern: "/v1/*", Replacement: "/v2/path"},
 			},
-		}))
+		})
+		defer cleanup()
+		rw.Use(rp)
 		rw.GET("/rewrite/{path...}", nil)
 	})
 

--- a/middleware/reverse_proxy.go
+++ b/middleware/reverse_proxy.go
@@ -45,8 +45,10 @@ type backend struct {
 	proxy       *httputil.ReverseProxy
 }
 
-// ReverseProxy creates a reverse proxy middleware from the given configuration
-func ReverseProxy(cfg config.ReverseProxyConfig) func(http.Handler) http.Handler {
+// ReverseProxy creates a reverse proxy middleware from the given configuration.
+// It returns the middleware handler and a cleanup function to stop health checks.
+// The cleanup function should be called on server shutdown to prevent goroutine leaks.
+func ReverseProxy(cfg config.ReverseProxyConfig) (func(http.Handler) http.Handler, func()) {
 	rp := &reverseProxy{
 		cfg:       cfg,
 		transport: cfg.Transport,
@@ -76,6 +78,12 @@ func ReverseProxy(cfg config.ReverseProxyConfig) func(http.Handler) http.Handler
 		ctx, cancel := context.WithCancel(context.Background())
 		rp.cancelFunc = cancel
 		go rp.healthCheckLoop(ctx)
+	}
+
+	cleanup := func() {
+		if rp.cancelFunc != nil {
+			rp.cancelFunc()
+		}
 	}
 
 	return func(next http.Handler) http.Handler {
@@ -113,7 +121,7 @@ func ReverseProxy(cfg config.ReverseProxyConfig) func(http.Handler) http.Handler
 			reg.Counter("proxy_requests_total", "target", "status").WithLabelValues(b.Target, strconv.Itoa(rec.statusCode)).Inc()
 			reg.Histogram("proxy_request_duration_seconds", []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}, "target").WithLabelValues(b.Target).Observe(duration)
 		})
-	}
+	}, cleanup
 }
 
 // initBackend initializes a single backend

--- a/middleware/reverse_proxy_test.go
+++ b/middleware/reverse_proxy_test.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -21,7 +20,7 @@ func TestReverseProxy_SingleTarget(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Target: upstream.URL,
 	})
 
@@ -43,7 +42,7 @@ func TestReverseProxy_StripPrefix(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Target:      upstream.URL,
 		StripPrefix: "/api",
 	})
@@ -62,7 +61,7 @@ func TestReverseProxy_StripPrefixRoot(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Target:      upstream.URL,
 		StripPrefix: "/api",
 	})
@@ -81,7 +80,7 @@ func TestReverseProxy_AddPrefix(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Target:    upstream.URL,
 		AddPrefix: "/v2",
 	})
@@ -100,7 +99,7 @@ func TestReverseProxy_StripAndAddPrefix(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Target:      upstream.URL,
 		StripPrefix: "/api",
 		AddPrefix:   "/v2",
@@ -120,7 +119,7 @@ func TestReverseProxy_Rewrite(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Target: upstream.URL,
 		Rewrites: []config.RewriteRule{
 			{Pattern: "/old/*", Replacement: "/new/path"},
@@ -141,7 +140,7 @@ func TestReverseProxy_SetHeaders(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Target: upstream.URL,
 		SetHeaders: map[string]string{
 			"X-Custom": "custom-value",
@@ -166,7 +165,7 @@ func TestReverseProxy_RemoveHeaders(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Target:        upstream.URL,
 		RemoveHeaders: []string{"X-Remove"},
 	})
@@ -189,7 +188,7 @@ func TestReverseProxy_ForwardHeaders(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Target:         upstream.URL,
 		ForwardHeaders: true,
 	})
@@ -216,7 +215,7 @@ func TestReverseProxy_ExemptPaths(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Target:      upstream.URL,
 		ExemptPaths: []string{"/health", "/metrics"},
 	})
@@ -253,7 +252,7 @@ func TestReverseProxy_ModifyRequest(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Target: upstream.URL,
 		ModifyRequest: func(r *http.Request) {
 			r.Header.Set("X-Modified", "modified-value")
@@ -276,7 +275,7 @@ func TestReverseProxy_ModifyResponse(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Target: upstream.URL,
 		ModifyResponse: func(r *http.Response) error {
 			r.Header.Set("X-Modified", "modified")
@@ -293,7 +292,7 @@ func TestReverseProxy_ModifyResponse(t *testing.T) {
 }
 
 func TestReverseProxy_ErrorHandler(t *testing.T) {
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Target: "http://localhost:1",
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			w.WriteHeader(http.StatusServiceUnavailable)
@@ -310,7 +309,7 @@ func TestReverseProxy_ErrorHandler(t *testing.T) {
 }
 
 func TestReverseProxy_FallbackHandler(t *testing.T) {
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Targets: []config.Backend{
 			{Target: "http://localhost:1", Healthy: false},
 		},
@@ -340,7 +339,7 @@ func TestReverseProxy_LoadBalancer_RoundRobin(t *testing.T) {
 	}))
 	defer upstream2.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Targets: []config.Backend{
 			{Target: upstream1.URL, Healthy: true},
 			{Target: upstream2.URL, Healthy: true},
@@ -382,7 +381,7 @@ func TestReverseProxy_LoadBalancer_Random(t *testing.T) {
 	}))
 	defer upstream2.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Targets: []config.Backend{
 			{Target: upstream1.URL, Healthy: true},
 			{Target: upstream2.URL, Healthy: true},
@@ -413,7 +412,7 @@ func TestReverseProxy_LoadBalancer_LeastConnections(t *testing.T) {
 	}))
 	defer upstream2.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Targets: []config.Backend{
 			{Target: upstream1.URL, Healthy: true},
 			{Target: upstream2.URL, Healthy: true},
@@ -468,7 +467,7 @@ func TestReverseProxy_HealthCheck(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Targets: []config.Backend{
 			{Target: upstream.URL, Healthy: true},
 		},
@@ -506,7 +505,7 @@ func TestReverseProxy_FlushInterval(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Target:        upstream.URL,
 		FlushInterval: 100 * time.Millisecond,
 	})
@@ -530,7 +529,7 @@ func TestReverseProxy_CustomTransport(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Target:    upstream.URL,
 		Transport: customTransport,
 	})
@@ -556,7 +555,7 @@ func TestReverseProxy_WithNextHandler(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Target: upstream.URL,
 	})
 
@@ -578,7 +577,7 @@ func TestReverseProxy_WithNextHandler(t *testing.T) {
 }
 
 func TestReverseProxy_NoHealthyBackends(t *testing.T) {
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Targets: []config.Backend{
 			{Target: "http://localhost:1", Healthy: false},
 		},
@@ -601,7 +600,7 @@ func TestReverseProxy_ResponseHeaders(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Target: upstream.URL,
 	})
 
@@ -619,7 +618,7 @@ func TestReverseProxy_PostBody(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Target: upstream.URL,
 	})
 
@@ -637,7 +636,7 @@ func TestReverseProxy_QueryParams(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Target: upstream.URL,
 	})
 
@@ -648,17 +647,14 @@ func TestReverseProxy_QueryParams(t *testing.T) {
 	zhtest.AssertWith(t, rec).Status(http.StatusOK).Body("foo=bar&baz=qux")
 }
 
-func TestReverseProxy_HealthCheckContextCancellation(t *testing.T) {
+func TestReverseProxy_HealthCheckCleanup(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer upstream.Close()
 
-	// Create a context that we can cancel
-	_, cancel := context.WithCancel(context.Background())
-
 	// Create reverse proxy with health checks
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
 		Targets: []config.Backend{
 			{Target: upstream.URL, Healthy: true},
 		},
@@ -681,19 +677,19 @@ func TestReverseProxy_HealthCheckContextCancellation(t *testing.T) {
 	// Wait for a health check cycle
 	time.Sleep(75 * time.Millisecond)
 
-	// Cancel the context - this should stop health checks
-	cancel()
+	// Call cleanup - this should stop health checks
+	cleanup()
 
 	// Wait a bit and verify no panic occurs
 	time.Sleep(100 * time.Millisecond)
 
-	// Handler should still work after context cancellation
+	// Handler should still work after cleanup
 	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec2 := httptest.NewRecorder()
 	handler.ServeHTTP(rec2, req2)
 
 	if rec2.Code != http.StatusOK {
-		t.Fatalf("expected status 200 after context cancel, got %d", rec2.Code)
+		t.Fatalf("expected status 200 after cleanup, got %d", rec2.Code)
 	}
 }
 
@@ -703,7 +699,7 @@ func BenchmarkReverseProxy(b *testing.B) {
 	}))
 	defer upstream.Close()
 
-	mw := ReverseProxy(config.ReverseProxyConfig{
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
 		Target: upstream.URL,
 	})
 


### PR DESCRIPTION
ReverseProxy now returns a cleanup function that properly stops the health check goroutine to prevent goroutine leaks on shutdown.

The function signature changed from:
    `func ReverseProxy(cfg) func(http.Handler) http.Handler`
to:
    `func ReverseProxy(cfg) (func(http.Handler) http.Handler, func())`

Usage:
    ```
    rp, cleanup := middleware.ReverseProxy(config)
    defer cleanup()
    ```

Updated all tests and examples to use the new signature.