### PR TITLE
feat: add half-open request limiting to circuit breaker

### DIFF
--- a/config/circuit_breaker.go
+++ b/config/circuit_breaker.go
@@ -13,6 +13,9 @@ type CircuitBreakerConfig struct {
 	RecoveryTimeout time.Duration
 	// SuccessThreshold is the number of consecutive successes needed to close the circuit from half-open
 	SuccessThreshold int
+	// MaxHalfOpenRequests is the maximum number of concurrent requests allowed in half-open state.
+	// This prevents thundering herd when service recovers. Default is 1.
+	MaxHalfOpenRequests int
 	// IsFailure determines if a response should be considered a failure
 	IsFailure func(*http.Request, int) bool
 	// KeyExtractor extracts the circuit breaker key from the request (for per-endpoint circuits)
@@ -25,9 +28,10 @@ type CircuitBreakerConfig struct {
 
 // DefaultCircuitBreakerConfig contains the default values for circuit breaker configuration.
 var DefaultCircuitBreakerConfig = CircuitBreakerConfig{
-	FailureThreshold: 5,
-	RecoveryTimeout:  30 * time.Second,
-	SuccessThreshold: 3,
+	FailureThreshold:    5,
+	RecoveryTimeout:     30 * time.Second,
+	SuccessThreshold:    3,
+	MaxHalfOpenRequests: 1,
 	IsFailure: func(r *http.Request, statusCode int) bool {
 		return statusCode >= http.StatusInternalServerError // Consider 5xx as failures
 	},

--- a/middleware/circuit_breaker.go
+++ b/middleware/circuit_breaker.go
@@ -22,12 +22,13 @@ const (
 
 // circuit represents a single circuit breaker instance
 type circuit struct {
-	state           CircuitState
-	failureCount    int
-	successCount    int
-	lastFailureTime time.Time
-	mu              sync.RWMutex
-	config          config.CircuitBreakerConfig
+	state              CircuitState
+	failureCount       int
+	successCount       int
+	halfOpenInFlight   int // Number of requests currently in flight in half-open state
+	lastFailureTime    time.Time
+	mu                 sync.RWMutex
+	config             config.CircuitBreakerConfig
 }
 
 // circuitBreakerMiddleware manages multiple circuit breakers
@@ -64,6 +65,9 @@ func CircuitBreaker(cfg ...config.CircuitBreakerConfig) func(http.Handler) http.
 	}
 	if c.OpenMessage == "" {
 		c.OpenMessage = config.DefaultCircuitBreakerConfig.OpenMessage
+	}
+	if c.MaxHalfOpenRequests <= 0 {
+		c.MaxHalfOpenRequests = config.DefaultCircuitBreakerConfig.MaxHalfOpenRequests
 	}
 
 	cbm := &circuitBreakerMiddleware{
@@ -126,7 +130,9 @@ func (c *circuit) getState() CircuitState {
 	return c.state
 }
 
-// isOpen checks if the circuit is open or should transition to half-open
+// isOpen checks if the circuit is open or should transition to half-open.
+// Returns true if the request should be blocked.
+// For half-open state, it checks if max concurrent requests limit is reached.
 func (c *circuit) isOpen() bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -139,10 +145,16 @@ func (c *circuit) isOpen() bool {
 		if time.Since(c.lastFailureTime) >= c.config.RecoveryTimeout {
 			c.state = StateHalfOpen
 			c.successCount = 0
+			c.halfOpenInFlight = 0
 			return false
 		}
 		return true
 	case StateHalfOpen:
+		// Check if we've reached the max concurrent requests limit
+		if c.halfOpenInFlight >= c.config.MaxHalfOpenRequests {
+			return true // Treat as open (reject request)
+		}
+		c.halfOpenInFlight++
 		return false
 	}
 
@@ -175,10 +187,15 @@ func (c *circuit) recordResult(r *http.Request, statusCode int, reg metrics.Regi
 		// In open state, requests are blocked
 
 	case StateHalfOpen:
+		// Decrement in-flight counter when request completes
+		c.halfOpenInFlight--
+
 		if isFailure {
 			c.state = StateOpen
 			c.lastFailureTime = time.Now()
 			c.failureCount++
+			c.successCount = 0
+			c.halfOpenInFlight = 0
 			reg.Counter("circuit_breaker_failures_total", "key").WithLabelValues(key).Inc()
 			reg.Counter("circuit_breaker_trips_total", "key").WithLabelValues(key).Inc()
 			reg.Counter("circuit_breaker_requests_total", "key", "result").WithLabelValues(key, "rejected").Inc()
@@ -188,6 +205,7 @@ func (c *circuit) recordResult(r *http.Request, statusCode int, reg metrics.Regi
 				c.state = StateClosed
 				c.failureCount = 0
 				c.successCount = 0
+				c.halfOpenInFlight = 0
 			}
 			reg.Counter("circuit_breaker_requests_total", "key", "result").WithLabelValues(key, "allowed").Inc()
 		}
@@ -220,5 +238,6 @@ func (cbm *circuitBreakerMiddleware) Reset(key string) {
 		c.state = StateClosed
 		c.failureCount = 0
 		c.successCount = 0
+		c.halfOpenInFlight = 0
 	}
 }

--- a/middleware/circuit_breaker.go
+++ b/middleware/circuit_breaker.go
@@ -22,13 +22,13 @@ const (
 
 // circuit represents a single circuit breaker instance
 type circuit struct {
-	state              CircuitState
-	failureCount       int
-	successCount       int
-	halfOpenInFlight   int // Number of requests currently in flight in half-open state
-	lastFailureTime    time.Time
-	mu                 sync.RWMutex
-	config             config.CircuitBreakerConfig
+	state            CircuitState
+	failureCount     int
+	successCount     int
+	halfOpenInFlight int // Number of requests currently in flight in half-open state
+	lastFailureTime  time.Time
+	mu               sync.RWMutex
+	config           config.CircuitBreakerConfig
 }
 
 // circuitBreakerMiddleware manages multiple circuit breakers

--- a/middleware/circuit_breaker_test.go
+++ b/middleware/circuit_breaker_test.go
@@ -490,3 +490,90 @@ func TestCircuitBreaker_GetState(t *testing.T) {
 		t.Errorf("expected StateClosed after reset, got %v", state)
 	}
 }
+
+func TestCircuitBreaker_HalfOpenRequestLimit(t *testing.T) {
+	// Test that MaxHalfOpenRequests limits concurrent requests in half-open state
+	cbm := &circuitBreakerMiddleware{
+		circuits: make(map[string]*circuit),
+		config: config.CircuitBreakerConfig{
+			FailureThreshold:    1,
+			RecoveryTimeout:     30 * time.Second,
+			SuccessThreshold:    10, // High threshold
+			MaxHalfOpenRequests: 2,
+		},
+	}
+
+	c := cbm.getCircuit("/test")
+
+	// Manually set to half-open state
+	c.mu.Lock()
+	c.state = StateHalfOpen
+	c.halfOpenInFlight = 0
+	c.mu.Unlock()
+
+	// First request should be allowed
+	if c.isOpen() {
+		t.Error("first request should be allowed in half-open state")
+	}
+
+	// Second request should be allowed
+	if c.isOpen() {
+		t.Error("second request should be allowed in half-open state")
+	}
+
+	// Third request should be blocked (MaxHalfOpenRequests=2)
+	if !c.isOpen() {
+		t.Error("third request should be blocked when MaxHalfOpenRequests=2")
+	}
+
+	// Simulate one request completing
+	c.mu.Lock()
+	c.halfOpenInFlight--
+	c.mu.Unlock()
+
+	// Now another request should be allowed
+	if c.isOpen() {
+		t.Error("request should be allowed after one in-flight completes")
+	}
+}
+
+func TestCircuitBreaker_HalfOpenRequestLimit_Default(t *testing.T) {
+	// Test that default MaxHalfOpenRequests is 1
+	cbm := &circuitBreakerMiddleware{
+		circuits: make(map[string]*circuit),
+		config: config.CircuitBreakerConfig{
+			FailureThreshold:    1,
+			RecoveryTimeout:     30 * time.Second,
+			SuccessThreshold:    10,
+			MaxHalfOpenRequests: 1, // Default is 1
+		},
+	}
+
+	c := cbm.getCircuit("/test")
+
+	// Manually set to half-open state
+	c.mu.Lock()
+	c.state = StateHalfOpen
+	c.halfOpenInFlight = 0
+	c.mu.Unlock()
+
+	// First request should be allowed
+	if c.isOpen() {
+		t.Error("first request should be allowed in half-open state with default limit")
+	}
+
+	// Second request should be blocked (default MaxHalfOpenRequests=1)
+	if !c.isOpen() {
+		t.Error("second request should be blocked when MaxHalfOpenRequests=1")
+	}
+
+	// Simulate request completing
+	c.mu.Lock()
+	c.halfOpenInFlight--
+	c.mu.Unlock()
+
+	// Now another request should be allowed
+	if c.isOpen() {
+		t.Error("request should be allowed after in-flight completes")
+	}
+}


### PR DESCRIPTION
- Add MaxHalfOpenRequests config (default: 1) to prevent thundering herd
- Track in-flight requests in half-open state
- Block requests when limit exceeded
- Add tests for half-open limiting