### PR TITLE
perf: optimize 404/405 handling with pre-encoded responses and lazy l…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ uploads
 
 # coverage
 coverage.html
+
+# profiling
+*.prof

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev audit cover cover-html fmt lint pre-commit test tidy update-deps
+.PHONY: dev audit cover cover-html fmt lint pre-commit test bench tidy update-deps
 
 .DEFAULT: help
 help:
@@ -17,7 +17,9 @@ help:
 	@echo "make pre-commit"
 	@echo "	run pre-commit hooks"
 	@echo "make test"
-	@echo "	execute all tests"
+	@echo "	run all tests"
+	@echo "make bench"
+	@echo "	run all benchmarks"
 	@echo "make tidy"
 	@echo "	clean and tidy dependencies"
 	@echo "make update-deps"
@@ -58,6 +60,9 @@ pre-commit: check-pre-commit
 
 test:
 	$(GOTESTSUM) $(TESTFLAGS)
+
+bench:
+	go test -bench=. -benchmem -run=^$$ ./...
 
 tidy:
 	go mod tidy -v

--- a/config/config.go
+++ b/config/config.go
@@ -86,10 +86,10 @@ type Config struct {
 	RequestLogger RequestLoggerConfig
 
 	// ErrorResponseType controls the format of 404/405 error responses.
-	// "json" returns RFC 9457 Problem Detail responses (application/problem+json).
-	// "plain" returns simple text/plain responses (faster, lower overhead).
-	// Default: "json"
-	ErrorResponseType string
+	// ErrorResponseJSON returns RFC 9457 Problem Detail responses (application/problem+json).
+	// ErrorResponsePlain returns simple text/plain responses.
+	// Default: ErrorResponsePlain
+	ErrorResponseType ErrorResponseType
 
 	// SecurityHeaders holds the configuration for the security headers middleware.
 	SecurityHeaders SecurityHeadersConfig
@@ -148,10 +148,12 @@ type Config struct {
 	TracerConfig TracerConfig
 }
 
-// ErrorResponse type constants.
+// ErrorResponseType defines the format of error responses.
+type ErrorResponseType string
+
 const (
-	ErrorResponseJSON  = "json"
-	ErrorResponsePlain = "plain"
+	ErrorResponseJSON  ErrorResponseType = "json"
+	ErrorResponsePlain ErrorResponseType = "plain"
 )
 
 // DefaultConfig contains all default values used by Config.

--- a/config/config.go
+++ b/config/config.go
@@ -85,6 +85,12 @@ type Config struct {
 	// RequestLogger holds the configuration for the HTTP request logging middleware.
 	RequestLogger RequestLoggerConfig
 
+	// ErrorResponseType controls the format of 404/405 error responses.
+	// "json" returns RFC 9457 Problem Detail responses (application/problem+json).
+	// "plain" returns simple text/plain responses (faster, lower overhead).
+	// Default: "json"
+	ErrorResponseType string
+
 	// SecurityHeaders holds the configuration for the security headers middleware.
 	SecurityHeaders SecurityHeadersConfig
 
@@ -142,6 +148,12 @@ type Config struct {
 	TracerConfig TracerConfig
 }
 
+// ErrorResponse type constants.
+const (
+	ErrorResponseJSON  = "json"
+	ErrorResponsePlain = "plain"
+)
+
 // DefaultConfig contains all default values used by Config.
 // Update this file if you want to change system-wide defaults.
 var DefaultConfig = Config{
@@ -155,6 +167,7 @@ var DefaultConfig = Config{
 	RequestLogger:             DefaultRequestLoggerConfig,
 	SecurityHeaders:           DefaultSecurityHeadersConfig,
 	Metrics:                   DefaultMetricsConfig,
+	ErrorResponseType:         ErrorResponsePlain,
 	Logger:                    nil, // means use DefaultLogger
 	Server:                    nil,
 	TLSServer:                 nil,

--- a/config/request_logger.go
+++ b/config/request_logger.go
@@ -24,7 +24,7 @@ const (
 // RequestLoggerConfig allows customization of request logging.
 type RequestLoggerConfig struct {
 	// Enabled determines if request logging is enabled at all.
-	// When false, no request logging occurs (fastest option).
+	// When false, no request logging occurs.
 	// Use a pointer to distinguish between "not set" and "explicitly set to false".
 	// Default: true
 	Enabled *bool

--- a/config/request_logger.go
+++ b/config/request_logger.go
@@ -23,6 +23,11 @@ const (
 
 // RequestLoggerConfig allows customization of request logging.
 type RequestLoggerConfig struct {
+	// Enabled determines if request logging is enabled at all.
+	// When false, no request logging occurs (fastest option).
+	// Use a pointer to distinguish between "not set" and "explicitly set to false".
+	// Default: true
+	Enabled *bool
 	// LogErrors determines if errors should be logged (defaults to true).
 	LogErrors bool
 	// Fields to include in logs (defaults to all fields).
@@ -80,6 +85,7 @@ var DefaultSensitiveFields = []string{
 
 // DefaultRequestLoggerConfig contains the default values for request logging configuration.
 var DefaultRequestLoggerConfig = RequestLoggerConfig{
+	Enabled:   Bool(true),
 	LogErrors: true,
 	Fields: []LogField{
 		FieldMethod,

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -425,34 +425,6 @@ func TestUnregisterCollector_NotFound(t *testing.T) {
 	reg.UnregisterCollector(collector)
 }
 
-func BenchmarkCounterInc(b *testing.B) {
-	reg := NewRegistry()
-	counter := reg.Counter("bench_counter", "label")
-	c := counter.WithLabelValues("value")
-
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			c.Inc()
-		}
-	})
-}
-
-func BenchmarkHistogramObserve(b *testing.B) {
-	reg := NewRegistry()
-	hist := reg.Histogram("bench_histogram", nil, "label")
-	h := hist.WithLabelValues("value")
-
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		i := 0
-		for pb.Next() {
-			h.Observe(float64(i%100) / 100.0)
-			i++
-		}
-	})
-}
-
 func TestCounterVec_Concurrent(t *testing.T) {
 	reg := NewRegistry()
 	c := reg.Counter("concurrent_counter", "label")

--- a/metrics/middleware_test.go
+++ b/metrics/middleware_test.go
@@ -564,33 +564,6 @@ func TestMiddleware_MultipleMethods(t *testing.T) {
 	}
 }
 
-func BenchmarkMiddleware(b *testing.B) {
-	reg := NewRegistry()
-	cfg := config.MetricsConfig{
-		Enabled:         true,
-		DurationBuckets: []float64{0.001, 0.01, 0.1},
-		SizeBuckets:     []float64{100, 1000},
-		PathLabelFunc:   func(p string) string { return p },
-	}
-
-	middleware := NewMiddleware(reg, cfg)
-
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
-	wrapped := middleware(handler)
-
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		req := httptest.NewRequest(http.MethodGet, "/test", nil)
-		rec := httptest.NewRecorder()
-		wrapped.ServeHTTP(rec, req)
-	}
-}
-
 func TestMiddleware_Router404And405(t *testing.T) {
 	// Create a real zerohttp router to test 404/405 handling
 	reg := NewRegistry()
@@ -674,39 +647,6 @@ func TestMiddleware_Router404And405(t *testing.T) {
 	}
 	if statuses["405"] != 1 {
 		t.Errorf("expected 1 request with status 405, got %d", statuses["405"])
-	}
-}
-
-func BenchmarkMiddleware_CustomLabels(b *testing.B) {
-	reg := NewRegistry()
-	cfg := config.MetricsConfig{
-		Enabled:         true,
-		DurationBuckets: []float64{0.001, 0.01, 0.1},
-		SizeBuckets:     []float64{100, 1000},
-		PathLabelFunc:   func(p string) string { return p },
-		CustomLabels: func(r *http.Request) map[string]string {
-			return map[string]string{
-				"tenant": "tenant-123",
-				"region": "us-east",
-			}
-		},
-	}
-
-	middleware := NewMiddleware(reg, cfg)
-
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
-	wrapped := middleware(handler)
-
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		req := httptest.NewRequest(http.MethodGet, "/test", nil)
-		rec := httptest.NewRecorder()
-		wrapped.ServeHTTP(rec, req)
 	}
 }
 

--- a/middleware/rate_limit_store_test.go
+++ b/middleware/rate_limit_store_test.go
@@ -361,16 +361,3 @@ func TestInMemoryStore_MaxKeysEviction_SlidingWindow(t *testing.T) {
 		t.Error("key 'b' should have been evicted and treated as new")
 	}
 }
-
-// BenchmarkInMemoryStore_CheckAndRecord benchmarks the store
-func BenchmarkInMemoryStore_CheckAndRecord(b *testing.B) {
-	store := NewInMemoryStore(config.TokenBucket, time.Minute, 1000, 10000)
-	ctx := context.Background()
-	now := time.Now()
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		key := string(rune('a' + (i % 26)))
-		store.CheckAndRecord(ctx, key, now)
-	}
-}

--- a/middleware/reverse_proxy_bench_test.go
+++ b/middleware/reverse_proxy_bench_test.go
@@ -1,0 +1,29 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alexferl/zerohttp/config"
+)
+
+func BenchmarkReverseProxy(b *testing.B) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("response"))
+	}))
+	defer upstream.Close()
+
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
+		Target: upstream.URL,
+	})
+
+	handler := mw(nil)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+	}
+}

