### PR TITLE
  fix: avoid double-locking in circuit breaker GetState

### DIFF
--- a/middleware/circuit_breaker.go
+++ b/middleware/circuit_breaker.go
@@ -197,14 +197,16 @@ func (c *circuit) recordResult(r *http.Request, statusCode int, reg metrics.Regi
 // GetState returns the current state of a circuit (for monitoring)
 func (cbm *circuitBreakerMiddleware) GetState(key string) CircuitState {
 	cbm.mu.RLock()
-	defer cbm.mu.RUnlock()
+	c, exists := cbm.circuits[key]
+	cbm.mu.RUnlock()
 
-	if c, exists := cbm.circuits[key]; exists {
-		c.mu.RLock()
-		defer c.mu.RUnlock()
-		return c.state
+	if !exists {
+		return StateClosed
 	}
-	return StateClosed
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.state
 }
 
 // Reset manually resets a circuit breaker (for admin operations)

--- a/middleware/circuit_breaker_test.go
+++ b/middleware/circuit_breaker_test.go
@@ -454,3 +454,39 @@ func TestCircuitBreaker_ConcurrentReset(t *testing.T) {
 		}
 	}
 }
+
+func TestCircuitBreaker_GetState(t *testing.T) {
+	cbm := &circuitBreakerMiddleware{
+		circuits: make(map[string]*circuit),
+		config: config.CircuitBreakerConfig{
+			FailureThreshold: 3,
+			RecoveryTimeout:  100 * time.Millisecond,
+		},
+	}
+
+	// Test initial state (circuit doesn't exist yet)
+	if state := cbm.GetState("/test"); state != StateClosed {
+		t.Errorf("expected StateClosed for non-existent circuit, got %v", state)
+	}
+
+	// Create and open a circuit
+	c := cbm.getCircuit("/test")
+	c.mu.Lock()
+	c.state = StateOpen
+	c.failureCount = 100
+	c.mu.Unlock()
+
+	// Circuit should be open now
+	if state := cbm.GetState("/test"); state != StateOpen {
+		t.Errorf("expected StateOpen, got %v", state)
+	}
+
+	// Reset circuit to closed
+	c.mu.Lock()
+	c.state = StateClosed
+	c.mu.Unlock()
+
+	if state := cbm.GetState("/test"); state != StateClosed {
+		t.Errorf("expected StateClosed after reset, got %v", state)
+	}
+}


### PR DESCRIPTION
  GetState was holding the middleware's read lock while acquiring the
  circuit's read lock. While technically safe (multiple read locks can
  be held), it was inefficient.

  Changes:
  - Release middleware lock before acquiring circuit lock
  - Return early with default StateClosed if circuit doesn't exist
  - Only acquire circuit lock when needed