### PR TITLE
feat: request logger body logging with masking

### DIFF
--- a/config/request_logger.go
+++ b/config/request_logger.go
@@ -17,6 +17,8 @@ const (
 	FieldRemoteAddr    LogField = "remote_addr"
 	FieldClientIP      LogField = "client_ip"
 	FieldRequestID     LogField = "request_id"
+	FieldRequestBody   LogField = "request_body"
+	FieldResponseBody  LogField = "response_body"
 )
 
 // RequestLoggerConfig allows customization of request logging.
@@ -27,6 +29,53 @@ type RequestLoggerConfig struct {
 	Fields []LogField
 	// ExemptPaths contains paths to skip logging (e.g., health checks).
 	ExemptPaths []string
+	// AllowedPaths contains paths where body logging is explicitly allowed.
+	// If set, body logging (LogRequestBody/LogResponseBody) will only occur
+	// for paths matching these patterns. Supports exact matches and prefixes (ending with /).
+	// If empty, body logging applies to all paths (subject to ExemptPaths).
+	AllowedPaths []string
+	// LogRequestBody enables logging of request bodies (defaults to false).
+	// This is opt-in due to performance and security considerations.
+	LogRequestBody bool
+	// LogResponseBody enables logging of response bodies (defaults to false).
+	// This is opt-in due to performance and security considerations.
+	LogResponseBody bool
+	// MaxBodySize is the maximum number of bytes to log for request/response bodies.
+	// If 0, defaults to 1KB. Use -1 for unlimited (not recommended).
+	MaxBodySize int
+	// SensitiveFields contains field names (case-insensitive) whose values should be
+	// masked in request/response body logs (e.g., "password", "token", "secret").
+	// Defaults to common sensitive field names if nil.
+	SensitiveFields []string
+}
+
+// DefaultSensitiveFields contains common sensitive field names that should be masked.
+// These are case-insensitive matches.
+var DefaultSensitiveFields = []string{
+	"password",
+	"passwd",
+	"pwd",
+	"secret",
+	"token",
+	"api_key",
+	"apikey",
+	"access_token",
+	"refresh_token",
+	"id_token",
+	"authorization",
+	"auth",
+	"credential",
+	"credentials",
+	"private_key",
+	"privatekey",
+	"ssh_key",
+	"sshkey",
+	"credit_card",
+	"creditcard",
+	"cc_number",
+	"cvv",
+	"ssn",
+	"dob",
 }
 
 // DefaultRequestLoggerConfig contains the default values for request logging configuration.
@@ -47,5 +96,8 @@ var DefaultRequestLoggerConfig = RequestLoggerConfig{
 		FieldClientIP,
 		FieldRequestID,
 	},
-	ExemptPaths: []string{},
+	ExemptPaths:     []string{},
+	AllowedPaths:    []string{},
+	MaxBodySize:     1024, // 1KB default
+	SensitiveFields: DefaultSensitiveFields,
 }

--- a/examples/request_logger/README.md
+++ b/examples/request_logger/README.md
@@ -1,0 +1,118 @@
+# Request Logger with Body Logging Example
+
+This example demonstrates the request/response body logging feature in zerohttp with automatic masking of sensitive fields.
+
+## Features Demonstrated
+
+- **Request body logging**: Captures and logs incoming request bodies
+- **Response body logging**: Captures and logs outgoing response bodies
+- **Sensitive field masking**: Automatically masks fields like `password`, `token`, `secret`, etc.
+- **Max body size limit**: Configurable limit to prevent excessive logging
+- **Nested object support**: Masking works in nested JSON objects
+
+## Running the Example
+
+```bash
+go run main.go
+```
+
+## Testing the Endpoints
+
+### 1. Login (password field masked)
+
+```bash
+curl -X POST http://localhost:8080/api/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"john","password":"super_secret_123"}'
+```
+
+**Expected log output:**
+```
+request_body={"username":"john","password":"[REDACTED]"}
+```
+
+### 2. Get Token (tokens masked in response)
+
+```bash
+curl -X POST http://localhost:8080/api/token \
+  -H 'Content-Type: application/json' \
+  -d '{"grant_type":"password"}'
+```
+
+**Expected log output:**
+```
+response_body={"access_token":"[REDACTED]","refresh_token":"[REDACTED]","token_type":"Bearer"}
+```
+
+### 3. Create User (nested objects)
+
+```bash
+curl -X POST http://localhost:8080/api/users \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"jane","email":"jane@example.com"}'
+```
+
+### 4. Health Check
+
+```bash
+curl http://localhost:8080/health
+```
+
+## Configuration
+
+The middleware is configured with:
+
+```go
+middleware.RequestLogger(logger, config.RequestLoggerConfig{
+    LogRequestBody:  true,                    // Enable request body logging
+    LogResponseBody: true,                    // Enable response body logging
+    MaxBodySize:     1024,                    // Max bytes to log (1KB)
+    Fields: []config.LogField{
+        config.FieldMethod,
+        config.FieldPath,
+        config.FieldStatus,
+        config.FieldDurationHuman,
+        config.FieldRequestBody,
+        config.FieldResponseBody,
+    },
+})
+```
+
+## Default Sensitive Fields
+
+The following fields are automatically masked by default:
+
+- `password`, `passwd`, `pwd`
+- `secret`, `token`, `api_key`, `apikey`
+- `access_token`, `refresh_token`, `id_token`
+- `authorization`, `auth`
+- `credential`, `credentials`
+- `private_key`, `privatekey`, `ssh_key`, `sshkey`
+- `credit_card`, `creditcard`, `cc_number`, `cvv`
+- `ssn`, `dob`
+
+## Custom Sensitive Fields
+
+You can customize which fields to mask:
+
+```go
+middleware.RequestLogger(logger, config.RequestLoggerConfig{
+    LogRequestBody:  true,
+    LogResponseBody: true,
+    SensitiveFields: []string{"ssn", "credit_card", "pin"},
+})
+```
+
+To disable masking entirely, set `SensitiveFields` to an empty slice:
+
+```go
+SensitiveFields: []string{}, // Empty but not nil
+```
+
+## Performance Considerations
+
+- Body logging is **opt-in** and disabled by default
+- Request bodies are read and restored transparently
+- Response bodies are captured without affecting the response
+- Max body size limits prevent excessive memory usage
+- Non-JSON bodies are logged as-is without masking