--- a/middleware/reverse_proxy_test.go
+++ b/middleware/reverse_proxy_test.go
@@ -692,23 +692,3 @@ func TestReverseProxy_HealthCheckCleanup(t *testing.T) {
 		t.Fatalf("expected status 200 after cleanup, got %d", rec2.Code)
 	}
 }
-
-func BenchmarkReverseProxy(b *testing.B) {
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte("response"))
-	}))
-	defer upstream.Close()
-
-	mw, _ := ReverseProxy(config.ReverseProxyConfig{
-		Target: upstream.URL,
-	})
-
-	handler := mw(nil)
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
-		rec := httptest.NewRecorder()
-		handler.ServeHTTP(rec, req)
-	}
-}

--- a/problem_detail_test.go
+++ b/problem_detail_test.go
@@ -1,0 +1,116 @@
+package zerohttp
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/alexferl/zerohttp/internal/problem"
+)
+
+func TestNewProblemDetail(t *testing.T) {
+	t.Run("creates problem detail with status and detail", func(t *testing.T) {
+		pd := NewProblemDetail(http.StatusNotFound, "Resource not found")
+
+		if pd.Status != http.StatusNotFound {
+			t.Errorf("expected status %d, got %d", http.StatusNotFound, pd.Status)
+		}
+		if pd.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got '%s'", pd.Title)
+		}
+		if pd.Detail != "Resource not found" {
+			t.Errorf("expected detail 'Resource not found', got '%s'", pd.Detail)
+		}
+	})
+
+	t.Run("creates problem detail with different status codes", func(t *testing.T) {
+		tests := []struct {
+			status int
+			want   string
+		}{
+			{http.StatusBadRequest, "Bad Request"},
+			{http.StatusUnauthorized, "Unauthorized"},
+			{http.StatusForbidden, "Forbidden"},
+			{http.StatusInternalServerError, "Internal Server Error"},
+			{http.StatusServiceUnavailable, "Service Unavailable"},
+		}
+
+		for _, tt := range tests {
+			pd := NewProblemDetail(tt.status, "test detail")
+			if pd.Status != tt.status {
+				t.Errorf("expected status %d, got %d", tt.status, pd.Status)
+			}
+			if pd.Title != tt.want {
+				t.Errorf("expected title '%s', got '%s'", tt.want, pd.Title)
+			}
+		}
+	})
+
+	t.Run("problem detail has extensions map", func(t *testing.T) {
+		pd := NewProblemDetail(http.StatusBadRequest, "Bad request")
+
+		if pd.Extensions == nil {
+			t.Error("expected Extensions to be initialized")
+		}
+	})
+}
+
+func TestNewValidationProblemDetail(t *testing.T) {
+	t.Run("creates validation problem detail with errors", func(t *testing.T) {
+		errors := []problem.ValidationError{
+			{Detail: "Field is required", Field: "name"},
+			{Detail: "Invalid email", Field: "email"},
+		}
+
+		pd := NewValidationProblemDetail("Validation failed", errors)
+
+		if pd.Status != http.StatusUnprocessableEntity {
+			t.Errorf("expected status %d, got %d", http.StatusUnprocessableEntity, pd.Status)
+		}
+		if pd.Title != "Unprocessable Entity" {
+			t.Errorf("expected title 'Unprocessable Entity', got '%s'", pd.Title)
+		}
+		if pd.Detail != "Validation failed" {
+			t.Errorf("expected detail 'Validation failed', got '%s'", pd.Detail)
+		}
+	})
+
+	t.Run("has errors extension", func(t *testing.T) {
+		errors := []problem.ValidationError{
+			{Detail: "Field is required", Field: "name"},
+		}
+
+		pd := NewValidationProblemDetail("Validation failed", errors)
+
+		if pd.Extensions == nil {
+			t.Fatal("expected Extensions to be initialized")
+		}
+
+		extensions, ok := pd.Extensions["errors"]
+		if !ok {
+			t.Error("expected 'errors' key in Extensions")
+		}
+
+		if extensions == nil {
+			t.Error("expected errors to not be nil")
+		}
+	})
+
+	t.Run("works with custom error types", func(t *testing.T) {
+		type CustomError struct {
+			Field   string `json:"field"`
+			Message string `json:"message"`
+			Code    int    `json:"code"`
+		}
+
+		errors := []CustomError{
+			{Field: "username", Message: "Too short", Code: 1001},
+			{Field: "password", Message: "Too weak", Code: 1002},
+		}
+
+		pd := NewValidationProblemDetail("Custom validation failed", errors)
+
+		if pd.Status != http.StatusUnprocessableEntity {
+			t.Errorf("expected status %d, got %d", http.StatusUnprocessableEntity, pd.Status)
+		}
+	})
+}

