### PR TITLE
feat: add dynamic CORS origin validation with AllowOriginFunc

### DIFF
--- a/config/cors.go
+++ b/config/cors.go
@@ -2,6 +2,10 @@ package config
 
 import "net/http"
 
+// OriginValidator is a function that validates if an origin is allowed.
+// Returns true if the origin is allowed, false otherwise.
+type OriginValidator func(origin string) bool
+
 // CORSConfig allows customization of CORS behavior
 type CORSConfig struct {
 	// AllowedOrigins is a list of allowed origins. Use ["*"] to allow all origins
@@ -20,6 +24,9 @@ type CORSConfig struct {
 	OptionsPassthrough bool
 	// ExemptPaths contains paths that skip CORS processing
 	ExemptPaths []string
+	// AllowOriginFunc is a custom function to validate origins dynamically.
+	// If set, this takes precedence over AllowedOrigins matching.
+	AllowOriginFunc OriginValidator
 }
 
 // DefaultCORSConfig contains the default values for CORS configuration.

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -88,15 +88,26 @@ func CORS(cfg ...config.CORSConfig) func(http.Handler) http.Handler {
 
 			// Determine if origin is allowed
 			var allowedOrigin string
-			if allowAllOrigins {
-				if c.AllowCredentials {
-					// When credentials are allowed, can't use "*"
-					allowedOrigin = origin
-				} else {
-					allowedOrigin = "*"
-				}
+			originAllowed := false
+
+			if c.AllowOriginFunc != nil {
+				// Use custom origin validator
+				originAllowed = c.AllowOriginFunc(origin)
+				// Set Vary header when using dynamic origin validation
+				w.Header().Set("Vary", "Origin")
+			} else if allowAllOrigins {
+				originAllowed = true
 			} else if allowedOriginMap[strings.ToLower(origin)] {
-				allowedOrigin = origin
+				originAllowed = true
+			}
+
+			if originAllowed {
+				if allowAllOrigins && !c.AllowCredentials {
+					// When credentials are allowed, can't use "*"
+					allowedOrigin = "*"
+				} else {
+					allowedOrigin = origin
+				}
 			}
 
 			// Set CORS headers if origin is allowed

--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -427,3 +427,104 @@ func TestCORS_Metrics(t *testing.T) {
 		t.Errorf("expected 1 rejected, got %d", rejected)
 	}
 }
+
+func TestCORSAllowOriginFunc(t *testing.T) {
+	tests := []struct {
+		name          string
+		origin        string
+		validator     config.OriginValidator
+		expectAllowed bool
+		expectVary    bool
+	}{
+		{
+			name:   "allowed by function",
+			origin: "https://app.example.com",
+			validator: func(origin string) bool {
+				return strings.HasSuffix(origin, ".example.com")
+			},
+			expectAllowed: true,
+			expectVary:    true,
+		},
+		{
+			name:   "rejected by function",
+			origin: "https://evil.com",
+			validator: func(origin string) bool {
+				return strings.HasSuffix(origin, ".example.com")
+			},
+			expectAllowed: false,
+			expectVary:    true,
+		},
+		{
+			name:   "function takes precedence over allowed origins",
+			origin: "https://other.com",
+			validator: func(origin string) bool {
+				return origin == "https://other.com"
+			},
+			expectAllowed: true,
+			expectVary:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mw := CORS(config.CORSConfig{
+				AllowedOrigins:  []string{"https://example.com"}, // Should be ignored when AllowOriginFunc is set
+				AllowOriginFunc: tt.validator,
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set("Origin", tt.origin)
+			rr := httptest.NewRecorder()
+
+			mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})).ServeHTTP(rr, req)
+
+			varyHeader := rr.Header().Get("Vary")
+			if tt.expectVary && varyHeader != "Origin" {
+				t.Errorf("expected Vary: Origin, got %s", varyHeader)
+			}
+			if !tt.expectVary && varyHeader == "Origin" {
+				t.Errorf("unexpected Vary: Origin header")
+			}
+
+			allowOrigin := rr.Header().Get("Access-Control-Allow-Origin")
+			if tt.expectAllowed && allowOrigin == "" {
+				t.Errorf("expected Access-Control-Allow-Origin header, got none")
+			}
+			if !tt.expectAllowed && allowOrigin != "" {
+				t.Errorf("expected no Access-Control-Allow-Origin header, got %s", allowOrigin)
+			}
+		})
+	}
+}
+
+func TestCORSCustomOriginFuncWithCredentials(t *testing.T) {
+	mw := CORS(config.CORSConfig{
+		AllowCredentials: true,
+		AllowOriginFunc: func(origin string) bool {
+			return strings.HasPrefix(origin, "https://")
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Origin", "https://app.example.com")
+	rr := httptest.NewRecorder()
+
+	mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rr, req)
+
+	// When credentials are allowed and using custom validator, should echo origin
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "https://app.example.com" {
+		t.Errorf("expected origin echo with credentials, got %s", got)
+	}
+
+	if got := rr.Header().Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Errorf("expected credentials header, got %s", got)
+	}
+
+	if got := rr.Header().Get("Vary"); got != "Origin" {
+		t.Errorf("expected Vary: Origin, got %s", got)
+	}
+}


### PR DESCRIPTION
- Add OriginValidator type for custom origin validation functions
- Add AllowOriginFunc to CORSConfig for dynamic origin matching
- Set Vary: Origin header when using dynamic validation
- Add tests for AllowOriginFunc and credentials interaction