--- a/examples/request_logger/main.go
+++ b/examples/request_logger/main.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
+)
+
+func main() {
+	// Create router with request logger config
+	// The router already has a default logger, we just need to configure it
+	router := zh.New(config.Config{
+		RequestLogger: config.RequestLoggerConfig{
+			LogRequestBody:  true,
+			LogResponseBody: true,
+			MaxBodySize:     1024,
+			Fields: []config.LogField{
+				config.FieldMethod,
+				config.FieldPath,
+				config.FieldStatus,
+				config.FieldDurationHuman,
+				config.FieldRequestBody,
+				config.FieldResponseBody,
+			},
+		},
+	})
+
+	// Login endpoint - demonstrates sensitive field masking (password)
+	router.POST("/api/login", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return zh.R.JSON(w, http.StatusOK, zh.M{
+			"status":  "success",
+			"message": "Login successful",
+			"token":   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+		})
+	}))
+
+	// Token endpoint - demonstrates token masking
+	router.POST("/api/token", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return zh.R.JSON(w, http.StatusOK, zh.M{
+			"access_token":  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+			"refresh_token": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4",
+			"token_type":    "Bearer",
+		})
+	}))
+
+	// Users endpoint - demonstrates nested object logging
+	router.POST("/api/users", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return zh.R.JSON(w, http.StatusCreated, zh.M{
+			"id":       123,
+			"username": "john_doe",
+			"email":    "john@example.com",
+			"profile": zh.M{
+				"bio":      "Software developer",
+				"location": "New York",
+			},
+		})
+	}))
+
+	// Payment endpoint - demonstrates custom sensitive field handling
+	router.POST("/api/payment", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return zh.R.JSON(w, http.StatusOK, zh.M{
+			"status":      "approved",
+			"transaction": "txn_123456",
+			"amount":      "49.99",
+		})
+	}))
+
+	// Health check - no sensitive data
+	router.GET("/health", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return zh.R.JSON(w, http.StatusOK, zh.M{
+			"status": "healthy",
+		})
+	}))
+
+	// Print usage examples
+	fmt.Println("Request Logger with Body Logging Example")
+	fmt.Println("=========================================")
+	fmt.Println()
+	fmt.Println("This example demonstrates request/response body logging with")
+	fmt.Println("automatic masking of sensitive fields like passwords and tokens.")
+	fmt.Println()
+	fmt.Println("Try these commands:")
+	fmt.Println()
+	fmt.Println("1. Login (password field will be masked):")
+	fmt.Println("   curl -X POST http://localhost:8080/api/login \\")
+	fmt.Println("     -H 'Content-Type: application/json' \\")
+	fmt.Println(`     -d '{"username":"john","password":"super_secret_123"}'`)
+	fmt.Println()
+	fmt.Println("2. Get token (tokens will be masked in response):")
+	fmt.Println("   curl -X POST http://localhost:8080/api/token \\")
+	fmt.Println("     -H 'Content-Type: application/json' \\")
+	fmt.Println(`     -d '{"grant_type":"password"}'`)
+	fmt.Println()
+	fmt.Println("3. Create user (nested objects):")
+	fmt.Println("   curl -X POST http://localhost:8080/api/users \\")
+	fmt.Println("     -H 'Content-Type: application/json' \\")
+	fmt.Println(`     -d '{"username":"jane","email":"jane@example.com"}'`)
+	fmt.Println()
+	fmt.Println("4. Health check (no body logging needed):")
+	fmt.Println("   curl http://localhost:8080/health")
+	fmt.Println()
+	fmt.Println("Server starting on :8080")
+	fmt.Println()
+
+	if err := router.Start(); err != nil {
+		panic(err)
+	}
+}

--- a/middleware/request_logger.go
+++ b/middleware/request_logger.go
@@ -1,7 +1,11 @@
 package middleware
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/alexferl/zerohttp/config"
@@ -15,8 +19,20 @@ func RequestLogger(logger log.Logger, cfg ...config.RequestLoggerConfig) func(ht
 	if len(cfg) > 0 {
 		c = cfg[0]
 	}
+
+	if len(c.ExemptPaths) > 0 && len(c.AllowedPaths) > 0 {
+		logger.Panic("RequestLogger: cannot set both ExemptPaths and AllowedPaths")
+	}
+
 	if c.Fields == nil {
 		c.Fields = config.DefaultRequestLoggerConfig.Fields
+	}
+	if c.SensitiveFields == nil {
+		c.SensitiveFields = config.DefaultRequestLoggerConfig.SensitiveFields
+	}
+	// If max body size not set, use default (0 means use default)
+	if c.MaxBodySize == 0 {
+		c.MaxBodySize = config.DefaultRequestLoggerConfig.MaxBodySize
 	}
 
 	fieldMap := make(map[config.LogField]bool)
@@ -35,20 +51,42 @@ func RequestLogger(logger log.Logger, cfg ...config.RequestLoggerConfig) func(ht
 
 			start := time.Now()
 
-			wrapped := rwutil.NewResponseWriter(w)
+			bodyLoggingAllowed := isBodyLoggingAllowed(r.URL.Path, c.AllowedPaths)
 
-			next.ServeHTTP(wrapped, r)
+			var requestBody string
+			if c.LogRequestBody && bodyLoggingAllowed {
+				requestBody = captureRequestBody(r, c.MaxBodySize)
+			}
+
+			var wrapped *bodyCapturingResponseWriter
+			if c.LogResponseBody && bodyLoggingAllowed {
+				wrapped = newBodyCapturingResponseWriter(w, c.MaxBodySize)
+				next.ServeHTTP(wrapped, r)
+			} else {
+				wrapped = &bodyCapturingResponseWriter{
+					ResponseWriter: rwutil.NewResponseWriter(w),
+				}
+				next.ServeHTTP(wrapped.ResponseWriter, r)
+			}
 
 			duration := time.Since(start)
 
-			LogRequest(logger, c, fieldMap, r, wrapped.StatusCode(), duration)
+			var responseBody string
+			if c.LogResponseBody && bodyLoggingAllowed {
+				responseBody = maskSensitiveData(wrapped.bodyString(), c.SensitiveFields)
+			}
+			if c.LogRequestBody && bodyLoggingAllowed && requestBody != "" {
+				requestBody = maskSensitiveData(requestBody, c.SensitiveFields)
+			}
+
+			LogRequest(logger, c, fieldMap, r, wrapped.StatusCode(), duration, requestBody, responseBody)
 		})
 	}
 }
 
 // LogRequest logs an HTTP request with consistent formatting.
 // If fieldMap is nil, it will be computed from cfg.Fields.
