### PR TITLE
  fix: log CSRF token generation errors

### DIFF
--- a/config/csrf.go
+++ b/config/csrf.go
@@ -1,6 +1,10 @@
 package config
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/alexferl/zerohttp/log"
+)
 
 // CSRFConfig holds configuration for CSRF protection
 type CSRFConfig struct {
@@ -55,6 +59,11 @@ type CSRFConfig struct {
 	// TokenGenerator is an optional function for generating CSRF tokens.
 	// Defaults to crypto-secure random generation.
 	TokenGenerator func(key []byte) (string, error)
+
+	// Logger is used to log errors during CSRF token generation.
+	// If nil, the global logger will be used.
+	// Default: nil
+	Logger log.Logger
 }
 
 // DefaultCSRFConfig contains the default values for CSRF configuration

--- a/middleware/csrf.go
+++ b/middleware/csrf.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/alexferl/zerohttp/config"
 	"github.com/alexferl/zerohttp/internal/problem"
+	"github.com/alexferl/zerohttp/log"
 	"github.com/alexferl/zerohttp/metrics"
 )
 
@@ -84,6 +85,12 @@ func CSRF(cfg ...config.CSRFConfig) func(http.Handler) http.Handler {
 		tokenGenerator = generateToken
 	}
 
+	// Use injected logger or global
+	logger := c.Logger
+	if logger == nil {
+		logger = log.GetGlobalLogger()
+	}
+
 	exemptMethodMap := make(map[string]bool)
 	for _, method := range c.ExemptMethods {
 		exemptMethodMap[strings.ToUpper(method)] = true
@@ -114,6 +121,7 @@ func CSRF(cfg ...config.CSRFConfig) func(http.Handler) http.Handler {
 					token, err = tokenGenerator(hmacKey)
 					if err != nil {
 						// Fail closed: reject request if we can't generate a token
+						logger.Error("CSRF token generation failed", log.E(err))
 						reg.Counter("csrf_rejected_total", "reason").WithLabelValues("token_generation_failed").Inc()
 						errorHandler(w, r)
 						return
@@ -153,6 +161,7 @@ func CSRF(cfg ...config.CSRFConfig) func(http.Handler) http.Handler {
 			newToken, err := tokenGenerator(hmacKey)
 			if err != nil {
 				// Fail closed: reject request if we can't generate a token
+				logger.Error("CSRF token generation failed", log.E(err))
 				reg.Counter("csrf_rejected_total", "reason").WithLabelValues("token_generation_failed").Inc()
 				errorHandler(w, r)
 				return


### PR DESCRIPTION
  The error from tokenGenerator was not being logged, only counted as a
  metric. This made debugging difficult when token generation failed.

  Changes:
  - Add Logger field to CSRFConfig (uses global logger if nil)
  - Import log package in csrf.go
  - Log errors at both token generation points using configured logger