--- a/render_test.go
+++ b/render_test.go
@@ -337,3 +337,54 @@ func TestRenderer_Redirect_WithQuery(t *testing.T) {
 
 	zhtest.AssertWith(t, w).Header(HeaderLocation, redirectURL)
 }
+
+func TestRenderer_ProblemDetail(t *testing.T) {
+	t.Run("basic problem detail", func(t *testing.T) {
+		w := httptest.NewRecorder()
+
+		problem := NewProblemDetail(http.StatusNotFound, "Resource not found")
+		problem.Instance = "/test/resource"
+
+		if err := R.ProblemDetail(w, problem); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		zhtest.AssertWith(t, w).
+			Status(http.StatusNotFound).
+			Header(HeaderContentType, MIMEApplicationProblem).
+			IsProblemDetail().
+			ProblemDetailTitle("Not Found").
+			ProblemDetailDetail("Resource not found")
+	})
+
+	t.Run("different status codes", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			status int
+			title  string
+		}{
+			{"bad request", http.StatusBadRequest, "Bad Request"},
+			{"unauthorized", http.StatusUnauthorized, "Unauthorized"},
+			{"forbidden", http.StatusForbidden, "Forbidden"},
+			{"internal error", http.StatusInternalServerError, "Internal Server Error"},
+			{"service unavailable", http.StatusServiceUnavailable, "Service Unavailable"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				w := httptest.NewRecorder()
+
+				problem := NewProblemDetail(tt.status, "test detail")
+
+				if err := R.ProblemDetail(w, problem); err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+
+				zhtest.AssertWith(t, w).
+					Status(tt.status).
+					IsProblemDetail().
+					ProblemDetailTitle(tt.title)
+			})
+		}
+	})
+}

--- a/router.go
+++ b/router.go
@@ -19,6 +19,30 @@ import (
 	"github.com/alexferl/zerohttp/middleware"
 )
 