-func LogRequest(logger log.Logger, cfg config.RequestLoggerConfig, fieldMap map[config.LogField]bool, r *http.Request, statusCode int, duration time.Duration) {
+func LogRequest(logger log.Logger, cfg config.RequestLoggerConfig, fieldMap map[config.LogField]bool, r *http.Request, statusCode int, duration time.Duration, requestBody, responseBody string) {
 	if fieldMap == nil {
 		fieldMap = make(map[config.LogField]bool)
 		for _, field := range cfg.Fields {
@@ -100,6 +138,12 @@ func LogRequest(logger log.Logger, cfg config.RequestLoggerConfig, fieldMap map[
 			logFields = append(logFields, log.F("request_id", requestID))
 		}
 	}
+	if fieldMap[config.FieldRequestBody] && cfg.LogRequestBody && requestBody != "" {
+		logFields = append(logFields, log.F("request_body", requestBody))
+	}
+	if fieldMap[config.FieldResponseBody] && cfg.LogResponseBody && responseBody != "" {
+		logFields = append(logFields, log.F("response_body", responseBody))
+	}
 
 	msg := "Request completed"
 
@@ -114,4 +158,189 @@ func LogRequest(logger log.Logger, cfg config.RequestLoggerConfig, fieldMap map[
 	} else {
 		logger.Info(msg, logFields...)
 	}
+}
+
+// bodyCapturingResponseWriter wraps ResponseWriter to capture response body for logging.
+type bodyCapturingResponseWriter struct {
+	*rwutil.ResponseWriter
+	body      *bytes.Buffer
+	maxSize   int
+	sizeLimit bool
+	truncated bool
+}
+
+// newBodyCapturingResponseWriter creates a new response writer that captures body.
+func newBodyCapturingResponseWriter(w http.ResponseWriter, maxSize int) *bodyCapturingResponseWriter {
+	return &bodyCapturingResponseWriter{
+		ResponseWriter: rwutil.NewResponseWriter(w),
+		body:           &bytes.Buffer{},
+		maxSize:        maxSize,
+		sizeLimit:      maxSize > 0,
+	}
+}
+
+// Write captures the response body and forwards to the underlying ResponseWriter.
+func (rw *bodyCapturingResponseWriter) Write(data []byte) (int, error) {
+	// Capture body up to max size
+	if !rw.sizeLimit || rw.body.Len() < rw.maxSize {
+		rw.body.Write(data)
+		// If we exceeded the limit, truncate and mark as truncated
+		if rw.sizeLimit && rw.body.Len() > rw.maxSize {
+			rw.body.Truncate(rw.maxSize)
+			rw.truncated = true
+		}
+	} else {
+		// Already exceeded limit, mark as truncated
+		rw.truncated = true
+	}
+	return rw.ResponseWriter.Write(data)
+}
+
+// body returns the captured body as a string.
+func (rw *bodyCapturingResponseWriter) bodyString() string {
+	if rw.body == nil {
+		return ""
+	}
+	body := rw.body.String()
+	if rw.truncated {
+		return body + "..."
+	}
+	return body
+}
+
+// captureRequestBody reads and restores the request body.
+func captureRequestBody(r *http.Request, maxSize int) string {
+	if r.Body == nil || r.Body == http.NoBody {
+		return ""
+	}
+
+	// Read the body
+	var body []byte
+	var err error
+
+	if maxSize > 0 {
+		// Limit reading to maxSize + 1 to detect truncation
+		body, err = io.ReadAll(io.LimitReader(r.Body, int64(maxSize)+1))
+	} else {
+		body, err = io.ReadAll(r.Body)
+	}
+
+	if err != nil {
+		return ""
+	}
+
+	// Restore the body so the next handler can read it
+	r.Body = io.NopCloser(bytes.NewBuffer(body))
+
+	// Truncate if exceeds max size
+	if maxSize > 0 && len(body) > maxSize {
+		return string(body[:maxSize]) + "..."
+	}
+	return string(body)
+}
+
+// maskSensitiveData masks sensitive fields in JSON data.
+func maskSensitiveData(data string, sensitiveFields []string) string {
+	if data == "" || len(sensitiveFields) == 0 {
+		return data
+	}
+
+	// Try to parse as JSON object
+	var jsonObj map[string]any
+	if err := json.Unmarshal([]byte(data), &jsonObj); err != nil {
+		// Try to parse as JSON array
+		var jsonArr []map[string]any
+		if err := json.Unmarshal([]byte(data), &jsonArr); err != nil {
+			// Not valid JSON, return as-is
+			return data
+		}
+		// Process array of objects
+		for i, obj := range jsonArr {
+			jsonArr[i] = maskObject(obj, sensitiveFields)
+		}
+		result, err := json.Marshal(jsonArr)
+		if err != nil {
+			return data
+		}
+		return string(result)
+	}
+
+	// Process single object
+	maskedObj := maskObject(jsonObj, sensitiveFields)
+	result, err := json.Marshal(maskedObj)
+	if err != nil {
+		return data
+	}
+	return string(result)
+}
+
+// maskObject masks sensitive fields in a single JSON object.
+func maskObject(obj map[string]any, sensitiveFields []string) map[string]any {
+	if obj == nil {
+		return nil
+	}
+
+	result := make(map[string]any, len(obj))
+	for key, value := range obj {
+		if isSensitiveField(key, sensitiveFields) {
+			result[key] = "[REDACTED]"
+		} else {
+			// Recursively mask nested objects
+			switch v := value.(type) {
+			case map[string]any:
+				result[key] = maskObject(v, sensitiveFields)
+			case []any:
+				result[key] = maskArray(v, sensitiveFields)
+			default:
+				result[key] = value
+			}
+		}
+	}
+	return result
+}
+
+// maskArray masks sensitive fields in a JSON array.
+func maskArray(arr []any, sensitiveFields []string) []any {
+	if arr == nil {
+		return nil
+	}
+
+	result := make([]any, len(arr))
+	for i, value := range arr {
+		switch v := value.(type) {
+		case map[string]any:
+			result[i] = maskObject(v, sensitiveFields)
+		case []any:
+			result[i] = maskArray(v, sensitiveFields)
+		default:
+			result[i] = value
+		}
+	}
+	return result
+}
+
+// isSensitiveField checks if a field name matches any sensitive field (case-insensitive).
+func isSensitiveField(field string, sensitiveFields []string) bool {
+	fieldLower := strings.ToLower(field)
+	for _, sensitive := range sensitiveFields {
+		if strings.EqualFold(sensitive, fieldLower) || strings.EqualFold(sensitive, field) {
+			return true
+		}
+	}
+	return false
+}
+
+// isBodyLoggingAllowed checks if body logging is allowed for the given path.
+// If allowedPaths is empty, body logging is allowed for all paths.
+// If allowedPaths is set, body logging is only allowed for matching paths.
+func isBodyLoggingAllowed(path string, allowedPaths []string) bool {
+	if len(allowedPaths) == 0 {
+		return true
+	}
+	for _, allowedPath := range allowedPaths {
+		if pathMatches(path, allowedPath) {
+			return true
+		}
+	}
+	return false
 }

--- a/middleware/request_logger_test.go
+++ b/middleware/request_logger_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -321,4 +322,563 @@ func TestDefaultRequestLoggerConfig(t *testing.T) {
 	if len(cfg.ExemptPaths) != 0 {
 		t.Errorf("Expected default exempt paths to be empty, got %d", len(cfg.ExemptPaths))
 	}
+	if cfg.MaxBodySize != 1024 {
+		t.Errorf("Expected default MaxBodySize to be 1024, got %d", cfg.MaxBodySize)
+	}
+	if len(cfg.SensitiveFields) == 0 {
+		t.Error("Expected default SensitiveFields to be populated")
+	}
+}
+
+func TestRequestLogger_RequestBodyLogging(t *testing.T) {
+	t.Run("enabled", func(t *testing.T) {
+		logger := &requestLoggerMockLogger{}
+		handler := &statusTestHandler{statusCode: http.StatusOK}
+		middleware := RequestLogger(logger, config.RequestLoggerConfig{
+			Fields:         []config.LogField{config.FieldMethod, config.FieldRequestBody},
+			LogRequestBody: true,
+		})(handler)
+
+		req := zhtest.NewRequest(http.MethodPost, "/test").
+			WithBytes([]byte(`{"name":"test","value":123}`)).
+			WithHeader("Content-Type", "application/json").
+			Build()
+		zhtest.Serve(middleware, req)
+
+		if len(logger.infoLogs) != 1 {
+			t.Fatalf("Expected 1 info log, got %d", len(logger.infoLogs))
+		}
+
+		if value, found := findFieldValue(logger.infoLogs[0].fields, "request_body"); !found {
+			t.Error("Expected request_body field to be present")
+		} else if body, ok := value.(string); !ok || body != `{"name":"test","value":123}` {
+			t.Errorf("Expected request_body to be '{\"name\":\"test\",\"value\":123}', got %v", value)
+		}
+	})
+
+	t.Run("disabled by default", func(t *testing.T) {
+		logger := &requestLoggerMockLogger{}
+		handler := &statusTestHandler{statusCode: http.StatusOK}
+		middleware := RequestLogger(logger)(handler)
+
+		req := zhtest.NewRequest(http.MethodPost, "/test").
+			WithBytes([]byte(`{"name":"test"}`)).
+			Build()
+		zhtest.Serve(middleware, req)
+
+		if len(logger.infoLogs) != 1 {
+			t.Fatalf("Expected 1 info log, got %d", len(logger.infoLogs))
+		}
+
+		if _, found := findFieldValue(logger.infoLogs[0].fields, "request_body"); found {
+			t.Error("Expected request_body field not to be present when disabled")
+		}
+	})
+
+	t.Run("body available to handler", func(t *testing.T) {
+		logger := &requestLoggerMockLogger{}
+
+		// Handler that reads the body
+		bodyReadingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			_, _ = w.Write([]byte("read: " + string(body)))
+		})
+
+		middleware := RequestLogger(logger, config.RequestLoggerConfig{
+			Fields:         []config.LogField{config.FieldMethod, config.FieldRequestBody},
+			LogRequestBody: true,
+		})(bodyReadingHandler)
+
+		req := zhtest.NewRequest(http.MethodPost, "/test").
+			WithBytes([]byte(`{"data":"value"}`)).
+			Build()
+		recorder := zhtest.Serve(middleware, req)
+
+		// Verify handler could read the body
+		if !strings.Contains(recorder.Body.String(), `{"data":"value"}`) {
+			t.Errorf("Expected handler to read body, got %s", recorder.Body.String())
+		}
+	})
+}
+
+func TestRequestLogger_ResponseBodyLogging(t *testing.T) {
+	t.Run("enabled", func(t *testing.T) {
+		logger := &requestLoggerMockLogger{}
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"status":"ok","id":123}`))
+		})
+		middleware := RequestLogger(logger, config.RequestLoggerConfig{
+			Fields:          []config.LogField{config.FieldMethod, config.FieldResponseBody},
+			LogResponseBody: true,
+		})(handler)
+
+		req := zhtest.NewRequest(http.MethodGet, "/test").Build()
+		zhtest.Serve(middleware, req)
+
+		if len(logger.infoLogs) != 1 {
+			t.Fatalf("Expected 1 info log, got %d", len(logger.infoLogs))
+		}
+
+		if value, found := findFieldValue(logger.infoLogs[0].fields, "response_body"); !found {
+			t.Error("Expected response_body field to be present")
+		} else if body, ok := value.(string); !ok {
+			t.Errorf("Expected response_body to be string, got %T", value)
+		} else {
+			// Check for expected content without relying on key order
+			if !strings.Contains(body, `"status":"ok"`) || !strings.Contains(body, `"id":123`) {
+				t.Errorf("Expected response_body to contain '{\"status\":\"ok\",\"id\":123}', got %v", body)
+			}
+		}
+	})
+
+	t.Run("disabled by default", func(t *testing.T) {
+		logger := &requestLoggerMockLogger{}
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		})
+		middleware := RequestLogger(logger)(handler)
+
+		req := zhtest.NewRequest(http.MethodGet, "/test").Build()
+		zhtest.Serve(middleware, req)
+
+		if len(logger.infoLogs) != 1 {
+			t.Fatalf("Expected 1 info log, got %d", len(logger.infoLogs))
+		}
+
+		if _, found := findFieldValue(logger.infoLogs[0].fields, "response_body"); found {
+			t.Error("Expected response_body field not to be present when disabled")
+		}
+	})
+
+	t.Run("response still returned", func(t *testing.T) {
+		logger := &requestLoggerMockLogger{}
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`response data`))
+		})
+		middleware := RequestLogger(logger, config.RequestLoggerConfig{
+			Fields:          []config.LogField{config.FieldStatus},
+			LogResponseBody: true,
+		})(handler)
+
+		req := zhtest.NewRequest(http.MethodGet, "/test").Build()
+		recorder := zhtest.Serve(middleware, req)
+
+		if recorder.Body.String() != "response data" {
+			t.Errorf("Expected response body to be 'response data', got %s", recorder.Body.String())
+		}
+	})
+}
+
+func TestRequestLogger_MaxBodySize(t *testing.T) {
+	t.Run("request body truncated", func(t *testing.T) {
+		logger := &requestLoggerMockLogger{}
+		handler := &statusTestHandler{statusCode: http.StatusOK}
+		middleware := RequestLogger(logger, config.RequestLoggerConfig{
+			Fields:         []config.LogField{config.FieldRequestBody},
+			LogRequestBody: true,
+			MaxBodySize:    10,
+		})(handler)
+
+		req := zhtest.NewRequest(http.MethodPost, "/test").
+			WithBytes([]byte(`this is a long request body`)).
+			Build()
+		zhtest.Serve(middleware, req)
+
+		if value, found := findFieldValue(logger.infoLogs[0].fields, "request_body"); found {
+			// 10 chars + "..." = 13
+			if len(value.(string)) != 13 {
+				t.Errorf("Expected request_body to be truncated to 10 chars + ..., got %d", len(value.(string)))
+			}
+			if !strings.HasSuffix(value.(string), "...") {
+				t.Errorf("Expected request_body to end with ..., got %s", value.(string))
+			}
+		}
+	})
+
+	t.Run("response body truncated", func(t *testing.T) {
+		logger := &requestLoggerMockLogger{}
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`this is a long response body`))
+		})
+		middleware := RequestLogger(logger, config.RequestLoggerConfig{
+			Fields:          []config.LogField{config.FieldResponseBody},
+			LogResponseBody: true,
+			MaxBodySize:     10,
+		})(handler)
+
+		req := zhtest.NewRequest(http.MethodGet, "/test").Build()
+		zhtest.Serve(middleware, req)
+
+		if value, found := findFieldValue(logger.infoLogs[0].fields, "response_body"); found {
+			// 10 chars + "..." = 13
+			if len(value.(string)) != 13 {
+				t.Errorf("Expected response_body to be truncated to 10 chars + ..., got %d", len(value.(string)))
+			}
+			if !strings.HasSuffix(value.(string), "...") {
+				t.Errorf("Expected response_body to end with ..., got %s", value.(string))
+			}
+		}
+	})
+
+	t.Run("unlimited body size", func(t *testing.T) {
+		logger := &requestLoggerMockLogger{}
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`short`))
+		})
+		middleware := RequestLogger(logger, config.RequestLoggerConfig{
+			Fields:          []config.LogField{config.FieldResponseBody},
+			LogResponseBody: true,
+			MaxBodySize:     -1, // Unlimited
+		})(handler)
+
+		req := zhtest.NewRequest(http.MethodGet, "/test").Build()
+		zhtest.Serve(middleware, req)
+
+		if value, found := findFieldValue(logger.infoLogs[0].fields, "response_body"); found {
+			if value != "short" {
+				t.Errorf("Expected response_body to be 'short', got %v", value)
+			}
+		}
+	})
+}
+
+func TestRequestLogger_SensitiveFieldMasking(t *testing.T) {
+	t.Run("masks password field", func(t *testing.T) {
+		logger := &requestLoggerMockLogger{}
+		handler := &statusTestHandler{statusCode: http.StatusOK}
+		middleware := RequestLogger(logger, config.RequestLoggerConfig{
+			Fields:         []config.LogField{config.FieldRequestBody},
+			LogRequestBody: true,
+			MaxBodySize:    1024,
+		})(handler)
+
+		req := zhtest.NewRequest(http.MethodPost, "/login").
+			WithBytes([]byte(`{"username":"admin","password":"secret123"}`)).
+			Build()
+		zhtest.Serve(middleware, req)
+
+		if value, found := findFieldValue(logger.infoLogs[0].fields, "request_body"); found {
+			body := value.(string)
+			if strings.Contains(body, "secret123") {
+				t.Errorf("Expected password to be masked, got %s", body)
+			}
+			if !strings.Contains(body, "[REDACTED]") {
+				t.Errorf("Expected [REDACTED] in body, got %s", body)
+			}
+		}
+	})
+
+	t.Run("masks token field", func(t *testing.T) {
+		logger := &requestLoggerMockLogger{}
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"access_token":"abc123","refresh_token":"xyz789"}`))
+		})
+		middleware := RequestLogger(logger, config.RequestLoggerConfig{
+			Fields:          []config.LogField{config.FieldResponseBody},
+			LogResponseBody: true,
+		})(handler)
+
+		req := zhtest.NewRequest(http.MethodPost, "/token").Build()
+		zhtest.Serve(middleware, req)
+
+		if value, found := findFieldValue(logger.infoLogs[0].fields, "response_body"); found {
+			body := value.(string)
+			if strings.Contains(body, "abc123") || strings.Contains(body, "xyz789") {
+				t.Errorf("Expected tokens to be masked, got %s", body)
+			}
+			count := strings.Count(body, "[REDACTED]")
+			if count != 2 {
+				t.Errorf("Expected 2 [REDACTED] values, got %d in %s", count, body)
+			}
+		}
+	})
+
+	t.Run("custom sensitive fields", func(t *testing.T) {
+		logger := &requestLoggerMockLogger{}
+		handler := &statusTestHandler{statusCode: http.StatusOK}
+		middleware := RequestLogger(logger, config.RequestLoggerConfig{
+			Fields:          []config.LogField{config.FieldRequestBody},
+			LogRequestBody:  true,
+			SensitiveFields: []string{"ssn", "credit_card"},
+		})(handler)
+
+		req := zhtest.NewRequest(http.MethodPost, "/payment").
+			WithBytes([]byte(`{"name":"John","ssn":"123-45-6789","credit_card":"4111-1111-1111-1111"}`)).
+			Build()
+		zhtest.Serve(middleware, req)
+
+		if value, found := findFieldValue(logger.infoLogs[0].fields, "request_body"); found {
+			body := value.(string)
+			if strings.Contains(body, "123-45-6789") || strings.Contains(body, "4111-1111-1111-1111") {
+				t.Errorf("Expected sensitive fields to be masked, got %s", body)
+			}
+			// "name" should not be masked
+			if !strings.Contains(body, "John") {
+				t.Errorf("Expected name to not be masked, got %s", body)
+			}
+		}
+	})
+
+	t.Run("nested object masking", func(t *testing.T) {
+		logger := &requestLoggerMockLogger{}
+		handler := &statusTestHandler{statusCode: http.StatusOK}
+		middleware := RequestLogger(logger, config.RequestLoggerConfig{
+			Fields:         []config.LogField{config.FieldRequestBody},
+			LogRequestBody: true,
+		})(handler)
+
+		req := zhtest.NewRequest(http.MethodPost, "/api").
+			WithBytes([]byte(`{"user":{"password":"nested_secret","name":"John"},"data":"value"}`)).
+			Build()
+		zhtest.Serve(middleware, req)
+
+		if value, found := findFieldValue(logger.infoLogs[0].fields, "request_body"); found {
+			body := value.(string)
+			if strings.Contains(body, "nested_secret") {
+				t.Errorf("Expected nested password to be masked, got %s", body)
+			}
+			// "name" inside user should not be masked
+			if !strings.Contains(body, "John") {
+				t.Errorf("Expected name to not be masked, got %s", body)
+			}
+		}
+	})
+
+	t.Run("array of objects masking", func(t *testing.T) {
+		logger := &requestLoggerMockLogger{}
+		handler := &statusTestHandler{statusCode: http.StatusOK}
+		middleware := RequestLogger(logger, config.RequestLoggerConfig{
+			Fields:         []config.LogField{config.FieldRequestBody},
+			LogRequestBody: true,
+		})(handler)
+
+		req := zhtest.NewRequest(http.MethodPost, "/api").
+			WithBytes([]byte(`[{"id":1,"password":"pass1"},{"id":2,"password":"pass2"}]`)).
+			Build()
+		zhtest.Serve(middleware, req)
+
+		if value, found := findFieldValue(logger.infoLogs[0].fields, "request_body"); found {
+			body := value.(string)
+			if strings.Contains(body, "pass1") || strings.Contains(body, "pass2") {
+				t.Errorf("Expected passwords in array to be masked, got %s", body)
+			}
+			// Check ids are preserved
+			if !strings.Contains(body, `"id":1`) || !strings.Contains(body, `"id":2`) {
+				t.Errorf("Expected ids to not be masked, got %s", body)
+			}
+		}
+	})
+
+	t.Run("non-json body passthrough", func(t *testing.T) {
+		logger := &requestLoggerMockLogger{}
+		handler := &statusTestHandler{statusCode: http.StatusOK}
+		middleware := RequestLogger(logger, config.RequestLoggerConfig{
+			Fields:         []config.LogField{config.FieldRequestBody},
+			LogRequestBody: true,
+		})(handler)
+
+		req := zhtest.NewRequest(http.MethodPost, "/api").
+			WithBytes([]byte(`plain text body`)).
+			Build()
+		zhtest.Serve(middleware, req)
+
+		if value, found := findFieldValue(logger.infoLogs[0].fields, "request_body"); found {
+			if value != "plain text body" {
+				t.Errorf("Expected plain text body, got %v", value)
+			}
+		}
+	})
+
+	t.Run("empty sensitive fields list", func(t *testing.T) {
+		logger := &requestLoggerMockLogger{}
+		handler := &statusTestHandler{statusCode: http.StatusOK}
+		middleware := RequestLogger(logger, config.RequestLoggerConfig{
+			Fields:          []config.LogField{config.FieldRequestBody},
+			LogRequestBody:  true,
+			SensitiveFields: []string{}, // Empty but not nil
+		})(handler)
+
+		req := zhtest.NewRequest(http.MethodPost, "/api").
+			WithBytes([]byte(`{"password":"secret"}`)).
+			Build()
+		zhtest.Serve(middleware, req)
+
+		if value, found := findFieldValue(logger.infoLogs[0].fields, "request_body"); found {
+			body := value.(string)
+			// With empty sensitive fields list, password should NOT be masked
+			if !strings.Contains(body, "secret") {
+				t.Errorf("Expected password not to be masked with empty list, got %s", body)
+			}
+		}
+	})
+}
+
+func TestRequestLogger_BothBodies(t *testing.T) {
+	logger := &requestLoggerMockLogger{}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"echo":` + string(body) + `}`))
+	})
+	middleware := RequestLogger(logger, config.RequestLoggerConfig{
+		Fields:          []config.LogField{config.FieldRequestBody, config.FieldResponseBody},
+		LogRequestBody:  true,
+		LogResponseBody: true,
+	})(handler)
+
+	req := zhtest.NewRequest(http.MethodPost, "/echo").
+		WithBytes([]byte(`{"msg":"hello"}`)).
+		Build()
+	recorder := zhtest.Serve(middleware, req)
+
+	// Verify handler works
+	if !strings.Contains(recorder.Body.String(), `"msg":"hello"`) {
+		t.Errorf("Expected handler to work, got %s", recorder.Body.String())
+	}
+
+	// Verify both bodies logged
+	if len(logger.infoLogs) != 1 {
+		t.Fatalf("Expected 1 info log, got %d", len(logger.infoLogs))
+	}
+
+	if _, found := findFieldValue(logger.infoLogs[0].fields, "request_body"); !found {
+		t.Error("Expected request_body field to be present")
+	}
+	if _, found := findFieldValue(logger.infoLogs[0].fields, "response_body"); !found {
+		t.Error("Expected response_body field to be present")
+	}
+}
+
+type panicLogger struct{}
+
+func (p *panicLogger) Debug(msg string, fields ...log.Field) {}
+func (p *panicLogger) Info(msg string, fields ...log.Field)  {}
+func (p *panicLogger) Warn(msg string, fields ...log.Field)  {}
+func (p *panicLogger) Error(msg string, fields ...log.Field) {}
+func (p *panicLogger) Panic(msg string, fields ...log.Field) {
+	panic(msg)
+}
+func (p *panicLogger) Fatal(msg string, fields ...log.Field)      {}
+func (p *panicLogger) WithFields(fields ...log.Field) log.Logger  { return p }
+func (p *panicLogger) WithContext(ctx context.Context) log.Logger { return p }
+
+func TestRequestLogger_ExemptPathsAndAllowedPathsPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected panic when both ExemptPaths and AllowedPaths are set")
+		} else if !strings.Contains(r.(string), "cannot set both ExemptPaths and AllowedPaths") {
+			t.Errorf("Expected panic message about ExemptPaths and AllowedPaths, got: %v", r)
+		}
+	}()
+
+	logger := &panicLogger{}
+	_ = RequestLogger(logger, config.RequestLoggerConfig{
+		ExemptPaths:  []string{"/health"},
+		AllowedPaths: []string{"/api/debug"},
+	})
+}
+
+func TestRequestLogger_AllowedPaths(t *testing.T) {
+	t.Run("body logging only for allowed paths", func(t *testing.T) {
+		logger := &requestLoggerMockLogger{}
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		})
+		middleware := RequestLogger(logger, config.RequestLoggerConfig{
+			Fields:          []config.LogField{config.FieldPath, config.FieldRequestBody, config.FieldResponseBody},
+			LogRequestBody:  true,
+			LogResponseBody: true,
+			AllowedPaths:    []string{"/api/debug"},
+		})(handler)
+
+		// Request to allowed path - bodies should be logged
+		req1 := zhtest.NewRequest(http.MethodPost, "/api/debug").
+			WithBytes([]byte(`{"test":"data"}`)).
+			Build()
+		zhtest.Serve(middleware, req1)
+
+		if len(logger.infoLogs) != 1 {
+			t.Fatalf("Expected 1 info log, got %d", len(logger.infoLogs))
+		}
+		if _, found := findFieldValue(logger.infoLogs[0].fields, "request_body"); !found {
+			t.Error("Expected request_body to be present for allowed path")
+		}
+		if _, found := findFieldValue(logger.infoLogs[0].fields, "response_body"); !found {
+			t.Error("Expected response_body to be present for allowed path")
+		}
+
+		// Request to non-allowed path - bodies should NOT be logged
+		logger2 := &requestLoggerMockLogger{}
+		middleware2 := RequestLogger(logger2, config.RequestLoggerConfig{
+			Fields:          []config.LogField{config.FieldPath, config.FieldRequestBody, config.FieldResponseBody},
+			LogRequestBody:  true,
+			LogResponseBody: true,
+			AllowedPaths:    []string{"/api/debug"},
+		})(handler)
+
+		req2 := zhtest.NewRequest(http.MethodPost, "/api/other").
+			WithBytes([]byte(`{"test":"data"}`)).
+			Build()
+		zhtest.Serve(middleware2, req2)
+
+		if len(logger2.infoLogs) != 1 {
+			t.Fatalf("Expected 1 info log, got %d", len(logger2.infoLogs))
+		}
+		if _, found := findFieldValue(logger2.infoLogs[0].fields, "request_body"); found {
+			t.Error("Expected request_body to NOT be present for non-allowed path")
+		}
+		if _, found := findFieldValue(logger2.infoLogs[0].fields, "response_body"); found {
+			t.Error("Expected response_body to NOT be present for non-allowed path")
+		}
+	})
+
+	t.Run("prefix matching for allowed paths", func(t *testing.T) {
+		logger := &requestLoggerMockLogger{}
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		})
+		middleware := RequestLogger(logger, config.RequestLoggerConfig{
+			Fields:          []config.LogField{config.FieldPath, config.FieldRequestBody, config.FieldResponseBody},
+			LogRequestBody:  true,
+			LogResponseBody: true,
+			AllowedPaths:    []string{"/api/debug/"},
+		})(handler)
+
+		// Request to path under allowed prefix
+		req := zhtest.NewRequest(http.MethodPost, "/api/debug/test").
+			WithBytes([]byte(`{"test":"data"}`)).
+			Build()
+		zhtest.Serve(middleware, req)
+
+		if len(logger.infoLogs) != 1 {
+			t.Fatalf("Expected 1 info log, got %d", len(logger.infoLogs))
+		}
+		if _, found := findFieldValue(logger.infoLogs[0].fields, "request_body"); !found {
+			t.Error("Expected request_body to be present for path under allowed prefix")
+		}
+	})
+
+	t.Run("empty allowed paths allows all", func(t *testing.T) {
+		logger := &requestLoggerMockLogger{}
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		})
+		middleware := RequestLogger(logger, config.RequestLoggerConfig{
+			Fields:          []config.LogField{config.FieldPath, config.FieldRequestBody, config.FieldResponseBody},
+			LogRequestBody:  true,
+			LogResponseBody: true,
+			AllowedPaths:    []string{}, // Empty - should allow all
+		})(handler)
+
+		req := zhtest.NewRequest(http.MethodPost, "/api/anything").
+			WithBytes([]byte(`{"test":"data"}`)).
+			Build()
+		zhtest.Serve(middleware, req)
+
+		if len(logger.infoLogs) != 1 {
+			t.Fatalf("Expected 1 info log, got %d", len(logger.infoLogs))
+		}
+		if _, found := findFieldValue(logger.infoLogs[0].fields, "request_body"); !found {
+			t.Error("Expected request_body to be present when AllowedPaths is empty")
+		}
+	})
 }

--- a/router.go
+++ b/router.go
@@ -443,7 +443,7 @@ func (r *defaultRouter) createStaticHandler(filesystem fs.FS, fallback bool, api
 		for _, prefix := range apiPrefixes {
 			if strings.HasPrefix(cleanPath, prefix) {
 				r.notFoundHandler.ServeHTTP(w, req)
-				middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusNotFound, time.Since(start))
+				middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusNotFound, time.Since(start), "", "")
 				return
 			}
 		}
@@ -458,7 +458,7 @@ func (r *defaultRouter) createStaticHandler(filesystem fs.FS, fallback bool, api
 			stat, err := file.Stat()
 			if err == nil && !stat.IsDir() {
 				http.FileServer(http.FS(filesystem)).ServeHTTP(w, req)
-				middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusOK, time.Since(start))
+				middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusOK, time.Since(start), "", "")
 				return
 			}
 		}
@@ -467,11 +467,11 @@ func (r *defaultRouter) createStaticHandler(filesystem fs.FS, fallback bool, api
 			// Fallback to index.html for client-side routing
 			req.URL.Path = "/"
 			http.FileServer(http.FS(filesystem)).ServeHTTP(w, req)
-			middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusOK, time.Since(start))
+			middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusOK, time.Since(start), "", "")
 		} else {
 			// Use custom 404 handler for missing files
 			r.notFoundHandler.ServeHTTP(w, req)
-			middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusNotFound, time.Since(start))
+			middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusNotFound, time.Since(start), "", "")
 		}
 	})
 }
@@ -591,13 +591,13 @@ func (r *defaultRouter) catchAllHandler() http.HandlerFunc {
 			if !methods[req.Method] {
 				w.Header().Set(HeaderAllow, allowedMethods(methods))
 				r.methodNotAllowedHandler.ServeHTTP(w, req)
-				middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusMethodNotAllowed, time.Since(start))
+				middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusMethodNotAllowed, time.Since(start), "", "")
 				return
 			}
 		}
 
 		r.notFoundHandler.ServeHTTP(w, req)
-		middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusNotFound, time.Since(start))
+		middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusNotFound, time.Since(start), "", "")
 	}
 }
 

--- a/server_config.go
+++ b/server_config.go
@@ -49,6 +49,21 @@ func mergeRequestLoggerConfig(defaultCfg, userCfg config.RequestLoggerConfig) co
 	if len(userCfg.ExemptPaths) > 0 {
 		defaultCfg.ExemptPaths = userCfg.ExemptPaths
 	}
+	if userCfg.LogRequestBody {
+		defaultCfg.LogRequestBody = userCfg.LogRequestBody
+	}
+	if userCfg.LogResponseBody {
+		defaultCfg.LogResponseBody = userCfg.LogResponseBody
+	}
+	if userCfg.MaxBodySize != 0 {
+		defaultCfg.MaxBodySize = userCfg.MaxBodySize
+	}
+	if userCfg.SensitiveFields != nil {
+		defaultCfg.SensitiveFields = userCfg.SensitiveFields
+	}
+	if len(userCfg.AllowedPaths) > 0 {
+		defaultCfg.AllowedPaths = userCfg.AllowedPaths
+	}
 	return defaultCfg
 }
 

--- a/server_config_test.go
+++ b/server_config_test.go
@@ -186,9 +186,13 @@ func TestMergeRequestLoggerConfig(t *testing.T) {
 
 	t.Run("user values override defaults", func(t *testing.T) {
 		user := config.RequestLoggerConfig{
-			LogErrors:   true,
-			Fields:      []config.LogField{config.FieldMethod, config.FieldPath, config.FieldDurationHuman},
-			ExemptPaths: []string{"/health", "/metrics"},
+			LogErrors:       true,
+			Fields:          []config.LogField{config.FieldMethod, config.FieldPath, config.FieldDurationHuman},
+			ExemptPaths:     []string{"/health", "/metrics"},
+			LogRequestBody:  true,
+			LogResponseBody: true,
+			MaxBodySize:     2048,
+			SensitiveFields: []string{"password", "token", "api_key"},
 		}
 		result := mergeRequestLoggerConfig(defaults, user)
 		if !result.LogErrors {
@@ -199,6 +203,36 @@ func TestMergeRequestLoggerConfig(t *testing.T) {
 		}
 		if len(result.ExemptPaths) != 2 {
 			t.Errorf("expected 2 ExemptPaths, got %d", len(result.ExemptPaths))
+		}
+		if !result.LogRequestBody {
+			t.Error("expected LogRequestBody to be true")
+		}
+		if !result.LogResponseBody {
+			t.Error("expected LogResponseBody to be true")
+		}
+		if result.MaxBodySize != 2048 {
+			t.Errorf("expected MaxBodySize 2048, got %d", result.MaxBodySize)
+		}
+		if len(result.SensitiveFields) != 3 {
+			t.Errorf("expected 3 SensitiveFields, got %d", len(result.SensitiveFields))
+		}
+	})
+
+	t.Run("allowed paths restricts body logging", func(t *testing.T) {
+		user := config.RequestLoggerConfig{
+			LogRequestBody:  true,
+			LogResponseBody: true,
+			AllowedPaths:    []string{"/api/debug", "/api/test/"},
+		}
+		result := mergeRequestLoggerConfig(defaults, user)
+		if !result.LogRequestBody {
+			t.Error("expected LogRequestBody to be true")
+		}
+		if !result.LogResponseBody {
+			t.Error("expected LogResponseBody to be true")
+		}
+		if len(result.AllowedPaths) != 2 {
+			t.Errorf("expected 2 AllowedPaths, got %d", len(result.AllowedPaths))
 		}
 	})
 }


### PR DESCRIPTION
Add opt-in request/response body logging with:
- LogRequestBody/LogResponseBody flags
- MaxBodySize limit (default 1KB)
- Auto-masking of sensitive fields (password, token, etc.)
- AllowedPaths to restrict to specific endpoints
- "..." suffix when truncated