### PR TITLE
  fix: prevent HMAC auth middleware from modifying request headers

### DIFF
--- a/middleware/hmac_auth.go
+++ b/middleware/hmac_auth.go
@@ -213,9 +213,28 @@ func HMACAuth(cfg ...config.HMACAuthConfig) func(http.Handler) http.Handler {
 				return
 			}
 
-			for _, header := range requiredHeaders {
-				if header == "host" {
-					if r.Host == "" {
+			// For presigned URLs, skip required header checks since the timestamp
+			// comes from the URL credential, not headers. The signature validation
+			// will still ensure the URL hasn't been tampered with.
+			if !parsed.IsPresigned {
+				for _, header := range requiredHeaders {
+					if header == "host" {
+						if r.Host == "" {
+							if auditLogger != nil {
+								auditLogger(parsed.AccessKeyID, parsed.Timestamp, false, "missing_header")
+							}
+							reg.Counter("hmac_auth_requests_total", "result").WithLabelValues("invalid").Inc()
+							handleHMACError(w, r, &HMACAuthError{
+								Type:   errMissingHeader.Type,
+								Title:  errMissingHeader.Title,
+								Status: errMissingHeader.Status,
+								Detail: "Missing required header: host",
+							}, errorHandler)
+							return
+						}
+						continue
+					}
+					if r.Header.Get(header) == "" {
 						if auditLogger != nil {
 							auditLogger(parsed.AccessKeyID, parsed.Timestamp, false, "missing_header")
 						}
@@ -224,24 +243,10 @@ func HMACAuth(cfg ...config.HMACAuthConfig) func(http.Handler) http.Handler {
 							Type:   errMissingHeader.Type,
 							Title:  errMissingHeader.Title,
 							Status: errMissingHeader.Status,
-							Detail: "Missing required header: host",
+							Detail: "Missing required header: " + header,
 						}, errorHandler)
 						return
 					}
-					continue
-				}
-				if r.Header.Get(header) == "" {
-					if auditLogger != nil {
-						auditLogger(parsed.AccessKeyID, parsed.Timestamp, false, "missing_header")
-					}
-					reg.Counter("hmac_auth_requests_total", "result").WithLabelValues("invalid").Inc()
-					handleHMACError(w, r, &HMACAuthError{
-						Type:   errMissingHeader.Type,
-						Title:  errMissingHeader.Title,
-						Status: errMissingHeader.Status,
-						Detail: "Missing required header: " + header,
-					}, errorHandler)
-					return
 				}
 			}
 
@@ -452,10 +457,6 @@ func parsePresignedURLParams(r *http.Request) (*parsedAuth, error) {
 		return nil, errors.New("invalid signature encoding")
 	}
 
-	// For presigned URLs, set the X-Timestamp header from the credential timestamp
-	// so that required header checks pass
-	r.Header.Set("X-Timestamp", ts.Format(time.RFC3339))
-
 	return &parsedAuth{
 		Algorithm:   algo,
 		AccessKeyID: accessKeyID,
@@ -582,7 +583,7 @@ func buildCanonicalRequest(
 	b.WriteString(buildCanonicalQueryString(query))
 	b.WriteByte('\n')
 
-	signedHeaders := buildSignedHeaders(r, parsed.Headers, timestampHeader)
+	signedHeaders := buildSignedHeaders(r, parsed.Headers, timestampHeader, parsed.Timestamp)
 	b.WriteString(signedHeaders)
 	b.WriteString("\n\n") // Two newlines: end headers section + blank line
 
@@ -616,7 +617,8 @@ func buildCanonicalQueryString(values url.Values) string {
 }
 
 // buildSignedHeaders creates the canonical headers string
-func buildSignedHeaders(r *http.Request, headers []string, timestampHeader string) string {
+// For presigned URLs, the timestamp from parsedAuth is used instead of the request header
+func buildSignedHeaders(r *http.Request, headers []string, timestampHeader string, presignedTimestamp time.Time) string {
 	var parts []string
 
 	for _, h := range headers {
@@ -625,8 +627,12 @@ func buildSignedHeaders(r *http.Request, headers []string, timestampHeader strin
 
 		if h == "host" {
 			value = r.Host
-		} else {
+		} else if presignedTimestamp.IsZero() || h != strings.ToLower(timestampHeader) {
+			// Normal case: get header from request
 			value = r.Header.Get(h)
+		} else {
+			// Presigned URL case: use the timestamp from the credential
+			value = presignedTimestamp.Format(time.RFC3339)
 		}
 
 		value = strings.TrimSpace(value)

--- a/middleware/hmac_auth_test.go
+++ b/middleware/hmac_auth_test.go
@@ -1867,3 +1867,56 @@ func TestHMACAuth_NilCredentialStore(t *testing.T) {
 		CredentialStore: nil,
 	})
 }
+
+// TestHMACAuth_PresignedURL_NoHeaderModification verifies that the middleware
+// does not modify the request headers when processing presigned URLs
+func TestHMACAuth_PresignedURL_NoHeaderModification(t *testing.T) {
+	creds := map[string]string{"test-key": "test-secret-key-that-is-32-bytes-long!"}
+	mw := HMACAuth(config.HMACAuthConfig{
+		CredentialStore: func(id string) []string {
+			if secret, ok := creds[id]; ok {
+				return []string{secret}
+			}
+			return nil
+		},
+		AllowPresignedURLs: true,
+	})
+
+	var capturedRequest *http.Request
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRequest = r
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Create a pre-signed URL
+	req := httptest.NewRequest(http.MethodGet, "https://api.example.com/data", nil)
+	signer := NewHMACSigner("test-key", "test-secret-key-that-is-32-bytes-long!")
+	presignedURL, err := signer.PresignURL(req, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("failed to create presigned URL: %v", err)
+	}
+
+	// Parse the presigned URL and make a request
+	parsedURL, _ := url.Parse(presignedURL)
+	req2 := httptest.NewRequest(http.MethodGet, parsedURL.String(), nil)
+
+	// Capture the original headers before the request is processed
+	originalTimestampHeader := req2.Header.Get("X-Timestamp")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req2)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200 for valid presigned URL, got %d", rr.Code)
+	}
+
+	// Verify that the X-Timestamp header was NOT modified by the middleware
+	if capturedRequest == nil {
+		t.Fatal("capturedRequest is nil")
+	}
+	finalTimestampHeader := capturedRequest.Header.Get("X-Timestamp")
+	if finalTimestampHeader != originalTimestampHeader {
+		t.Errorf("X-Timestamp header was modified by middleware: original=%q, final=%q",
+			originalTimestampHeader, finalTimestampHeader)
+	}
+}


### PR DESCRIPTION
  The parsePresignedURLParams() function was setting the X-Timestamp
  header as a side effect to pass required header checks. This modified
  the original request which could affect downstream handlers.

  Changes:
  - Removed r.Header.Set() from parsePresignedURLParams()
  - Modified buildSignedHeaders() to accept timestamp from parsedAuth
  - Skip required header check for presigned URLs (timestamp from URL)
  - Add test to verify headers are not modified