+var (
+	// preEncodedNotFoundJSON is the pre-encoded 404 Not Found JSON response
+	preEncodedNotFoundJSON []byte
+	// preEncodedMethodNotAllowedJSON is the pre-encoded 405 Method Not Allowed JSON response
+	preEncodedMethodNotAllowedJSON []byte
+)
+
+func init() {
+	// Pre-encode JSON responses at init time to avoid repeated encoding overhead
+	notFoundProblem := &ProblemDetail{
+		Title:  "Not Found",
+		Status: http.StatusNotFound,
+		Detail: "Requested resource was not found",
+	}
+	preEncodedNotFoundJSON, _ = json.Marshal(notFoundProblem)
+
+	methodNotAllowedProblem := &ProblemDetail{
+		Title:  "Method Not Allowed",
+		Status: http.StatusMethodNotAllowed,
+		Detail: "HTTP method is not allowed",
+	}
+	preEncodedMethodNotAllowedJSON, _ = json.Marshal(methodNotAllowedProblem)
+}
+
 // HandlerFunc is a handler function that returns an error.
 // Errors are handled directly without panic propagation.
 type HandlerFunc func(w http.ResponseWriter, r *http.Request) error
@@ -45,7 +69,7 @@ func handleHandlerError(w http.ResponseWriter, err error) {
 	// Check for validation errors (422)
 	var verr ValidationErrorer
 	if errors.As(err, &verr) {
-		w.Header().Set("Content-Type", "application/problem+json")
+		w.Header().Set(HeaderContentType, MIMEApplicationProblem)
 		w.WriteHeader(http.StatusUnprocessableEntity)
 		response := map[string]any{
 			"title":  "Unprocessable Entity",
@@ -61,7 +85,7 @@ func handleHandlerError(w http.ResponseWriter, err error) {
 
 	// Check for binding errors (400)
 	if IsBindError(err) {
-		w.Header().Set("Content-Type", "application/problem+json")
+		w.Header().Set(HeaderContentType, MIMEApplicationProblem)
 		w.WriteHeader(http.StatusBadRequest)
 		response := map[string]any{
 			"title":  "Bad Request",
@@ -75,7 +99,7 @@ func handleHandlerError(w http.ResponseWriter, err error) {
 	}
 
 	// For all other errors, return 500 Internal Server Error
-	w.Header().Set("Content-Type", "application/problem+json")
+	w.Header().Set(HeaderContentType, MIMEApplicationProblem)
 	w.WriteHeader(http.StatusInternalServerError)
 	response := map[string]any{
 		"title":  "Internal Server Error",
@@ -573,58 +597,96 @@ func (r *defaultRouter) handle(method, path string, fn http.Handler, mw []func(h
 	}
 }
 
+// shouldLogRequest returns true if request logging should be enabled.
+// It checks both the RequestLogger.Enabled setting and DisableDefaultMiddlewares.
+func (r *defaultRouter) shouldLogRequest() bool {
+	if r.config.DisableDefaultMiddlewares {
+		return false
+	}
+	return r.config.RequestLogger.Enabled == nil || *r.config.RequestLogger.Enabled
+}
+
 // catchAllHandler returns a handler that processes unmatched requests.
 // It determines whether to return a 404 Not Found or 405 Method Not Allowed response
 // based on whether any methods are registered for the requested path.
 func (r *defaultRouter) catchAllHandler() http.HandlerFunc {
+	useJSON := r.config.ErrorResponseType == config.ErrorResponseJSON
+	shouldLog := r.shouldLogRequest()
+
 	return func(w http.ResponseWriter, req *http.Request) {
-		start := time.Now()
+		var start time.Time
 
-		requestID := req.Header.Get(r.config.RequestID.Header)
-		if requestID == "" {
-			requestID = r.config.RequestID.Generator()
+		if shouldLog {
+			start = time.Now()
+
+			// Lazy request ID generation - only when logging
+			requestID := req.Header.Get(r.config.RequestID.Header)
+			if requestID == "" {
+				requestID = r.config.RequestID.Generator()
+			}
+			w.Header().Set(r.config.RequestID.Header, requestID)
 		}
-
-		w.Header().Set(r.config.RequestID.Header, requestID)
 
 		if methods, exists := r.registeredRoutes[req.URL.Path]; exists {
 			if !methods[req.Method] {
 				w.Header().Set(HeaderAllow, allowedMethods(methods))
-				r.methodNotAllowedHandler.ServeHTTP(w, req)
-				middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusMethodNotAllowed, time.Since(start), "", "")
+
+				if useJSON {
+					jsonMethodNotAllowedHandler(w, req)
+				} else {
+					r.methodNotAllowedHandler.ServeHTTP(w, req)
+				}
+
+				if shouldLog {
+					middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusMethodNotAllowed, time.Since(start), "", "")
+				}
 				return
 			}
 		}
 
-		r.notFoundHandler.ServeHTTP(w, req)
-		middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusNotFound, time.Since(start), "", "")
+		if useJSON {
+			jsonNotFoundHandler(w, req)
+		} else {
+			r.notFoundHandler.ServeHTTP(w, req)
+		}
+
+		if shouldLog {
+			middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusNotFound, time.Since(start), "", "")
+		}
 	}
 }
 
 // defaultNotFoundHandler is the default handler for 404 Not Found responses.
-// It returns a problem detail response indicating that the requested resource was not found.
+// It returns a pre-encoded plain text response for optimal performance.
 var defaultNotFoundHandler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	problem := NewProblemDetail(http.StatusNotFound, "The requested resource was not found")
-	if err := R.ProblemDetail(w, problem); err != nil {
-		// Fallback to plain text if problem detail fails
-		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte("404 Not Found\n"))
-	}
+	w.Header().Set(HeaderContentType, MIMETextPlainCharset)
+	w.WriteHeader(http.StatusNotFound)
+	_, _ = w.Write([]byte("Requested resource was not found\n"))
 })
 
 // defaultMethodNotAllowedHandler is the default handler for 405 Method Not Allowed responses.
-// It returns a problem detail response indicating that the HTTP method is not allowed.
+// It returns a pre-encoded plain text response for optimal performance.
 // The "Allow" header should be set by the caller to indicate which methods are allowed.
 var defaultMethodNotAllowedHandler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	problem := NewProblemDetail(http.StatusMethodNotAllowed, "The HTTP method is not allowed")
-	if err := R.ProblemDetail(w, problem); err != nil {
-		// Fallback to plain text if problem detail fails
-		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		_, _ = w.Write([]byte("405 Method Not Allowed\n"))
-	}
+	w.Header().Set(HeaderContentType, MIMETextPlainCharset)
+	w.WriteHeader(http.StatusMethodNotAllowed)
+	_, _ = w.Write([]byte("HTTP method is not allowed\n"))
 })
