### PR TITLE
  fix: add mutex protection to etagResponseWriter

### DIFF
--- a/middleware/etag.go
+++ b/middleware/etag.go
@@ -61,6 +61,7 @@ type etagResponseWriter struct {
 	reg             metrics.Registry
 	etagGenerated   bool
 	finalized       bool
+	mu              sync.Mutex // protects buffer and state fields
 }
 
 // newETagResponseWriter creates a new etagResponseWriter
@@ -93,8 +94,9 @@ func (ew *etagResponseWriter) release() {
 	}
 }
 
-// WriteHeader captures the status code and checks if ETag generation should be skipped
-func (ew *etagResponseWriter) WriteHeader(status int) {
+// writeHeaderLocked captures the status code and checks if ETag generation should be skipped.
+// Caller must hold ew.mu.
+func (ew *etagResponseWriter) writeHeaderLocked(status int) {
 	if ew.hasWritten {
 		return
 	}
@@ -136,12 +138,16 @@ func (ew *etagResponseWriter) WriteHeader(status int) {
 	}
 }
 
-// Write captures the response body for ETag generation
-func (ew *etagResponseWriter) Write(p []byte) (int, error) {
-	if !ew.hasWritten {
-		ew.WriteHeader(http.StatusOK)
-	}
+// WriteHeader captures the status code and checks if ETag generation should be skipped
+func (ew *etagResponseWriter) WriteHeader(status int) {
+	ew.mu.Lock()
+	defer ew.mu.Unlock()
+	ew.writeHeaderLocked(status)
+}
 
+// writeLocked captures the response body for ETag generation.
+// Caller must hold ew.mu.
+func (ew *etagResponseWriter) writeLocked(p []byte) (int, error) {
 	n := len(p)
 	ew.written += n
 
@@ -161,6 +167,19 @@ func (ew *etagResponseWriter) Write(p []byte) (int, error) {
 	}
 
 	return ew.buf.Write(p)
+}
+
+// Write captures the response body for ETag generation
+func (ew *etagResponseWriter) Write(p []byte) (int, error) {
+	ew.mu.Lock()
+
+	if !ew.hasWritten {
+		ew.writeHeaderLocked(http.StatusOK)
+	}
+
+	n, err := ew.writeLocked(p)
+	ew.mu.Unlock()
+	return n, err
 }
 
 // generateETag generates the ETag from the buffered content
@@ -273,11 +292,13 @@ func (ew *etagResponseWriter) shouldServeRange(etag string) bool {
 
 // Flush implements http.Flusher
 func (ew *etagResponseWriter) Flush() {
+	ew.mu.Lock()
 	// If we have buffered data and haven't written to the response yet,
 	// we need to flush the ETag processing first
 	if ew.buf.Len() > 0 && !ew.skipETag && !ew.finalized {
-		ew.finalize()
+		ew.finalizeLocked()
 	}
+	ew.mu.Unlock()
 
 	if f, ok := ew.ResponseWriter.(http.Flusher); ok {
 		f.Flush()
@@ -300,8 +321,9 @@ func (ew *etagResponseWriter) Push(target string, opts *http.PushOptions) error 
 	return errors.New("middleware: http.Pusher is unavailable on the writer")
 }
 
-// finalize processes the buffered response, generates ETag, and writes the response
-func (ew *etagResponseWriter) finalize() {
+// finalizeLocked processes the buffered response, generates ETag, and writes the response.
+// Caller must hold ew.mu.
+func (ew *etagResponseWriter) finalizeLocked() {
 	if ew.skipETag || ew.finalized {
 		return
 	}
@@ -346,6 +368,13 @@ func (ew *etagResponseWriter) finalize() {
 		_, _ = ew.ResponseWriter.Write(ew.buf.Bytes())
 	}
 	ew.recordMetrics(ew.status)
+}
+
+// finalize processes the buffered response, generates ETag, and writes the response
+func (ew *etagResponseWriter) finalize() {
+	ew.mu.Lock()
+	defer ew.mu.Unlock()
+	ew.finalizeLocked()
 }
 
 // recordMetrics records ETag metrics

--- a/middleware/etag_test.go
+++ b/middleware/etag_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1317,4 +1318,36 @@ func TestETag_Metrics(t *testing.T) {
 	if totalGen != 2 {
 		t.Errorf("expected 2 generated ETags, got %d", totalGen)
 	}
+}
+
+// TestETag_ConcurrentWriteAndFlush tests that concurrent Write operations
+// don't cause a data race on the buffer field
+func TestETag_ConcurrentWriteAndFlush(t *testing.T) {
+	mw := ETag()
+
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var wg sync.WaitGroup
+
+		// Simulate concurrent writes
+		for range 10 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, _ = w.Write([]byte("data"))
+				// Note: Flush is not safe for concurrent use in httptest.ResponseRecorder
+				// so we only test concurrent writes here which is the actual issue
+			}()
+		}
+
+		wg.Wait()
+
+		// Single flush after all writes complete
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
 }


### PR DESCRIPTION
  The etagResponseWriter had a potential data race on the buffer field
  and state fields (hasWritten, written, skipETag, finalized) when
  Write() and Flush() were called concurrently.

  Changes:
  - Add sync.Mutex to etagResponseWriter struct
  - Create writeHeaderLocked(), writeLocked(), finalizeLocked() internal methods
  - Update public methods (WriteHeader, Write, Flush, finalize) to use locking
  - Add TestETag_ConcurrentWriteAndFlush to verify thread safety