+
+// jsonNotFoundHandler returns a JSON problem detail 404 response.
+func jsonNotFoundHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set(HeaderContentType, MIMEApplicationProblem)
+	w.WriteHeader(http.StatusNotFound)
+	_, _ = w.Write(preEncodedNotFoundJSON)
+}
+
+// jsonMethodNotAllowedHandler returns a JSON problem detail 405 response.
+// The "Allow" header should be set by the caller to indicate which methods are allowed.
+func jsonMethodNotAllowedHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set(HeaderContentType, MIMEApplicationProblem)
+	w.WriteHeader(http.StatusMethodNotAllowed)
+	_, _ = w.Write(preEncodedMethodNotAllowedJSON)
+}
 
 // allowedMethods converts a map of HTTP methods to a comma-separated string
 // suitable for the "Allow" header in 405 Method Not Allowed responses.

--- a/router_bench_test.go
+++ b/router_bench_test.go
@@ -1,0 +1,493 @@
+package zerohttp
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alexferl/zerohttp/log"
+)
+
+// noopLogger is a logger that discards all output for benchmarking.
+type noopLogger struct{}
+
+func (n *noopLogger) Debug(msg string, fields ...log.Field) {}
+func (n *noopLogger) Info(msg string, fields ...log.Field)  {}
+func (n *noopLogger) Warn(msg string, fields ...log.Field)  {}
+func (n *noopLogger) Error(msg string, fields ...log.Field) {}
+func (n *noopLogger) Panic(msg string, fields ...log.Field) { panic(msg) }
+func (n *noopLogger) Fatal(msg string, fields ...log.Field) {}
+func (n *noopLogger) WithFields(fields ...log.Field) log.Logger {
+	return n
+}
+
+func (n *noopLogger) WithContext(ctx context.Context) log.Logger {
+	return n
+}
+
+// BenchmarkRouter_SimpleRoute measures the overhead of zerohttp router
+// compared to a baseline http.ServeMux for simple route matching.
+func BenchmarkRouter_SimpleRoute(b *testing.B) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	})
+
+	b.Run("Baseline_ServeMux", func(b *testing.B) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /test", handler)
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("Zerohttp_Router", func(b *testing.B) {
+		router := NewRouter()
+		router.GET("/test", handler)
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+}
+
+// BenchmarkRouter_HandlerFunc measures the overhead of HandlerFunc
+// (error-returning handlers) compared to standard http.Handler.
+func BenchmarkRouter_HandlerFunc(b *testing.B) {
+	b.Run("Standard_Handler", func(b *testing.B) {
+		router := NewRouter()
+		router.GET("/test", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("OK"))
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("HandlerFunc_NoError", func(b *testing.B) {
+		router := NewRouter()
+		router.GET("/test", HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("OK"))
+			return nil
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+}
+
+// BenchmarkRouter_ParameterizedRoutes measures routing performance
+// with parameterized paths (Go 1.22+ pattern syntax).
+func BenchmarkRouter_ParameterizedRoutes(b *testing.B) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	})
+
+	b.Run("Baseline_ServeMux", func(b *testing.B) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /users/{id}", handler)
+
+		req := httptest.NewRequest(http.MethodGet, "/users/123", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("Zerohttp_Router", func(b *testing.B) {
+		router := NewRouter()
+		router.GET("/users/{id}", handler)
+
+		req := httptest.NewRequest(http.MethodGet, "/users/123", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+}
+
+// BenchmarkRouter_NotFound measures 404 handling overhead.
+func BenchmarkRouter_NotFound(b *testing.B) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	})
+
+	b.Run("Baseline_ServeMux", func(b *testing.B) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /exists", handler)
+
+		req := httptest.NewRequest(http.MethodGet, "/notfound", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("Zerohttp_Router", func(b *testing.B) {
+		router := NewRouter()
+		router.SetLogger(&noopLogger{})
+		router.GET("/exists", handler)
+
+		req := httptest.NewRequest(http.MethodGet, "/notfound", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+}
+
+// BenchmarkRouter_MethodNotAllowed measures 405 handling overhead.
+func BenchmarkRouter_MethodNotAllowed(b *testing.B) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	})
+
+	b.Run("Baseline_ServeMux", func(b *testing.B) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /test", handler)
+
+		req := httptest.NewRequest(http.MethodPost, "/test", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("Zerohttp_Router", func(b *testing.B) {
+		router := NewRouter()
+		router.SetLogger(&noopLogger{})
+		router.GET("/test", handler)
+
+		req := httptest.NewRequest(http.MethodPost, "/test", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+}
+
+// BenchmarkRouter_MiddlewareOverhead measures the overhead of middleware
+// wrapping in zerohttp compared to direct middleware application.
+func BenchmarkRouter_MiddlewareOverhead(b *testing.B) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	})
+
+	simpleMiddleware := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+		})
+	}
+
+	b.Run("Baseline_ServeMux_1Middleware", func(b *testing.B) {
+		mux := http.NewServeMux()
+		wrapped := simpleMiddleware(handler)
+		mux.Handle("GET /test", wrapped)
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("Zerohttp_1Middleware", func(b *testing.B) {
+		router := NewRouter(simpleMiddleware)
+		router.GET("/test", handler)
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("Baseline_ServeMux_5Middleware", func(b *testing.B) {
+		mux := http.NewServeMux()
+		var wrapped http.Handler = handler
+		for range 5 {
+			wrapped = simpleMiddleware(wrapped)
+		}
+		mux.Handle("GET /test", wrapped)
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("Zerohttp_5Middleware", func(b *testing.B) {
+		middlewares := make([]func(http.Handler) http.Handler, 5)
+		for i := range 5 {
+			middlewares[i] = simpleMiddleware
+		}
+		router := NewRouter(middlewares...)
+		router.GET("/test", handler)
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+}
+
+// BenchmarkRouter_ManyRoutes measures routing performance as the number
+// of registered routes increases.
+func BenchmarkRouter_ManyRoutes(b *testing.B) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	})
+
+	routeCounts := []int{10, 50, 100, 500}
+
+	for _, count := range routeCounts {
+		b.Run(fmt.Sprintf("Baseline_ServeMux_%dRoutes", count), func(b *testing.B) {
+			mux := http.NewServeMux()
+			for i := range count {
+				mux.HandleFunc(fmt.Sprintf("GET /route%d", i), handler)
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/route0", nil)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				w := httptest.NewRecorder()
+				mux.ServeHTTP(w, req)
+			}
+		})
+
+		b.Run(fmt.Sprintf("Zerohttp_Router_%dRoutes", count), func(b *testing.B) {
+			router := NewRouter()
+			for i := range count {
+				router.GET(fmt.Sprintf("/route%d", i), handler)
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/route0", nil)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
+			}
+		})
+	}
+}
+
+// BenchmarkRouter_RouteGroups measures the overhead of using route groups.
+func BenchmarkRouter_RouteGroups(b *testing.B) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	})
+
+	b.Run("NoGroups", func(b *testing.B) {
+		router := NewRouter()
+		router.GET("/api/v1/users", handler)
+		router.GET("/api/v1/posts", handler)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("WithGroups", func(b *testing.B) {
+		router := NewRouter()
+		router.Group(func(api Router) {
+			api.GET("/api/v1/users", handler)
+			api.GET("/api/v1/posts", handler)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+}
+
+// BenchmarkRouter_HEADRequest measures HEAD request handling overhead.
+func BenchmarkRouter_HEADRequest(b *testing.B) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("response body content"))
+	})
+
+	b.Run("Baseline_ServeMux", func(b *testing.B) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /test", handler)
+
+		req := httptest.NewRequest(http.MethodHead, "/test", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("Zerohttp_Router", func(b *testing.B) {
+		router := NewRouter()
+		router.GET("/test", handler)
+
+		req := httptest.NewRequest(http.MethodHead, "/test", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("Zerohttp_HandlerFunc", func(b *testing.B) {
+		router := NewRouter()
+		router.GET("/test", HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+			w.Header().Set("Content-Type", "text/plain")
+			return R.Text(w, http.StatusOK, "response body content")
+		}))
+
+		req := httptest.NewRequest(http.MethodHead, "/test", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+}
+
+// BenchmarkRouter_AllHTTPMethods measures routing performance across all HTTP methods.
+func BenchmarkRouter_AllHTTPMethods(b *testing.B) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	methods := []string{
+		http.MethodGet,
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodPatch,
+		http.MethodDelete,
+		http.MethodOptions,
+	}
+
+	for _, method := range methods {
+		b.Run(fmt.Sprintf("Baseline_ServeMux_%s", method), func(b *testing.B) {
+			mux := http.NewServeMux()
+			mux.HandleFunc(method+" /test", handler)
+
+			req := httptest.NewRequest(method, "/test", nil)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				w := httptest.NewRecorder()
+				mux.ServeHTTP(w, req)
+			}
+		})
+
+		b.Run(fmt.Sprintf("Zerohttp_Router_%s", method), func(b *testing.B) {
+			router := NewRouter()
+			switch method {
+			case http.MethodGet:
+				router.GET("/test", handler)
+			case http.MethodPost:
+				router.POST("/test", handler)
+			case http.MethodPut:
+				router.PUT("/test", handler)
+			case http.MethodPatch:
+				router.PATCH("/test", handler)
+			case http.MethodDelete:
+				router.DELETE("/test", handler)
+			case http.MethodOptions:
+				router.OPTIONS("/test", handler)
+			}
+
+			req := httptest.NewRequest(method, "/test", nil)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
+			}
+		})
+	}
+}

--- a/router_test.go
+++ b/router_test.go
@@ -492,7 +492,7 @@ func TestRouter_ErrorHandlers(t *testing.T) {
 
 		zhtest.AssertWith(t, w).
 			Status(http.StatusNotFound).
-			Header(HeaderContentType, MIMEApplicationProblem)
+			Header(HeaderContentType, MIMETextPlainCharset)
 
 		router.NotFound(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
@@ -556,10 +556,10 @@ func TestRouter_ErrorHandlers(t *testing.T) {
 		// Now call the handler - should trigger fallback path
 		defaultNotFoundHandler.ServeHTTP(w, req)
 
-		// Content-Type should be text/plain (fallback)
+		// Content-Type should be text/plain; charset=utf-8
 		contentType := w.Header().Get("Content-Type")
-		if contentType != "text/plain" {
-			t.Errorf("expected Content-Type %q, got %q", "text/plain", contentType)
+		if contentType != MIMETextPlainCharset {
+			t.Errorf("expected Content-Type %q, got %q", MIMETextPlainCharset, contentType)
 		}
 	})
 
@@ -570,8 +570,8 @@ func TestRouter_ErrorHandlers(t *testing.T) {
 		defaultMethodNotAllowedHandler.ServeHTTP(w, req)
 
 		contentType := w.Header().Get("Content-Type")
-		if contentType != "text/plain" {
-			t.Errorf("expected Content-Type %q, got %q", "text/plain", contentType)
+		if contentType != MIMETextPlainCharset {
+			t.Errorf("expected Content-Type %q, got %q", MIMETextPlainCharset, contentType)
 		}
 	})
 }
@@ -690,7 +690,7 @@ func TestUtilityFunctions(t *testing.T) {
 
 		zhtest.AssertWith(t, w).
 			Status(http.StatusNotFound).
-			Header(HeaderContentType, MIMEApplicationProblem)
+			Header(HeaderContentType, MIMETextPlainCharset)
 	})
 
 	t.Run("defaultMethodNotAllowedHandler", func(t *testing.T) {
@@ -700,17 +700,17 @@ func TestUtilityFunctions(t *testing.T) {
 
 		zhtest.AssertWith(t, w).
 			Status(http.StatusMethodNotAllowed).
-			Header(HeaderContentType, MIMEApplicationProblem)
+			Header(HeaderContentType, MIMETextPlainCharset)
 	})
 
-	t.Run("defaultNotFoundHandler", func(t *testing.T) {
+	t.Run("defaultNotFoundHandler body", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
 		w := httptest.NewRecorder()
 		defaultNotFoundHandler.ServeHTTP(w, req)
 
 		zhtest.AssertWith(t, w).
 			Status(http.StatusNotFound).
-			Header(HeaderContentType, MIMEApplicationProblem)
+			Body("Requested resource was not found\n")
 	})
 
 	t.Run("allowedMethods", func(t *testing.T) {
@@ -1045,6 +1045,75 @@ func TestRouter_CONNECT_WebTransport(t *testing.T) {
 
 		if !upgradeCalled {
 			t.Error("CONNECT handler was not called for WebTransport upgrade")
+		}
+	})
+}
+
+func TestShouldLogRequest(t *testing.T) {
+	t.Run("returns true when Enabled is nil (default)", func(t *testing.T) {
+		r := NewRouter().(*defaultRouter)
+		r.SetConfig(config.Config{
+			RequestLogger: config.RequestLoggerConfig{
+				Enabled: nil, // use default
+			},
+		})
+
+		if !r.shouldLogRequest() {
+			t.Error("expected shouldLogRequest to be true when Enabled is nil")
+		}
+	})
+
+	t.Run("returns true when Enabled is explicitly true", func(t *testing.T) {
+		r := NewRouter().(*defaultRouter)
+		r.SetConfig(config.Config{
+			RequestLogger: config.RequestLoggerConfig{
+				Enabled: config.Bool(true),
+			},
+		})
+
+		if !r.shouldLogRequest() {
+			t.Error("expected shouldLogRequest to be true when Enabled is true")
+		}
+	})
+
+	t.Run("returns false when Enabled is explicitly false", func(t *testing.T) {
+		r := NewRouter().(*defaultRouter)
+		r.SetConfig(config.Config{
+			RequestLogger: config.RequestLoggerConfig{
+				Enabled: config.Bool(false),
+			},
+		})
+
+		if r.shouldLogRequest() {
+			t.Error("expected shouldLogRequest to be false when Enabled is false")
+		}
+	})
+
+	t.Run("returns false when DisableDefaultMiddlewares is true", func(t *testing.T) {
+		r := NewRouter().(*defaultRouter)
+		r.SetConfig(config.Config{
+			DisableDefaultMiddlewares: true,
+			RequestLogger: config.RequestLoggerConfig{
+				Enabled: config.Bool(true), // even if Enabled is true
+			},
+		})
+
+		if r.shouldLogRequest() {
+			t.Error("expected shouldLogRequest to be false when DisableDefaultMiddlewares is true")
+		}
+	})
+
+	t.Run("returns true when DisableDefaultMiddlewares is false and Enabled is nil", func(t *testing.T) {
+		r := NewRouter().(*defaultRouter)
+		r.SetConfig(config.Config{
+			DisableDefaultMiddlewares: false,
+			RequestLogger: config.RequestLoggerConfig{
+				Enabled: nil,
+			},
+		})
+
+		if !r.shouldLogRequest() {
+			t.Error("expected shouldLogRequest to be true when DisableDefaultMiddlewares is false and Enabled is nil")
 		}
 	})
 }

--- a/router_test.go
+++ b/router_test.go
@@ -1117,3 +1117,33 @@ func TestShouldLogRequest(t *testing.T) {
 		}
 	})
 }
+
+func TestJSONNotFoundHandler(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/not-found", nil)
+
+	jsonNotFoundHandler(w, req)
+
+	zhtest.AssertWith(t, w).
+		Status(http.StatusNotFound).
+		Header(HeaderContentType, MIMEApplicationProblem).
+		BodyContains(`"title":"Not Found"`).
+		BodyContains(`"status":404`)
+}
+
+func TestJSONMethodNotAllowedHandler(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+
+	// The Allow header should be set by the caller
+	w.Header().Set(HeaderAllow, "GET, HEAD")
+
+	jsonMethodNotAllowedHandler(w, req)
+
+	zhtest.AssertWith(t, w).
+		Status(http.StatusMethodNotAllowed).
+		Header(HeaderContentType, MIMEApplicationProblem).
+		Header(HeaderAllow, "GET, HEAD").
+		BodyContains(`"title":"Method Not Allowed"`).
+		BodyContains(`"status":405`)
+}

--- a/server_config.go
+++ b/server_config.go
@@ -40,6 +40,9 @@ func mergeRequestIDConfig(defaultCfg, userCfg config.RequestIDConfig) config.Req
 
 // mergeRequestLoggerConfig merges user config with defaults
 func mergeRequestLoggerConfig(defaultCfg, userCfg config.RequestLoggerConfig) config.RequestLoggerConfig {
+	if userCfg.Enabled != nil {
+		defaultCfg.Enabled = userCfg.Enabled
+	}
 	if userCfg.LogErrors {
 		defaultCfg.LogErrors = userCfg.LogErrors
 	}

--- a/server_config_test.go
+++ b/server_config_test.go
@@ -235,6 +235,45 @@ func TestMergeRequestLoggerConfig(t *testing.T) {
 			t.Errorf("expected 2 AllowedPaths, got %d", len(result.AllowedPaths))
 		}
 	})
+
+	t.Run("Enabled nil uses default (true)", func(t *testing.T) {
+		user := config.RequestLoggerConfig{
+			LogErrors: true,
+		}
+		result := mergeRequestLoggerConfig(defaults, user)
+		if result.Enabled == nil {
+			t.Error("expected Enabled to be set to default, got nil")
+		}
+		if !*result.Enabled {
+			t.Error("expected Enabled to be true when not set (nil)")
+		}
+	})
+
+	t.Run("Enabled explicitly set to false", func(t *testing.T) {
+		user := config.RequestLoggerConfig{
+			Enabled: config.Bool(false),
+		}
+		result := mergeRequestLoggerConfig(defaults, user)
+		if result.Enabled == nil {
+			t.Error("expected Enabled to be set, got nil")
+		}
+		if *result.Enabled {
+			t.Error("expected Enabled to be false when explicitly set")
+		}
+	})
+
+	t.Run("Enabled explicitly set to true", func(t *testing.T) {
+		user := config.RequestLoggerConfig{
+			Enabled: config.Bool(true),
+		}
+		result := mergeRequestLoggerConfig(defaults, user)
+		if result.Enabled == nil {
+			t.Error("expected Enabled to be set, got nil")
+		}
+		if !*result.Enabled {
+			t.Error("expected Enabled to be true when explicitly set")
+		}
+	})
 }
 
 func TestMergeSecurityHeadersConfig(t *testing.T) {

--- a/type_registry_test.go
+++ b/type_registry_test.go
@@ -685,29 +685,3 @@ func TestMixedEmbeddedAndRegular(t *testing.T) {
 		t.Errorf("expected both 'a' and 'b', got %v", tags)
 	}
 }
-
-func BenchmarkTagLookup(b *testing.B) {
-	type TestStruct struct {
-		Field1  string `form:"field1"`
-		Field2  string `form:"field2"`
-		Field3  string `form:"field3"`
-		Field4  string `form:"field4"`
-		Field5  string `form:"field5"`
-		Field6  string `form:"field6"`
-		Field7  string `form:"field7"`
-		Field8  string `form:"field8"`
-		Field9  string `form:"field9"`
-		Field10 string `form:"field10"`
-	}
-
-	typ := reflect.TypeOf(TestStruct{})
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		info, err := globalTypeRegistry.getTypeInfo(typ)
-		if err != nil {
-			b.Fatalf("failed to get type info: %v", err)
-		}
-		_ = info.getBindableFields("form", false)
-	}
-}


### PR DESCRIPTION
…ogging

- Pre-encode JSON error responses at init time to avoid repeated encoding
- Add lazy request ID generation - only generated when logging is enabled
- Use pre-encoded plain text for default 404/405 handlers (faster than ProblemDetail)
- Add shouldLogRequest() helper to respect DisableDefaultMiddlewares setting

Also fixes RequestLogger.Enabled to use *bool so users can explicitly disable logging with config.Bool(false).