### PR TITLE
perf: add comprehensive benchmark suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ help:
 GOTESTSUM := go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=1
 TESTFLAGS := -shuffle=on
 COVERFLAGS := -covermode=atomic
-GOLANGCI_LINT := go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
+GOLANGCI_LINT := go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3
 
 check-pre-commit:
 ifeq (, $(shell which pre-commit))

--- a/bind_bench_test.go
+++ b/bind_bench_test.go
@@ -1,0 +1,821 @@
+package zerohttp
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// BenchmarkBinder_JSON_Baseline compares JSON binding vs stdlib json.Decoder
+func BenchmarkBinder_JSON_Baseline(b *testing.B) {
+	type User struct {
+		Name  string `json:"name"`
+		Email string `json:"email"`
+		Age   int    `json:"age"`
+	}
+
+	jsonData := `{"name":"John Doe","email":"john@example.com","age":30}`
+
+	b.Run("Stdlib_Decoder", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			var result User
+			decoder := json.NewDecoder(strings.NewReader(jsonData))
+			decoder.DisallowUnknownFields()
+			_ = decoder.Decode(&result)
+		}
+	})
+
+	b.Run("Binder_JSON", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			var result User
+			_ = B.JSON(strings.NewReader(jsonData), &result)
+		}
+	})
+
+	b.Run("Stdlib_Unmarshal", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			var result User
+			_ = json.Unmarshal([]byte(jsonData), &result)
+		}
+	})
+}
+
+// BenchmarkBinder_JSON_PayloadSizes measures JSON binding with different payload sizes
+func BenchmarkBinder_JSON_PayloadSizes(b *testing.B) {
+	type Item struct {
+		ID    int    `json:"id"`
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	}
+
+	type Response struct {
+		Items []Item `json:"items"`
+		Count int    `json:"count"`
+	}
+
+	sizes := []struct {
+		name string
+		data string
+	}{
+		{
+			name: "Tiny_100B",
+			data: `{"items":[{"id":1,"name":"test","value":"a"}],"count":1}`,
+		},
+		{
+			name: "Small_1KB",
+			data: func() string {
+				items := make([]Item, 10)
+				for i := range 10 {
+					items[i] = Item{ID: i, Name: fmt.Sprintf("Item %d", i), Value: fmt.Sprintf("Value %d", i)}
+				}
+				data, _ := json.Marshal(Response{Items: items, Count: 10})
+				return string(data)
+			}(),
+		},
+		{
+			name: "Medium_10KB",
+			data: func() string {
+				items := make([]Item, 100)
+				for i := range 100 {
+					items[i] = Item{ID: i, Name: fmt.Sprintf("Item %d", i), Value: strings.Repeat("x", 50)}
+				}
+				data, _ := json.Marshal(Response{Items: items, Count: 100})
+				return string(data)
+			}(),
+		},
+		{
+			name: "Large_100KB",
+			data: func() string {
+				items := make([]Item, 1000)
+				for i := range 1000 {
+					items[i] = Item{ID: i, Name: fmt.Sprintf("Item %d", i), Value: strings.Repeat("y", 50)}
+				}
+				data, _ := json.Marshal(Response{Items: items, Count: 1000})
+				return string(data)
+			}(),
+		},
+	}
+
+	for _, s := range sizes {
+		b.Run(s.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				var result Response
+				_ = B.JSON(strings.NewReader(s.data), &result)
+			}
+		})
+	}
+}
+
+// BenchmarkBinder_JSON_DataTypes compares binding different Go types from JSON
+func BenchmarkBinder_JSON_DataTypes(b *testing.B) {
+	b.Run("SimpleStruct", func(b *testing.B) {
+		type Simple struct {
+			Name  string `json:"name"`
+			Value int    `json:"value"`
+		}
+		data := `{"name":"test","value":42}`
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			var result Simple
+			_ = B.JSON(strings.NewReader(data), &result)
+		}
+	})
+
+	b.Run("NestedStruct", func(b *testing.B) {
+		type Address struct {
+			Street string `json:"street"`
+			City   string `json:"city"`
+		}
+		type Person struct {
+			Name    string  `json:"name"`
+			Address Address `json:"address"`
+		}
+		data := `{"name":"John","address":{"street":"123 Main","city":"NYC"}}`
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			var result Person
+			_ = B.JSON(strings.NewReader(data), &result)
+		}
+	})
+
+	b.Run("Slice", func(b *testing.B) {
+		type List struct {
+			Items []string `json:"items"`
+		}
+		data := `{"items":["a","b","c","d","e"]}`
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			var result List
+			_ = B.JSON(strings.NewReader(data), &result)
+		}
+	})
+
+	b.Run("PointerFields", func(b *testing.B) {
+		type WithPointers struct {
+			Name  *string `json:"name"`
+			Age   *int    `json:"age"`
+			Email *string `json:"email"`
+		}
+		data := `{"name":"John","age":30,"email":"john@example.com"}`
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			var result WithPointers
+			_ = B.JSON(strings.NewReader(data), &result)
+		}
+	})
+
+	b.Run("MixedTypes", func(b *testing.B) {
+		type Mixed struct {
+			Name   string   `json:"name"`
+			Age    int      `json:"age"`
+			Active bool     `json:"active"`
+			Score  float64  `json:"score"`
+			Tags   []string `json:"tags"`
+		}
+		data := `{"name":"John","age":30,"active":true,"score":95.5,"tags":["go","web"]}`
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			var result Mixed
+			_ = B.JSON(strings.NewReader(data), &result)
+		}
+	})
+}
+
+// BenchmarkBinder_Form measures form data binding performance
+func BenchmarkBinder_Form(b *testing.B) {
+	type FormData struct {
+		Name   string   `form:"name"`
+		Email  string   `form:"email"`
+		Age    int      `form:"age"`
+		Active bool     `form:"active"`
+		Tags   []string `form:"tags"`
+	}
+
+	formData := url.Values{
+		"name":   []string{"John Doe"},
+		"email":  []string{"john@example.com"},
+		"age":    []string{"30"},
+		"active": []string{"true"},
+		"tags":   []string{"go", "web", "api"},
+	}
+
+	b.Run("Simple", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(formData.Encode()))
+		req.Header.Set(HeaderContentType, MIMEApplicationFormURLEncoded)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			// Need fresh request body for each iteration
+			req.Body = io.NopCloser(strings.NewReader(formData.Encode()))
+			var result FormData
+			_ = B.Form(req, &result)
+		}
+	})
+
+	b.Run("FieldCount_5", func(b *testing.B) {
+		type SmallForm struct {
+			F1 string `form:"f1"`
+			F2 string `form:"f2"`
+			F3 int    `form:"f3"`
+			F4 bool   `form:"f4"`
+			F5 string `form:"f5"`
+		}
+		data := url.Values{
+			"f1": []string{"val1"},
+			"f2": []string{"val2"},
+			"f3": []string{"10"},
+			"f4": []string{"true"},
+			"f5": []string{"val5"},
+		}
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set(HeaderContentType, MIMEApplicationFormURLEncoded)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req.Body = io.NopCloser(strings.NewReader(data.Encode()))
+			var result SmallForm
+			_ = B.Form(req, &result)
+		}
+	})
+
+	b.Run("FieldCount_20", func(b *testing.B) {
+		type LargeForm struct {
+			F1  string `form:"f1"`
+			F2  string `form:"f2"`
+			F3  string `form:"f3"`
+			F4  string `form:"f4"`
+			F5  string `form:"f5"`
+			F6  int    `form:"f6"`
+			F7  int    `form:"f7"`
+			F8  int    `form:"f8"`
+			F9  int    `form:"f9"`
+			F10 int    `form:"f10"`
+			F11 bool   `form:"f11"`
+			F12 bool   `form:"f12"`
+			F13 bool   `form:"f13"`
+			F14 bool   `form:"f14"`
+			F15 bool   `form:"f15"`
+			F16 string `form:"f16"`
+			F17 string `form:"f17"`
+			F18 string `form:"f18"`
+			F19 string `form:"f19"`
+			F20 string `form:"f20"`
+		}
+		data := url.Values{
+			"f1": []string{"v1"}, "f2": []string{"v2"}, "f3": []string{"v3"},
+			"f4": []string{"v4"}, "f5": []string{"v5"}, "f6": []string{"6"},
+			"f7": []string{"7"}, "f8": []string{"8"}, "f9": []string{"9"},
+			"f10": []string{"10"}, "f11": []string{"true"}, "f12": []string{"false"},
+			"f13": []string{"true"}, "f14": []string{"false"}, "f15": []string{"true"},
+			"f16": []string{"v16"}, "f17": []string{"v17"}, "f18": []string{"v18"},
+			"f19": []string{"v19"}, "f20": []string{"v20"},
+		}
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set(HeaderContentType, MIMEApplicationFormURLEncoded)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req.Body = io.NopCloser(strings.NewReader(data.Encode()))
+			var result LargeForm
+			_ = B.Form(req, &result)
+		}
+	})
+}
+
+// BenchmarkBinder_Form_DataTypes measures form binding with different data types
+func BenchmarkBinder_Form_DataTypes(b *testing.B) {
+	b.Run("Strings", func(b *testing.B) {
+		type StringForm struct {
+			Name  string `form:"name"`
+			Email string `form:"email"`
+		}
+		data := url.Values{"name": []string{"John"}, "email": []string{"john@example.com"}}
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set(HeaderContentType, MIMEApplicationFormURLEncoded)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req.Body = io.NopCloser(strings.NewReader(data.Encode()))
+			var result StringForm
+			_ = B.Form(req, &result)
+		}
+	})
+
+	b.Run("Integers", func(b *testing.B) {
+		type IntForm struct {
+			Age   int  `form:"age"`
+			Count int  `form:"count"`
+			Size  int8 `form:"size"`
+		}
+		data := url.Values{"age": []string{"30"}, "count": []string{"100"}, "size": []string{"127"}}
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set(HeaderContentType, MIMEApplicationFormURLEncoded)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req.Body = io.NopCloser(strings.NewReader(data.Encode()))
+			var result IntForm
+			_ = B.Form(req, &result)
+		}
+	})
+
+	b.Run("Floats", func(b *testing.B) {
+		type FloatForm struct {
+			Price  float64 `form:"price"`
+			Rating float32 `form:"rating"`
+		}
+		data := url.Values{"price": []string{"99.99"}, "rating": []string{"4.5"}}
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set(HeaderContentType, MIMEApplicationFormURLEncoded)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req.Body = io.NopCloser(strings.NewReader(data.Encode()))
+			var result FloatForm
+			_ = B.Form(req, &result)
+		}
+	})
+
+	b.Run("Booleans", func(b *testing.B) {
+		type BoolForm struct {
+			Active     bool `form:"active"`
+			Verified   bool `form:"verified"`
+			Subscribed bool `form:"subscribed"`
+		}
+		data := url.Values{"active": []string{"true"}, "verified": []string{"1"}, "subscribed": []string{"false"}}
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set(HeaderContentType, MIMEApplicationFormURLEncoded)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req.Body = io.NopCloser(strings.NewReader(data.Encode()))
+			var result BoolForm
+			_ = B.Form(req, &result)
+		}
+	})
+
+	b.Run("Slices", func(b *testing.B) {
+		type SliceForm struct {
+			Tags []string `form:"tags"`
+			IDs  []int    `form:"ids"`
+		}
+		data := url.Values{"tags": []string{"go", "web", "api"}, "ids": []string{"1", "2", "3"}}
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set(HeaderContentType, MIMEApplicationFormURLEncoded)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req.Body = io.NopCloser(strings.NewReader(data.Encode()))
+			var result SliceForm
+			_ = B.Form(req, &result)
+		}
+	})
+}
+
+// BenchmarkBinder_Query measures query parameter binding performance
+func BenchmarkBinder_Query(b *testing.B) {
+	type QueryParams struct {
+		Page   int      `query:"page"`
+		Limit  int      `query:"limit"`
+		Search string   `query:"search"`
+		Active bool     `query:"active"`
+		Tags   []string `query:"tags"`
+	}
+
+	b.Run("Simple", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "/?page=1&limit=20&search=test", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			var result QueryParams
+			_ = B.Query(req, &result)
+		}
+	})
+
+	b.Run("WithSlices", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "/?tags=go&tags=web&tags=api&page=1&limit=10", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			var result QueryParams
+			_ = B.Query(req, &result)
+		}
+	})
+
+	b.Run("EmptyQuery", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			var result QueryParams
+			_ = B.Query(req, &result)
+		}
+	})
+
+	b.Run("ManyParams", func(b *testing.B) {
+		type ManyParams struct {
+			Param1  string `query:"param1"`
+			Param2  string `query:"param2"`
+			Param3  string `query:"param3"`
+			Param4  string `query:"param4"`
+			Param5  string `query:"param5"`
+			Param6  int    `query:"param6"`
+			Param7  int    `query:"param7"`
+			Param8  bool   `query:"param8"`
+			Param9  bool   `query:"param9"`
+			Param10 string `query:"param10"`
+		}
+		req := httptest.NewRequest(http.MethodGet, "/?param1=a&param2=b&param3=c&param4=d&param5=e&param6=6&param7=7&param8=true&param9=false&param10=j", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			var result ManyParams
+			_ = B.Query(req, &result)
+		}
+	})
+}
+
+// BenchmarkBinder_Query_DataTypes measures query binding with different types
+func BenchmarkBinder_Query_DataTypes(b *testing.B) {
+	b.Run("Strings", func(b *testing.B) {
+		type StringQuery struct {
+			Name  string `query:"name"`
+			Email string `query:"email"`
+		}
+		req := httptest.NewRequest(http.MethodGet, "/?name=John&email=john@example.com", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			var result StringQuery
+			_ = B.Query(req, &result)
+		}
+	})
+
+	b.Run("Integers", func(b *testing.B) {
+		type IntQuery struct {
+			Page  int `query:"page"`
+			Limit int `query:"limit"`
+		}
+		req := httptest.NewRequest(http.MethodGet, "/?page=1&limit=20", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			var result IntQuery
+			_ = B.Query(req, &result)
+		}
+	})
+
+	b.Run("Booleans", func(b *testing.B) {
+		type BoolQuery struct {
+			Active bool `query:"active"`
+		}
+		req := httptest.NewRequest(http.MethodGet, "/?active=true", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			var result BoolQuery
+			_ = B.Query(req, &result)
+		}
+	})
+
+	b.Run("StringSlices", func(b *testing.B) {
+		type SliceQuery struct {
+			Tags []string `query:"tags"`
+		}
+		req := httptest.NewRequest(http.MethodGet, "/?tags=go&tags=web&tags=api", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			var result SliceQuery
+			_ = B.Query(req, &result)
+		}
+	})
+
+	b.Run("IntSlices", func(b *testing.B) {
+		type IntSliceQuery struct {
+			IDs []int `query:"ids"`
+		}
+		req := httptest.NewRequest(http.MethodGet, "/?ids=1&ids=2&ids=3&ids=4&ids=5", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			var result IntSliceQuery
+			_ = B.Query(req, &result)
+		}
+	})
+}
+
+// BenchmarkBinder_MultipartForm measures multipart form binding performance
+func BenchmarkBinder_MultipartForm(b *testing.B) {
+	type MultipartData struct {
+		Name  string `form:"name"`
+		Email string `form:"email"`
+		Age   int    `form:"age"`
+	}
+
+	b.Run("FormValuesOnly", func(b *testing.B) {
+		// Pre-build multipart body
+		var body bytes.Buffer
+		writer := multipart.NewWriter(&body)
+		_ = writer.WriteField("name", "John")
+		_ = writer.WriteField("email", "john@example.com")
+		_ = writer.WriteField("age", "30")
+		_ = writer.Close()
+
+		contentType := writer.FormDataContentType()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body.Bytes()))
+			req.Header.Set(HeaderContentType, contentType)
+			var result MultipartData
+			_ = B.MultipartForm(req, &result, 32<<20)
+		}
+	})
+
+	b.Run("SingleFile", func(b *testing.B) {
+		type WithFile struct {
+			Name     string      `form:"name"`
+			Document *FileHeader `form:"document"`
+		}
+
+		// Pre-build multipart body with file
+		var body bytes.Buffer
+		writer := multipart.NewWriter(&body)
+		_ = writer.WriteField("name", "Test")
+		fileWriter, _ := writer.CreateFormFile("document", "test.txt")
+		_, _ = fileWriter.Write([]byte("Hello, World!"))
+		_ = writer.Close()
+
+		contentType := writer.FormDataContentType()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body.Bytes()))
+			req.Header.Set(HeaderContentType, contentType)
+			var result WithFile
+			_ = B.MultipartForm(req, &result, 32<<20)
+		}
+	})
+
+	b.Run("MultipleFiles", func(b *testing.B) {
+		type WithFiles struct {
+			Name        string        `form:"name"`
+			Attachments []*FileHeader `form:"attachments"`
+		}
+
+		// Pre-build multipart body with multiple files
+		var body bytes.Buffer
+		writer := multipart.NewWriter(&body)
+		_ = writer.WriteField("name", "Test")
+		for i := range 3 {
+			fileWriter, _ := writer.CreateFormFile("attachments", fmt.Sprintf("file%d.txt", i))
+			_, _ = fmt.Fprintf(fileWriter, "Content %d", i)
+		}
+		_ = writer.Close()
+
+		contentType := writer.FormDataContentType()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body.Bytes()))
+			req.Header.Set(HeaderContentType, contentType)
+			var result WithFiles
+			_ = B.MultipartForm(req, &result, 32<<20)
+		}
+	})
+}
+
+// BenchmarkBinder_MultipartForm_FileSizes measures multipart with different file sizes
+func BenchmarkBinder_MultipartForm_FileSizes(b *testing.B) {
+	type WithFile struct {
+		Name     string      `form:"name"`
+		Document *FileHeader `form:"document"`
+	}
+
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"1KB", 1024},
+		{"10KB", 10 * 1024},
+		{"100KB", 100 * 1024},
+		{"1MB", 1024 * 1024},
+	}
+
+	for _, s := range sizes {
+		b.Run(s.name, func(b *testing.B) {
+			// Pre-build multipart body
+			fileContent := make([]byte, s.size)
+			var body bytes.Buffer
+			writer := multipart.NewWriter(&body)
+			_ = writer.WriteField("name", "Test")
+			fileWriter, _ := writer.CreateFormFile("document", "test.bin")
+			_, _ = fileWriter.Write(fileContent)
+			_ = writer.Close()
+
+			contentType := writer.FormDataContentType()
+			bodyBytes := body.Bytes()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(bodyBytes))
+				req.Header.Set(HeaderContentType, contentType)
+				var result WithFile
+				_ = B.MultipartForm(req, &result, 32<<20)
+			}
+		})
+	}
+}
+
+// BenchmarkBinder_NestedStruct measures binding to nested/embedded structs
+func BenchmarkBinder_NestedStruct(b *testing.B) {
+	b.Run("Embedded_Form", func(b *testing.B) {
+		type Embedded struct {
+			Name string `form:"name"`
+		}
+		type Container struct {
+			Embedded
+			Email string `form:"email"`
+		}
+
+		data := url.Values{"name": []string{"John"}, "email": []string{"john@example.com"}}
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set(HeaderContentType, MIMEApplicationFormURLEncoded)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req.Body = io.NopCloser(strings.NewReader(data.Encode()))
+			var result Container
+			_ = B.Form(req, &result)
+		}
+	})
+
+	b.Run("Embedded_Query", func(b *testing.B) {
+		type Embedded struct {
+			Page  int `query:"page"`
+			Limit int `query:"limit"`
+		}
+		type Container struct {
+			Embedded
+			Search string `query:"search"`
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/?page=1&limit=20&search=test", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			var result Container
+			_ = B.Query(req, &result)
+		}
+	})
+
+	b.Run("DeepNested_Form", func(b *testing.B) {
+		type Deep struct {
+			Value string `form:"value"`
+		}
+		type Middle struct {
+			Deep
+			MiddleVal string `form:"middle"`
+		}
+		type Container struct {
+			Middle
+			Top string `form:"top"`
+		}
+
+		data := url.Values{"value": []string{"deep"}, "middle": []string{"mid"}, "top": []string{"topval"}}
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set(HeaderContentType, MIMEApplicationFormURLEncoded)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req.Body = io.NopCloser(strings.NewReader(data.Encode()))
+			var result Container
+			_ = B.Form(req, &result)
+		}
+	})
+}
+
+// BenchmarkBinder_Concurrent measures concurrent binding performance
+func BenchmarkBinder_Concurrent(b *testing.B) {
+	type User struct {
+		Name  string `json:"name"`
+		Email string `json:"email"`
+		Age   int    `json:"age"`
+	}
+
+	jsonData := `{"name":"John Doe","email":"john@example.com","age":30}`
+
+	b.Run("JSON_Parallel", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				var result User
+				_ = B.JSON(strings.NewReader(jsonData), &result)
+			}
+		})
+	})
+
+	b.Run("Query_Parallel", func(b *testing.B) {
+		type Query struct {
+			Page  int    `query:"page"`
+			Limit int    `query:"limit"`
+			Sort  string `query:"sort"`
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		b.RunParallel(func(pb *testing.PB) {
+			req := httptest.NewRequest(http.MethodGet, "/?page=1&limit=20&sort=name", nil)
+			for pb.Next() {
+				var result Query
+				_ = B.Query(req, &result)
+			}
+		})
+	})
+}

--- a/internal/rwutil/rwutil_bench_test.go
+++ b/internal/rwutil/rwutil_bench_test.go
@@ -1,0 +1,338 @@
+package rwutil
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// BenchmarkResponseWriter_WriteHeader measures status code capture overhead
+func BenchmarkResponseWriter_WriteHeader(b *testing.B) {
+	b.Run("RawResponseWriter", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	b.Run("WrappedResponseWriter", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			rw := NewResponseWriter(w)
+			rw.WriteHeader(http.StatusOK)
+		}
+	})
+}
+
+// BenchmarkResponseWriter_WriteHeader_DifferentStatuses measures different status codes
+func BenchmarkResponseWriter_WriteHeader_DifferentStatuses(b *testing.B) {
+	statuses := []int{
+		http.StatusOK,
+		http.StatusCreated,
+		http.StatusNoContent,
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusNotFound,
+		http.StatusInternalServerError,
+	}
+
+	for _, status := range statuses {
+		b.Run(fmt.Sprintf("Status%d", status), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				w := httptest.NewRecorder()
+				rw := NewResponseWriter(w)
+				rw.WriteHeader(status)
+			}
+		})
+	}
+}
+
+// BenchmarkResponseWriter_Write measures Write performance
+func BenchmarkResponseWriter_Write(b *testing.B) {
+	data := []byte("Hello, World!")
+
+	b.Run("RawResponseWriter", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			_, _ = w.Write(data)
+		}
+	})
+
+	b.Run("WrappedResponseWriter", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			rw := NewResponseWriter(w)
+			_, _ = rw.Write(data)
+		}
+	})
+
+	b.Run("WrappedWithHeaderWritten", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			rw := NewResponseWriter(w)
+			rw.WriteHeader(http.StatusOK)
+			_, _ = rw.Write(data)
+		}
+	})
+}
+
+// BenchmarkResponseWriter_Write_DifferentSizes measures Write with different payload sizes
+func BenchmarkResponseWriter_Write_DifferentSizes(b *testing.B) {
+	sizes := []int{100, 1024, 10240, 102400}
+
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("Size%d", size), func(b *testing.B) {
+			data := make([]byte, size)
+
+			b.Run("Raw", func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for b.Loop() {
+					w := httptest.NewRecorder()
+					_, _ = w.Write(data)
+				}
+			})
+
+			b.Run("Wrapped", func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for b.Loop() {
+					w := httptest.NewRecorder()
+					rw := NewResponseWriter(w)
+					_, _ = rw.Write(data)
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkResponseWriter_StatusCode measures StatusCode() call overhead
+func BenchmarkResponseWriter_StatusCode(b *testing.B) {
+	b.Run("AfterWriteHeader", func(b *testing.B) {
+		w := httptest.NewRecorder()
+		rw := NewResponseWriter(w)
+		rw.WriteHeader(http.StatusCreated)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_ = rw.StatusCode()
+		}
+	})
+
+	b.Run("Default", func(b *testing.B) {
+		w := httptest.NewRecorder()
+		rw := NewResponseWriter(w)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_ = rw.StatusCode()
+		}
+	})
+}
+
+// BenchmarkResponseWriter_HeaderWritten measures HeaderWritten() call overhead
+func BenchmarkResponseWriter_HeaderWritten(b *testing.B) {
+	b.Run("AfterWriteHeader", func(b *testing.B) {
+		w := httptest.NewRecorder()
+		rw := NewResponseWriter(w)
+		rw.WriteHeader(http.StatusOK)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_ = rw.HeaderWritten()
+		}
+	})
+
+	b.Run("BeforeWriteHeader", func(b *testing.B) {
+		w := httptest.NewRecorder()
+		rw := NewResponseWriter(w)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_ = rw.HeaderWritten()
+		}
+	})
+}
+
+// BenchmarkResponseWriter_MultipleWrites measures multiple Write calls
+func BenchmarkResponseWriter_MultipleWrites(b *testing.B) {
+	data := []byte("chunk")
+
+	b.Run("SingleWrite", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			rw := NewResponseWriter(w)
+			_, _ = rw.Write(data)
+		}
+	})
+
+	b.Run("MultipleWrites_10", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			rw := NewResponseWriter(w)
+			for range 10 {
+				_, _ = rw.Write(data)
+			}
+		}
+	})
+}
+
+// BenchmarkResponseWriter_NestedLayers measures nested wrapper overhead
+func BenchmarkResponseWriter_NestedLayers(b *testing.B) {
+	data := []byte("test")
+
+	layerCounts := []int{1, 3, 5}
+
+	for _, count := range layerCounts {
+		b.Run(fmt.Sprintf("Layers%d", count), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				w := httptest.NewRecorder()
+				var rw http.ResponseWriter = w
+				for range count {
+					rw = NewResponseWriter(rw)
+				}
+				_, _ = rw.Write(data)
+			}
+		})
+	}
+}
+
+// BenchmarkFlusherResponseWriter measures FlusherResponseWriter performance
+func BenchmarkFlusherResponseWriter(b *testing.B) {
+	b.Run("Create", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			_ = NewFlusherResponseWriter(w)
+		}
+	})
+
+	b.Run("Flush", func(b *testing.B) {
+		w := httptest.NewRecorder()
+		frw := NewFlusherResponseWriter(w)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			frw.Flush()
+		}
+	})
+
+	b.Run("WriteAndFlush", func(b *testing.B) {
+		data := []byte("streaming data")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			frw := NewFlusherResponseWriter(w)
+			_, _ = frw.Write(data)
+			frw.Flush()
+		}
+	})
+}
+
+// BenchmarkResponseWriter_Header measures Header() access overhead
+func BenchmarkResponseWriter_Header(b *testing.B) {
+	b.Run("RawResponseWriter", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			_ = w.Header()
+		}
+	})
+
+	b.Run("WrappedResponseWriter", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			rw := NewResponseWriter(w)
+			_ = rw.Header()
+		}
+	})
+}
+
+// BenchmarkResponseWriter_Concurrent measures concurrent access
+func BenchmarkResponseWriter_Concurrent(b *testing.B) {
+	data := []byte("concurrent write")
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			w := httptest.NewRecorder()
+			rw := NewResponseWriter(w)
+			_, _ = rw.Write(data)
+		}
+	})
+}
+
+// BenchmarkResponseWriter_DoubleWriteHeader tests idempotent WriteHeader
+func BenchmarkResponseWriter_DoubleWriteHeader(b *testing.B) {
+	b.Run("SingleWriteHeader", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			rw := NewResponseWriter(w)
+			rw.WriteHeader(http.StatusOK)
+		}
+	})
+
+	b.Run("DoubleWriteHeader", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			rw := NewResponseWriter(w)
+			rw.WriteHeader(http.StatusOK)
+			rw.WriteHeader(http.StatusInternalServerError)
+		}
+	})
+}

--- a/metrics/metrics_bench_test.go
+++ b/metrics/metrics_bench_test.go
@@ -1,0 +1,547 @@
+package metrics
+
+import (
+	"fmt"
+	"testing"
+)
+
+// BenchmarkCounter_Increment measures counter Inc() overhead.
+func BenchmarkCounter_Increment(b *testing.B) {
+	b.Run("SimpleInc", func(b *testing.B) {
+		reg := NewRegistry()
+		counter := reg.Counter("test_counter")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			counter.Inc()
+		}
+	})
+
+	b.Run("AddValue", func(b *testing.B) {
+		reg := NewRegistry()
+		counter := reg.Counter("test_counter")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			counter.Add(5)
+		}
+	})
+
+	b.Run("Concurrent", func(b *testing.B) {
+		reg := NewRegistry()
+		counter := reg.Counter("test_counter")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				counter.Inc()
+			}
+		})
+	})
+}
+
+// BenchmarkCounter_WithLabels measures counter operations with label lookups.
+func BenchmarkCounter_WithLabels(b *testing.B) {
+	testCases := []struct {
+		name   string
+		labels []string
+	}{
+		{"NoLabels", nil},
+		{"OneLabel", []string{"method"}},
+		{"TwoLabels", []string{"method", "status"}},
+		{"ThreeLabels", []string{"method", "status", "path"}},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			reg := NewRegistry()
+			counter := reg.Counter("test_counter", tc.labels...)
+
+			labelValues := make([]string, len(tc.labels))
+			for i := range tc.labels {
+				labelValues[i] = fmt.Sprintf("value%d", i)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				counter.WithLabelValues(labelValues...).Inc()
+			}
+		})
+	}
+}
+
+// BenchmarkCounter_LabelCardinality measures performance with many label values.
+func BenchmarkCounter_LabelCardinality(b *testing.B) {
+	cardinalities := []int{1, 10, 100, 1000}
+
+	for _, card := range cardinalities {
+		b.Run(fmt.Sprintf("Cardinality%d", card), func(b *testing.B) {
+			reg := NewRegistry(RegistryConfig{MaxCardinality: card})
+			counter := reg.Counter("test_counter", "id")
+
+			// Pre-populate with all label values
+			for i := range card {
+				counter.WithLabelValues(fmt.Sprintf("id%d", i)).Inc()
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				counter.WithLabelValues("id0").Inc()
+			}
+		})
+	}
+}
+
+// BenchmarkGauge_Operations measures gauge operation overhead.
+func BenchmarkGauge_Operations(b *testing.B) {
+	b.Run("Set", func(b *testing.B) {
+		reg := NewRegistry()
+		gauge := reg.Gauge("test_gauge")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			gauge.Set(42.5)
+		}
+	})
+
+	b.Run("Inc", func(b *testing.B) {
+		reg := NewRegistry()
+		gauge := reg.Gauge("test_gauge")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			gauge.Inc()
+		}
+	})
+
+	b.Run("Dec", func(b *testing.B) {
+		reg := NewRegistry()
+		gauge := reg.Gauge("test_gauge")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			gauge.Dec()
+		}
+	})
+
+	b.Run("Add", func(b *testing.B) {
+		reg := NewRegistry()
+		gauge := reg.Gauge("test_gauge")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			gauge.Add(1.5)
+		}
+	})
+
+	b.Run("Sub", func(b *testing.B) {
+		reg := NewRegistry()
+		gauge := reg.Gauge("test_gauge")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			gauge.Sub(1.5)
+		}
+	})
+
+	b.Run("ConcurrentSet", func(b *testing.B) {
+		reg := NewRegistry()
+		gauge := reg.Gauge("test_gauge")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				gauge.Set(42.5)
+			}
+		})
+	})
+}
+
+// BenchmarkGauge_WithLabels measures gauge operations with label lookups.
+func BenchmarkGauge_WithLabels(b *testing.B) {
+	testCases := []struct {
+		name   string
+		labels []string
+	}{
+		{"NoLabels", nil},
+		{"OneLabel", []string{"region"}},
+		{"TwoLabels", []string{"region", "zone"}},
+		{"ThreeLabels", []string{"region", "zone", "instance"}},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			reg := NewRegistry()
+			gauge := reg.Gauge("test_gauge", tc.labels...)
+
+			labelValues := make([]string, len(tc.labels))
+			for i := range tc.labels {
+				labelValues[i] = fmt.Sprintf("value%d", i)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				gauge.WithLabelValues(labelValues...).Set(42.5)
+			}
+		})
+	}
+}
+
+// BenchmarkHistogram_Observe measures histogram observation overhead.
+func BenchmarkHistogram_Observe(b *testing.B) {
+	buckets := []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+
+	b.Run("DefaultBuckets", func(b *testing.B) {
+		reg := NewRegistry()
+		hist := reg.Histogram("test_histogram", buckets)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			hist.Observe(0.5)
+		}
+	})
+
+	b.Run("FewBuckets", func(b *testing.B) {
+		reg := NewRegistry()
+		hist := reg.Histogram("test_histogram", []float64{0.1, 1, 10})
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			hist.Observe(0.5)
+		}
+	})
+
+	b.Run("ManyBuckets", func(b *testing.B) {
+		reg := NewRegistry()
+		hist := reg.Histogram("test_histogram", []float64{0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 50})
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			hist.Observe(0.5)
+		}
+	})
+
+	b.Run("Concurrent", func(b *testing.B) {
+		reg := NewRegistry()
+		hist := reg.Histogram("test_histogram", buckets)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				hist.Observe(0.5)
+			}
+		})
+	})
+}
+
+// BenchmarkHistogram_WithLabels measures histogram operations with label lookups.
+func BenchmarkHistogram_WithLabels(b *testing.B) {
+	buckets := []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+
+	testCases := []struct {
+		name   string
+		labels []string
+	}{
+		{"NoLabels", nil},
+		{"OneLabel", []string{"endpoint"}},
+		{"TwoLabels", []string{"endpoint", "method"}},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			reg := NewRegistry()
+			hist := reg.Histogram("test_histogram", buckets, tc.labels...)
+
+			labelValues := make([]string, len(tc.labels))
+			for i := range tc.labels {
+				labelValues[i] = fmt.Sprintf("value%d", i)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				hist.WithLabelValues(labelValues...).Observe(0.5)
+			}
+		})
+	}
+}
+
+// BenchmarkRegistry_Operations measures registry creation and lookup.
+func BenchmarkRegistry_Operations(b *testing.B) {
+	b.Run("CounterCreate", func(b *testing.B) {
+		reg := NewRegistry()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			reg.Counter(fmt.Sprintf("counter%d", b.N))
+		}
+	})
+
+	b.Run("CounterLookup", func(b *testing.B) {
+		reg := NewRegistry()
+		reg.Counter("test_counter")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			reg.Counter("test_counter")
+		}
+	})
+
+	b.Run("GaugeCreate", func(b *testing.B) {
+		reg := NewRegistry()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			reg.Gauge(fmt.Sprintf("gauge%d", b.N))
+		}
+	})
+
+	b.Run("GaugeLookup", func(b *testing.B) {
+		reg := NewRegistry()
+		reg.Gauge("test_gauge")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			reg.Gauge("test_gauge")
+		}
+	})
+
+	b.Run("HistogramCreate", func(b *testing.B) {
+		reg := NewRegistry()
+		buckets := []float64{0.1, 1, 10}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			reg.Histogram(fmt.Sprintf("hist%d", b.N), buckets)
+		}
+	})
+
+	b.Run("HistogramLookup", func(b *testing.B) {
+		reg := NewRegistry()
+		buckets := []float64{0.1, 1, 10}
+		reg.Histogram("test_hist", buckets)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			reg.Histogram("test_hist", buckets)
+		}
+	})
+}
+
+// BenchmarkRegistry_ManyMetrics measures registry with many metrics.
+func BenchmarkRegistry_ManyMetrics(b *testing.B) {
+	metricCounts := []int{10, 100, 500}
+
+	for _, count := range metricCounts {
+		b.Run(fmt.Sprintf("Counters%d", count), func(b *testing.B) {
+			reg := NewRegistry()
+			for i := range count {
+				reg.Counter(fmt.Sprintf("counter%d", i))
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				reg.Counter("counter0").Inc()
+			}
+		})
+
+		b.Run(fmt.Sprintf("Gauges%d", count), func(b *testing.B) {
+			reg := NewRegistry()
+			for i := range count {
+				reg.Gauge(fmt.Sprintf("gauge%d", i))
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				reg.Gauge("gauge0").Set(42.5)
+			}
+		})
+
+		b.Run(fmt.Sprintf("Histograms%d", count), func(b *testing.B) {
+			reg := NewRegistry()
+			buckets := []float64{0.1, 1, 10}
+			for i := range count {
+				reg.Histogram(fmt.Sprintf("hist%d", i), buckets)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				reg.Histogram("hist0", buckets).Observe(0.5)
+			}
+		})
+	}
+}
+
+// BenchmarkRegistry_Gather measures metric gathering/scraping performance.
+func BenchmarkRegistry_Gather(b *testing.B) {
+	b.Run("EmptyRegistry", func(b *testing.B) {
+		reg := NewRegistry()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = reg.Gather()
+		}
+	})
+
+	b.Run("SingleCounter", func(b *testing.B) {
+		reg := NewRegistry()
+		counter := reg.Counter("test_counter")
+		counter.Inc()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = reg.Gather()
+		}
+	})
+
+	b.Run("SingleCounterWithLabels", func(b *testing.B) {
+		reg := NewRegistry()
+		counter := reg.Counter("test_counter", "method", "status")
+		counter.WithLabelValues("GET", "200").Inc()
+		counter.WithLabelValues("POST", "201").Inc()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = reg.Gather()
+		}
+	})
+
+	b.Run("ManyMetrics", func(b *testing.B) {
+		reg := NewRegistry()
+		for i := range 100 {
+			c := reg.Counter(fmt.Sprintf("counter%d", i), "label")
+			c.WithLabelValues("value").Inc()
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = reg.Gather()
+		}
+	})
+
+	b.Run("ManyLabelValues", func(b *testing.B) {
+		reg := NewRegistry(RegistryConfig{MaxCardinality: 1000})
+		counter := reg.Counter("test_counter", "id")
+		for i := range 1000 {
+			counter.WithLabelValues(fmt.Sprintf("id%d", i)).Inc()
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = reg.Gather()
+		}
+	})
+}
+
+// BenchmarkNopRegistry measures no-op registry overhead.
+func BenchmarkNopRegistry(b *testing.B) {
+	b.Run("Counter", func(b *testing.B) {
+		reg := SafeRegistry(nil)
+		counter := reg.Counter("test")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			counter.Inc()
+		}
+	})
+
+	b.Run("Gauge", func(b *testing.B) {
+		reg := SafeRegistry(nil)
+		gauge := reg.Gauge("test")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			gauge.Set(42.5)
+		}
+	})
+
+	b.Run("Histogram", func(b *testing.B) {
+		reg := SafeRegistry(nil)
+		hist := reg.Histogram("test", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			hist.Observe(0.5)
+		}
+	})
+}
+
+// BenchmarkLabelKeyCreation measures label key creation overhead.
+func BenchmarkLabelKeyCreation(b *testing.B) {
+	testCases := []struct {
+		name   string
+		labels []string
+	}{
+		{"Empty", nil},
+		{"One", []string{"value1"}},
+		{"Two", []string{"value1", "value2"}},
+		{"Three", []string{"value1", "value2", "value3"}},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				_ = makeLabelKey(tc.labels)
+			}
+		})
+	}
+}
+
+// BenchmarkLabelKeyParse measures label key parsing overhead.
+func BenchmarkLabelKeyParse(b *testing.B) {
+	testCases := []struct {
+		name       string
+		labelNames []string
+		key        string
+	}{
+		{"Empty", nil, ""},
+		{"One", []string{"label1"}, "value1"},
+		{"Two", []string{"label1", "label2"}, "value1\x00value2"},
+		{"Three", []string{"label1", "label2", "label3"}, "value1\x00value2\x00value3"},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				_ = parseLabelKey(tc.key, tc.labelNames)
+			}
+		})
+	}
+}

--- a/middleware/basic_auth_bench_test.go
+++ b/middleware/basic_auth_bench_test.go
@@ -1,0 +1,162 @@
+package middleware
+
+import (
+	"crypto/subtle"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alexferl/zerohttp/config"
+)
+
+// BenchmarkBasicAuth_Methods compares different credential validation methods
+func BenchmarkBasicAuth_Methods(b *testing.B) {
+	b.Run("CredentialsMap", func(b *testing.B) {
+		handler := BasicAuth(config.BasicAuthConfig{
+			Credentials: map[string]string{
+				"admin": "secret123",
+				"user":  "password456",
+			},
+		})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.SetBasicAuth("admin", "secret123")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+		}
+	})
+
+	b.Run("ValidatorFunction", func(b *testing.B) {
+		handler := BasicAuth(config.BasicAuthConfig{
+			Validator: func(user, pass string) bool {
+				return user == "admin" && pass == "secret123"
+			},
+		})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.SetBasicAuth("admin", "secret123")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+		}
+	})
+}
+
+// BenchmarkBasicAuth_ConstantTimeComparison measures the overhead of constant-time comparison
+func BenchmarkBasicAuth_ConstantTimeComparison(b *testing.B) {
+	correctPass := "secret123"
+	testPass := "secret123"
+	wrongPass := "wrongpass"
+
+	b.Run("StandardComparison", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_ = testPass == correctPass
+		}
+	})
+
+	b.Run("ConstantTimeCompare_Correct", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			subtle.ConstantTimeCompare([]byte(testPass), []byte(correctPass))
+		}
+	})
+
+	b.Run("ConstantTimeCompare_Wrong", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			subtle.ConstantTimeCompare([]byte(wrongPass), []byte(correctPass))
+		}
+	})
+}
+
+// BenchmarkBasicAuth_Scenarios measures different auth scenarios
+func BenchmarkBasicAuth_Scenarios(b *testing.B) {
+	scenarios := []struct {
+		name   string
+		user   string
+		pass   string
+		expect int
+	}{
+		{"Valid", "admin", "secret123", http.StatusOK},
+		{"InvalidPassword", "admin", "wrongpass", http.StatusUnauthorized},
+		{"InvalidUser", "unknown", "secret123", http.StatusUnauthorized},
+		{"MissingAuth", "", "", http.StatusUnauthorized},
+	}
+
+	for _, s := range scenarios {
+		b.Run(s.name, func(b *testing.B) {
+			handler := BasicAuth(config.BasicAuthConfig{
+				Credentials: map[string]string{
+					"admin": "secret123",
+				},
+			})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			if s.user != "" {
+				req.SetBasicAuth(s.user, s.pass)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+			}
+		})
+	}
+}
+
+// BenchmarkBasicAuth_UserCount measures performance with different user counts
+func BenchmarkBasicAuth_UserCount(b *testing.B) {
+	userCounts := []int{1, 10, 100}
+
+	for _, count := range userCounts {
+		b.Run(fmt.Sprintf("Users%d", count), func(b *testing.B) {
+			creds := make(map[string]string, count)
+			for i := range count {
+				creds[fmt.Sprintf("user%d", i)] = fmt.Sprintf("pass%d", i)
+			}
+
+			handler := BasicAuth(config.BasicAuthConfig{
+				Credentials: creds,
+			})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.SetBasicAuth("user0", "pass0")
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+			}
+		})
+	}
+}

--- a/middleware/circuit_breaker_bench_test.go
+++ b/middleware/circuit_breaker_bench_test.go
@@ -1,0 +1,427 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/metrics"
+)
+
+// BenchmarkCircuitBreaker_States measures performance in different circuit states
+func BenchmarkCircuitBreaker_States(b *testing.B) {
+	states := []struct {
+		name       string
+		setupFunc  func(*circuit)
+		expectOpen bool
+	}{
+		{
+			name: "Closed",
+			setupFunc: func(c *circuit) {
+				c.state = StateClosed
+			},
+			expectOpen: false,
+		},
+		{
+			name: "Open",
+			setupFunc: func(c *circuit) {
+				c.state = StateOpen
+				c.lastFailureTime = time.Now()
+			},
+			expectOpen: true,
+		},
+		{
+			name: "HalfOpen",
+			setupFunc: func(c *circuit) {
+				c.state = StateHalfOpen
+				c.halfOpenInFlight = 0
+			},
+			expectOpen: false,
+		},
+	}
+
+	for _, s := range states {
+		b.Run(s.name, func(b *testing.B) {
+			cbm := &circuitBreakerMiddleware{
+				circuits: make(map[string]*circuit),
+				config:   config.DefaultCircuitBreakerConfig,
+			}
+
+			// Pre-create circuit in desired state
+			c := cbm.getCircuit("test-key")
+			s.setupFunc(c)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				c := cbm.getCircuit("test-key")
+				c.isOpen()
+			}
+		})
+	}
+}
+
+// BenchmarkCircuitBreaker_FullMiddleware measures the complete middleware overhead
+func BenchmarkCircuitBreaker_FullMiddleware(b *testing.B) {
+	scenarios := []struct {
+		name string
+		code int
+	}{
+		{"Success", http.StatusOK},
+		{"Failure", http.StatusInternalServerError},
+	}
+
+	for _, s := range scenarios {
+		b.Run(s.name, func(b *testing.B) {
+			cbm := CircuitBreaker(config.CircuitBreakerConfig{
+				FailureThreshold: 100, // High threshold to prevent tripping
+			})
+
+			handler := cbm(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(s.code)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+			}
+		})
+	}
+}
+
+// BenchmarkCircuitBreaker_Concurrent measures concurrent performance
+func BenchmarkCircuitBreaker_Concurrent(b *testing.B) {
+	concurrencyLevels := []int{1, 10, 100}
+
+	for _, concurrency := range concurrencyLevels {
+		b.Run(fmt.Sprintf("Goroutines%d", concurrency), func(b *testing.B) {
+			cbm := CircuitBreaker(config.CircuitBreakerConfig{
+				FailureThreshold: 100,
+			})
+
+			handler := cbm(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					rr := httptest.NewRecorder()
+					handler.ServeHTTP(rr, req)
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkCircuitBreaker_RecordResult measures result recording performance
+func BenchmarkCircuitBreaker_RecordResult(b *testing.B) {
+	states := []struct {
+		name   string
+		state  CircuitState
+		status int
+	}{
+		{"Closed_Success", StateClosed, http.StatusOK},
+		{"Closed_Failure", StateClosed, http.StatusInternalServerError},
+		{"HalfOpen_Success", StateHalfOpen, http.StatusOK},
+		{"HalfOpen_Failure", StateHalfOpen, http.StatusInternalServerError},
+	}
+
+	for _, s := range states {
+		b.Run(s.name, func(b *testing.B) {
+			cbm := &circuitBreakerMiddleware{
+				circuits: make(map[string]*circuit),
+				config:   config.DefaultCircuitBreakerConfig,
+			}
+
+			c := cbm.getCircuit("test-key")
+			c.state = s.state
+			c.halfOpenInFlight = 1 // Simulate in-flight request
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			reg := metrics.NewRegistry()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				c.recordResult(req, s.status, reg, "test-key")
+			}
+		})
+	}
+}
+
+// BenchmarkCircuitBreaker_GetCircuit measures circuit lookup/creation performance
+func BenchmarkCircuitBreaker_GetCircuit(b *testing.B) {
+	scenarios := []struct {
+		name     string
+		numKeys  int
+		keyIndex int // Which key to look up (0 = first created, numKeys-1 = last)
+	}{
+		{"SingleKey", 1, 0},
+		{"10Keys_First", 10, 0},
+		{"10Keys_Last", 10, 9},
+		{"100Keys_Last", 100, 99},
+	}
+
+	for _, s := range scenarios {
+		b.Run(s.name, func(b *testing.B) {
+			cbm := &circuitBreakerMiddleware{
+				circuits: make(map[string]*circuit),
+				config:   config.DefaultCircuitBreakerConfig,
+			}
+
+			// Pre-populate circuits
+			keys := make([]string, s.numKeys)
+			for i := 0; i < s.numKeys; i++ {
+				keys[i] = fmt.Sprintf("key-%d", i)
+				_ = cbm.getCircuit(keys[i])
+			}
+
+			targetKey := keys[s.keyIndex]
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				cbm.getCircuit(targetKey)
+			}
+		})
+	}
+}
+
+// BenchmarkCircuitBreaker_ConfigVariations measures impact of different configurations
+func BenchmarkCircuitBreaker_ConfigVariations(b *testing.B) {
+	configs := []struct {
+		name string
+		cfg  config.CircuitBreakerConfig
+	}{
+		{
+			name: "Default",
+			cfg:  config.DefaultCircuitBreakerConfig,
+		},
+		{
+			name: "HighThreshold",
+			cfg: config.CircuitBreakerConfig{
+				FailureThreshold: 1000,
+				RecoveryTimeout:  time.Minute,
+				SuccessThreshold: 100,
+			},
+		},
+		{
+			name: "LowThreshold",
+			cfg: config.CircuitBreakerConfig{
+				FailureThreshold: 2,
+				RecoveryTimeout:  time.Second,
+				SuccessThreshold: 1,
+			},
+		},
+		{
+			name: "CustomKeyExtractor",
+			cfg: config.CircuitBreakerConfig{
+				KeyExtractor: func(r *http.Request) string {
+					return r.Header.Get("X-Service-Key")
+				},
+			},
+		},
+	}
+
+	for _, c := range configs {
+		b.Run(c.name, func(b *testing.B) {
+			cbm := CircuitBreaker(c.cfg)
+
+			handler := cbm(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set("X-Service-Key", "service-a")
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+			}
+		})
+	}
+}
+
+// BenchmarkCircuitBreaker_HalfOpenLimiting measures half-open request limiting
+func BenchmarkCircuitBreaker_HalfOpenLimiting(b *testing.B) {
+	limits := []int{1, 5, 10}
+
+	for _, limit := range limits {
+		b.Run(fmt.Sprintf("Limit%d", limit), func(b *testing.B) {
+			cbm := &circuitBreakerMiddleware{
+				circuits: make(map[string]*circuit),
+				config: config.CircuitBreakerConfig{
+					MaxHalfOpenRequests: limit,
+				},
+			}
+
+			c := cbm.getCircuit("test-key")
+			c.state = StateHalfOpen
+			c.halfOpenInFlight = 0
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				c.isOpen()
+			}
+		})
+	}
+}
+
+// BenchmarkCircuitBreaker_StateTransition measures state transition overhead
+func BenchmarkCircuitBreaker_StateTransition(b *testing.B) {
+	transitions := []struct {
+		name         string
+		initialState CircuitState
+		failures     int
+		successes    int
+	}{
+		{
+			name:         "ClosedToOpen",
+			initialState: StateClosed,
+			failures:     5,
+			successes:    0,
+		},
+		{
+			name:         "HalfOpenToClosed",
+			initialState: StateHalfOpen,
+			failures:     0,
+			successes:    5,
+		},
+		{
+			name:         "HalfOpenToOpen",
+			initialState: StateHalfOpen,
+			failures:     1,
+			successes:    0,
+		},
+	}
+
+	for _, t := range transitions {
+		b.Run(t.name, func(b *testing.B) {
+			cfg := config.DefaultCircuitBreakerConfig
+			cfg.FailureThreshold = 5
+			cfg.SuccessThreshold = 5
+			cbm := &circuitBreakerMiddleware{
+				circuits: make(map[string]*circuit),
+				config:   cfg,
+			}
+
+			c := cbm.getCircuit("test-key")
+			c.state = t.initialState
+			c.halfOpenInFlight = 1
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			reg := metrics.NewRegistry()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				// Reset state
+				c.state = t.initialState
+				c.failureCount = 0
+				c.successCount = 0
+
+				// Record failures
+				for i := 0; i < t.failures; i++ {
+					c.recordResult(req, http.StatusInternalServerError, reg, "test-key")
+				}
+
+				// Record successes
+				for i := 0; i < t.successes; i++ {
+					c.recordResult(req, http.StatusOK, reg, "test-key")
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkCircuitBreaker_Baseline compares against no middleware
+func BenchmarkCircuitBreaker_Baseline(b *testing.B) {
+	b.Run("NoMiddleware", func(b *testing.B) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+		}
+	})
+
+	b.Run("WithCircuitBreaker", func(b *testing.B) {
+		cbm := CircuitBreaker(config.CircuitBreakerConfig{
+			FailureThreshold: 100,
+		})
+
+		handler := cbm(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+		}
+	})
+}
+
+// BenchmarkCircuitBreaker_MultipleCircuits measures performance with many circuits
+func BenchmarkCircuitBreaker_MultipleCircuits(b *testing.B) {
+	circuitCounts := []int{1, 10, 100, 1000}
+
+	for _, count := range circuitCounts {
+		b.Run(fmt.Sprintf("Circuits%d", count), func(b *testing.B) {
+			cbm := &circuitBreakerMiddleware{
+				circuits: make(map[string]*circuit),
+				config:   config.DefaultCircuitBreakerConfig,
+			}
+
+			// Pre-create circuits
+			keys := make([]string, count)
+			for i := 0; i < count; i++ {
+				keys[i] = fmt.Sprintf("key-%d", i)
+				_ = cbm.getCircuit(keys[i])
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			i := 0
+			for b.Loop() {
+				c := cbm.getCircuit(keys[i%count])
+				c.isOpen()
+				i++
+			}
+		})
+	}
+}

--- a/middleware/compress_bench_test.go
+++ b/middleware/compress_bench_test.go
@@ -1,0 +1,453 @@
+package middleware
+
+import (
+	"compress/flate"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/alexferl/zerohttp/config"
+)
+
+// BenchmarkCompress_Algorithms compares gzip vs deflate encoding speed
+func BenchmarkCompress_Algorithms(b *testing.B) {
+	content := []byte(strings.Repeat("This is test content for compression. ", 100))
+
+	algorithms := []struct {
+		name    string
+		encoder string
+		alg     config.CompressionAlgorithm
+	}{
+		{"Gzip", "gzip", config.Gzip},
+		{"Deflate", "deflate", config.Deflate},
+	}
+
+	for _, alg := range algorithms {
+		b.Run(alg.name, func(b *testing.B) {
+			mw := Compress(config.CompressConfig{
+				Algorithms: []config.CompressionAlgorithm{alg.alg},
+				Types:      []string{"text/plain"},
+			})
+
+			handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				_, _ = w.Write(content)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set("Accept-Encoding", alg.encoder)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+			}
+		})
+	}
+}
+
+// BenchmarkCompress_PoolEfficiency measures the benefit of encoder pooling
+func BenchmarkCompress_PoolEfficiency(b *testing.B) {
+	content := []byte(strings.Repeat("Test content for compression pooling. ", 50))
+
+	// Create compressor with pooling (default)
+	pooledCompressor := NewCompressor(5, "text/plain")
+
+	b.Run("WithPooling", func(b *testing.B) {
+		handler := pooledCompressor.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write(content)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+		}
+	})
+
+	// Simulate no pooling by creating a new compressor each time
+	b.Run("WithoutPooling", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			// Create new compressor each iteration (simulates no pooling)
+			compressor := NewCompressor(5, "text/plain")
+			handler := compressor.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				_, _ = w.Write(content)
+			}))
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+		}
+	})
+}
+
+// BenchmarkCompress_ContentTypeMatching measures content-type matching overhead
+func BenchmarkCompress_ContentTypeMatching(b *testing.B) {
+	content := []byte(strings.Repeat("Test content. ", 20))
+
+	testCases := []struct {
+		name  string
+		types []string
+	}{
+		{"ExactMatch", []string{"text/plain", "text/html", "application/json"}},
+		{"Wildcard", []string{"text/*", "application/*"}},
+		{"Mixed", []string{"text/plain", "text/html", "application/*"}},
+		{"ManyTypes", []string{
+			"text/plain", "text/html", "text/css", "text/javascript",
+			"application/json", "application/xml", "application/javascript",
+			"image/svg+xml", "application/pdf",
+		}},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			compressor := NewCompressor(5, tc.types...)
+
+			handler := compressor.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				_, _ = w.Write(content)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set("Accept-Encoding", "gzip")
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+			}
+		})
+	}
+}
+
+// BenchmarkCompress_CompressionLevels compares different compression levels
+func BenchmarkCompress_CompressionLevels(b *testing.B) {
+	content := []byte(strings.Repeat("This is test content that will be compressed. ", 100))
+
+	levels := []int{1, 3, 5, 6, 9}
+
+	for _, level := range levels {
+		b.Run(fmt.Sprintf("Level%d", level), func(b *testing.B) {
+			compressor := NewCompressor(level, "text/plain")
+
+			handler := compressor.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				_, _ = w.Write(content)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set("Accept-Encoding", "gzip")
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+			}
+		})
+	}
+}
+
+// BenchmarkCompress_PayloadSizes measures performance with different payload sizes
+func BenchmarkCompress_PayloadSizes(b *testing.B) {
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"100B", 100},
+		{"1KB", 1024},
+		{"10KB", 10 * 1024},
+		{"100KB", 100 * 1024},
+		{"1MB", 1024 * 1024},
+	}
+
+	for _, s := range sizes {
+		b.Run(s.name, func(b *testing.B) {
+			content := []byte(strings.Repeat("x", s.size))
+
+			mw := Compress(config.CompressConfig{
+				Types: []string{"text/plain"},
+			})
+
+			handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				_, _ = w.Write(content)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set("Accept-Encoding", "gzip")
+
+			b.ReportAllocs()
+			b.SetBytes(int64(s.size))
+			b.ResetTimer()
+
+			for b.Loop() {
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+			}
+		})
+	}
+}
+
+// BenchmarkCompress_Concurrent measures concurrent compression performance
+func BenchmarkCompress_Concurrent(b *testing.B) {
+	content := []byte(strings.Repeat("Test content for concurrent compression. ", 50))
+
+	concurrencyLevels := []int{1, 10, 100}
+
+	for _, concurrency := range concurrencyLevels {
+		b.Run(fmt.Sprintf("Goroutines%d", concurrency), func(b *testing.B) {
+			mw := Compress(config.CompressConfig{
+				Types: []string{"text/plain"},
+			})
+
+			handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				_, _ = w.Write(content)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set("Accept-Encoding", "gzip")
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					rr := httptest.NewRecorder()
+					handler.ServeHTTP(rr, req)
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkCompress_NoCompressionFallback measures overhead when compression is skipped
+func BenchmarkCompress_NoCompressionFallback(b *testing.B) {
+	content := []byte(strings.Repeat("Test content. ", 20))
+
+	mw := Compress(config.CompressConfig{
+		Types: []string{"text/html"}, // Only compress HTML
+	})
+
+	b.Run("NoAcceptEncoding", func(b *testing.B) {
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write(content)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		// No Accept-Encoding header
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+		}
+	})
+
+	b.Run("NonCompressibleType", func(b *testing.B) {
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(content)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+		}
+	})
+
+	b.Run("Baseline_NoMiddleware", func(b *testing.B) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write(content)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+		}
+	})
+}
+
+// BenchmarkCompress_ExemptPaths measures path exemption checking overhead
+func BenchmarkCompress_ExemptPaths(b *testing.B) {
+	content := []byte(strings.Repeat("Test content. ", 20))
+
+	testCases := []struct {
+		name        string
+		exemptPaths []string
+		path        string
+	}{
+		{"NoExemptions", nil, "/test"},
+		{"OneExemption", []string{"/health"}, "/test"},
+		{"ManyExemptions", []string{"/health", "/metrics", "/api/internal/", "/debug/", "/admin/"}, "/test"},
+		{"ExemptPathMatch", []string{"/health", "/metrics", "/api/internal/"}, "/api/internal/data"},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			mw := Compress(config.CompressConfig{
+				Types:       []string{"text/plain"},
+				ExemptPaths: tc.exemptPaths,
+			})
+
+			handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				_, _ = w.Write(content)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			req.Header.Set("Accept-Encoding", "gzip")
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+			}
+		})
+	}
+}
+
+// BenchmarkCompress_ResponseWriterWrapping measures the overhead of wrapping ResponseWriter
+func BenchmarkCompress_ResponseWriterWrapping(b *testing.B) {
+	content := []byte(strings.Repeat("Test content. ", 20))
+
+	b.Run("WithCompression", func(b *testing.B) {
+		compressor := NewCompressor(5, "text/plain")
+
+		handler := compressor.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write(content)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+		}
+	})
+
+	b.Run("WithoutCompression", func(b *testing.B) {
+		compressor := NewCompressor(5, "text/html") // Different type than response
+
+		handler := compressor.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write(content)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+		}
+	})
+}
+
+// BenchmarkCompress_Decompression verifies compressed data is valid and measures decompression
+func BenchmarkCompress_Decompression(b *testing.B) {
+	content := []byte(strings.Repeat("This is test content for compression and decompression. ", 100))
+
+	b.Run("Gzip_Decompress", func(b *testing.B) {
+		compressor := NewCompressor(5, "text/plain")
+
+		// First, compress the content
+		compressed := httptest.NewRecorder()
+		handler := compressor.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write(content)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+		handler.ServeHTTP(compressed, req)
+
+		compressedBody := compressed.Body.Bytes()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.SetBytes(int64(len(content)))
+
+		for b.Loop() {
+			reader, _ := gzip.NewReader(strings.NewReader(string(compressedBody)))
+			_, _ = io.ReadAll(reader)
+			_ = reader.Close()
+		}
+	})
+
+	b.Run("Deflate_Decompress", func(b *testing.B) {
+		compressor := NewCompressor(5, "text/plain")
+		compressor.algorithms[config.Gzip] = false // Disable gzip
+
+		// First, compress the content
+		compressed := httptest.NewRecorder()
+		handler := compressor.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write(content)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Accept-Encoding", "deflate")
+		handler.ServeHTTP(compressed, req)
+
+		compressedBody := compressed.Body.Bytes()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.SetBytes(int64(len(content)))
+
+		for b.Loop() {
+			reader := flate.NewReader(strings.NewReader(string(compressedBody)))
+			_, _ = io.ReadAll(reader)
+			_ = reader.Close()
+		}
+	})
+}

--- a/middleware/csrf_bench_test.go
+++ b/middleware/csrf_bench_test.go
@@ -390,7 +390,7 @@ func BenchmarkCSRF_Concurrent(b *testing.B) {
 func BenchmarkCSRF_HMACComparison(b *testing.B) {
 	key := []byte("test-key-32-bytes-long-for-hmac!!")
 	data := make([]byte, 32)
-	rand.Read(data)
+	_, _ = rand.Read(data)
 
 	b.Run("HMAC_Generate", func(b *testing.B) {
 		b.ReportAllocs()

--- a/middleware/csrf_bench_test.go
+++ b/middleware/csrf_bench_test.go
@@ -1,0 +1,449 @@
+package middleware
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/alexferl/zerohttp/config"
+)
+
+// BenchmarkCSRF_TokenGeneration measures token generation performance
+func BenchmarkCSRF_TokenGeneration(b *testing.B) {
+	key := []byte("test-key-32-bytes-long-for-hmac!!")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		_, _ = generateToken(key)
+	}
+}
+
+// BenchmarkCSRF_TokenValidation measures token validation/comparison
+func BenchmarkCSRF_TokenValidation(b *testing.B) {
+	key := []byte("test-key-32-bytes-long-for-hmac!!")
+	token, _ := generateToken(key)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		_ = compareTokens(token, token, key)
+	}
+}
+
+// BenchmarkCSRF_TokenComparisonScenarios different validation scenarios
+func BenchmarkCSRF_TokenComparisonScenarios(b *testing.B) {
+	key := []byte("test-key-32-bytes-long-for-hmac!!")
+	validToken, _ := generateToken(key)
+	invalidToken, _ := generateToken(key)
+
+	b.Run("ValidToken", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_ = compareTokens(validToken, validToken, key)
+		}
+	})
+
+	b.Run("InvalidToken", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_ = compareTokens(validToken, invalidToken, key)
+		}
+	})
+
+	b.Run("MalformedToken", func(b *testing.B) {
+		malformed := "not-a-valid-token"
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_ = compareTokens(validToken, malformed, key)
+		}
+	})
+}
+
+// BenchmarkCSRF_ExtractToken measures token extraction from different sources
+func BenchmarkCSRF_ExtractToken(b *testing.B) {
+	b.Run("Header", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set("X-CSRF-Token", "test-token-value")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_ = extractToken(req, "header", "X-CSRF-Token")
+		}
+	})
+
+	b.Run("Query", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "/?csrf_token=test-token-value", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_ = extractToken(req, "query", "csrf_token")
+		}
+	})
+
+	b.Run("Form", func(b *testing.B) {
+		formData := url.Values{"csrf_token": []string{"test-token-value"}}
+		body := strings.NewReader(formData.Encode())
+		req := httptest.NewRequest(http.MethodPost, "/", body)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_ = extractToken(req, "form", "csrf_token")
+		}
+	})
+}
+
+// BenchmarkCSRF_Middleware measures full middleware overhead
+func BenchmarkCSRF_Middleware(b *testing.B) {
+	key := []byte("test-key-32-bytes-long-for-hmac!!")
+
+	b.Run("GET_ExemptMethod", func(b *testing.B) {
+		handler := CSRF(config.CSRFConfig{
+			HMACKey:       key,
+			ExemptMethods: []string{http.MethodGet},
+		})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("GET_NewToken", func(b *testing.B) {
+		handler := CSRF(config.CSRFConfig{
+			HMACKey:       key,
+			ExemptMethods: []string{}, // GET is not exempt, will generate token
+		})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("POST_ValidToken", func(b *testing.B) {
+		handler := CSRF(config.CSRFConfig{HMACKey: key})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		// Pre-generate a valid token
+		token, _ := generateToken(key)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			req.Header.Set("X-CSRF-Token", token)
+			req.AddCookie(&http.Cookie{Name: "csrf_token", Value: token})
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("POST_InvalidToken", func(b *testing.B) {
+		handler := CSRF(config.CSRFConfig{HMACKey: key})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		validToken, _ := generateToken(key)
+		invalidToken, _ := generateToken(key)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			req.Header.Set("X-CSRF-Token", invalidToken)
+			req.AddCookie(&http.Cookie{Name: "csrf_token", Value: validToken})
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("POST_MissingToken", func(b *testing.B) {
+		handler := CSRF(config.CSRFConfig{HMACKey: key})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+		}
+	})
+}
+
+// BenchmarkCSRF_TokenFormatValidation measures token format validation
+func BenchmarkCSRF_TokenFormatValidation(b *testing.B) {
+	key := []byte("test-key-32-bytes-long-for-hmac!!")
+	validToken, _ := generateToken(key)
+
+	cases := []struct {
+		name  string
+		token string
+	}{
+		{"Valid", validToken},
+		{"Empty", ""},
+		{"InvalidBase64", "!!!not-base64!!!"},
+		{"TooShort", base64.RawURLEncoding.EncodeToString([]byte("short"))},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				_ = validateTokenFormat(tc.token)
+			}
+		})
+	}
+}
+
+// BenchmarkCSRF_ParseTokenLookup measures token lookup parsing
+func BenchmarkCSRF_ParseTokenLookup(b *testing.B) {
+	lookups := []string{
+		"header:X-CSRF-Token",
+		"form:csrf_token",
+		"query:csrf_token",
+		"invalid", // falls back to default
+	}
+
+	for _, lookup := range lookups {
+		name := strings.ReplaceAll(lookup, ":", "_")
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				_, _ = parseTokenLookup(lookup)
+			}
+		})
+	}
+}
+
+// BenchmarkCSRF_SetCookie measures cookie setting overhead
+func BenchmarkCSRF_SetCookie(b *testing.B) {
+	cfg := config.CSRFConfig{
+		CookieName:     "csrf_token",
+		CookieMaxAge:   86400,
+		CookiePath:     "/",
+		CookieDomain:   "",
+		CookieSecure:   boolPtr(true),
+		CookieSameSite: http.SameSiteStrictMode,
+	}
+	token := "test-csrf-token-value"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		w := httptest.NewRecorder()
+		setCSRFCookie(w, cfg, token)
+	}
+}
+
+// BenchmarkCSRF_ExemptPaths measures exempt path checking
+func BenchmarkCSRF_ExemptPaths(b *testing.B) {
+	key := []byte("test-key-32-bytes-long-for-hmac!!")
+	exemptPaths := []string{"/api/*", "/health", "/static/*"}
+
+	handler := CSRF(config.CSRFConfig{
+		HMACKey:     key,
+		ExemptPaths: exemptPaths,
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	b.Run("ExemptPath", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodPost, "/health", nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("NonExemptPath", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodPost, "/api/users", nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+		}
+	})
+}
+
+// BenchmarkCSRF_Concurrent measures concurrent token operations
+func BenchmarkCSRF_Concurrent(b *testing.B) {
+	key := []byte("test-key-32-bytes-long-for-hmac!!")
+
+	b.Run("TokenGeneration", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				_, _ = generateToken(key)
+			}
+		})
+	})
+
+	b.Run("TokenValidation", func(b *testing.B) {
+		token, _ := generateToken(key)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				_ = compareTokens(token, token, key)
+			}
+		})
+	})
+
+	b.Run("Middleware_GET", func(b *testing.B) {
+		handler := CSRF(config.CSRFConfig{
+			HMACKey:       key,
+			ExemptMethods: []string{http.MethodGet},
+		})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				w := httptest.NewRecorder()
+				handler.ServeHTTP(w, req)
+			}
+		})
+	})
+
+	b.Run("Middleware_POST_Valid", func(b *testing.B) {
+		handler := CSRF(config.CSRFConfig{HMACKey: key})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		token, _ := generateToken(key)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				req := httptest.NewRequest(http.MethodPost, "/", nil)
+				req.Header.Set("X-CSRF-Token", token)
+				req.AddCookie(&http.Cookie{Name: "csrf_token", Value: token})
+				w := httptest.NewRecorder()
+				handler.ServeHTTP(w, req)
+			}
+		})
+	})
+}
+
+// BenchmarkCSRF_HMACComparison compares HMAC operations at different levels
+func BenchmarkCSRF_HMACComparison(b *testing.B) {
+	key := []byte("test-key-32-bytes-long-for-hmac!!")
+	data := make([]byte, 32)
+	rand.Read(data)
+
+	b.Run("HMAC_Generate", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			mac := hmac.New(sha256.New, key)
+			mac.Write(data)
+			_ = mac.Sum(nil)
+		}
+	})
+
+	b.Run("HMAC_Verify", func(b *testing.B) {
+		mac := hmac.New(sha256.New, key)
+		mac.Write(data)
+		signature := mac.Sum(nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			mac2 := hmac.New(sha256.New, key)
+			mac2.Write(data)
+			expected := mac2.Sum(nil)
+			_ = subtle.ConstantTimeCompare(signature, expected)
+		}
+	})
+
+	b.Run("Base64_Encode", func(b *testing.B) {
+		combined := append(data, make([]byte, sha256.Size)...)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_ = base64.RawURLEncoding.EncodeToString(combined)
+		}
+	})
+
+	b.Run("Base64_Decode", func(b *testing.B) {
+		combined := append(data, make([]byte, sha256.Size)...)
+		encoded := base64.RawURLEncoding.EncodeToString(combined)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_, _ = base64.RawURLEncoding.DecodeString(encoded)
+		}
+	})
+}
+
+// boolPtr is a helper to get a pointer to a bool
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/middleware/etag_bench_test.go
+++ b/middleware/etag_bench_test.go
@@ -1,0 +1,379 @@
+package middleware
+
+import (
+	"bytes"
+	"crypto/md5"
+	"fmt"
+	"hash"
+	"hash/fnv"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/alexferl/zerohttp/config"
+)
+
+// BenchmarkETag_HashAlgorithms compares FNV vs MD5 hashing performance
+func BenchmarkETag_HashAlgorithms(b *testing.B) {
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"100B", 100},
+		{"1KB", 1024},
+		{"10KB", 10 * 1024},
+		{"100KB", 100 * 1024},
+	}
+
+	for _, s := range sizes {
+		data := make([]byte, s.size)
+
+		b.Run("FNV/"+s.name, func(b *testing.B) {
+			h := fnv.New64a()
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				h.Reset()
+				h.Write(data)
+				_ = h.Sum64()
+			}
+		})
+
+		b.Run("MD5/"+s.name, func(b *testing.B) {
+			h := md5.New()
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				h.Reset()
+				h.Write(data)
+				_ = h.Sum(nil)
+			}
+		})
+	}
+}
+
+// BenchmarkETag_GenerateETag measures ETag generation with different algorithms
+func BenchmarkETag_GenerateETag(b *testing.B) {
+	sizes := []int{100, 1024, 10240}
+
+	for _, size := range sizes {
+		data := make([]byte, size)
+
+		b.Run(fmt.Sprintf("FNV_%dB", size), func(b *testing.B) {
+			ew := &etagResponseWriter{
+				config: config.ETagConfig{Algorithm: config.FNV},
+				buf:    bytes.NewBuffer(data),
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				_ = ew.generateETag()
+			}
+		})
+
+		b.Run(fmt.Sprintf("MD5_%dB", size), func(b *testing.B) {
+			ew := &etagResponseWriter{
+				config: config.ETagConfig{Algorithm: config.MD5},
+				buf:    bytes.NewBuffer(data),
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				_ = ew.generateETag()
+			}
+		})
+
+		b.Run(fmt.Sprintf("FNV_Weak_%dB", size), func(b *testing.B) {
+			weak := true
+			ew := &etagResponseWriter{
+				config: config.ETagConfig{Algorithm: config.FNV, Weak: &weak},
+				buf:    bytes.NewBuffer(data),
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				_ = ew.generateETag()
+			}
+		})
+	}
+}
+
+// BenchmarkETag_Middleware measures full middleware overhead
+func BenchmarkETag_Middleware(b *testing.B) {
+	sizes := []struct {
+		name string
+		data string
+	}{
+		{"Tiny_100B", strings.Repeat("a", 100)},
+		{"Small_1KB", strings.Repeat("b", 1024)},
+		{"Medium_10KB", strings.Repeat("c", 10*1024)},
+	}
+
+	algorithms := []struct {
+		name string
+		algo config.ETagAlgorithm
+	}{
+		{"FNV", config.FNV},
+		{"MD5", config.MD5},
+	}
+
+	for _, algo := range algorithms {
+		for _, s := range sizes {
+			b.Run(algo.name+"/"+s.name, func(b *testing.B) {
+				handler := ETag(config.ETagConfig{Algorithm: algo.algo})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					_, _ = w.Write([]byte(s.data))
+				}))
+
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for b.Loop() {
+					req := httptest.NewRequest(http.MethodGet, "/", nil)
+					w := httptest.NewRecorder()
+					handler.ServeHTTP(w, req)
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkETag_ConditionalRequests measures If-None-Match handling
+func BenchmarkETag_ConditionalRequests(b *testing.B) {
+	data := "Hello, World!"
+	// Pre-compute the ETag
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(data))
+	etag := fmt.Sprintf(`"%x"`, h.Sum64())
+
+	b.Run("CacheHit_304", func(b *testing.B) {
+		handler := ETag()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(data))
+		}))
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("If-None-Match", etag)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("CacheMiss_200", func(b *testing.B) {
+		handler := ETag()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(data))
+		}))
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("If-None-Match", `"different-etag"`)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("NoConditionalHeader", func(b *testing.B) {
+		handler := ETag()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(data))
+		}))
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+		}
+	})
+}
+
+// BenchmarkETag_Match compares different ETag matching scenarios
+func BenchmarkETag_Match(b *testing.B) {
+	cases := []struct {
+		name        string
+		ifNoneMatch string
+		etag        string
+	}{
+		{"ExactMatch", `"abc123"`, `"abc123"`},
+		{"WeakMatch", `W/"abc123"`, `W/"abc123"`},
+		{"MixedWeakStrong", `W/"abc123"`, `"abc123"`},
+		{"Wildcard", `*`, `"anything"`},
+		{"NoMatch", `"different"`, `"abc123"`},
+		{"MultipleValues", `"other", "abc123"`, `"abc123"`},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				_ = etagMatches(tc.ifNoneMatch, tc.etag)
+			}
+		})
+	}
+}
+
+// BenchmarkETag_PooledVsNew compares pooled hash instances vs new allocations
+func BenchmarkETag_PooledVsNew(b *testing.B) {
+	data := make([]byte, 1024)
+
+	b.Run("Pooled_FNV", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			h := fnvHashPool.Get().(hash.Hash64)
+			h.Reset()
+			_, _ = h.Write(data)
+			_ = h.Sum64()
+			fnvHashPool.Put(h)
+		}
+	})
+
+	b.Run("New_FNV", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			h := fnv.New64a()
+			_, _ = h.Write(data)
+			_ = h.Sum64()
+		}
+	})
+
+	b.Run("Pooled_MD5", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			h := md5HashPool.Get().(hash.Hash)
+			h.Reset()
+			h.Write(data)
+			_ = h.Sum(nil)
+			md5HashPool.Put(h)
+		}
+	})
+
+	b.Run("New_MD5", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			h := md5.New()
+			h.Write(data)
+			_ = h.Sum(nil)
+		}
+	})
+}
+
+// BenchmarkETag_FileETag measures file ETag generation
+func BenchmarkETag_FileETag(b *testing.B) {
+	b.Run("Weak", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_ = GenerateFileETag(1709999999, 1024*1024*100, true)
+		}
+	})
+
+	b.Run("Strong", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_ = GenerateFileETag(1709999999, 1024*1024*100, false)
+		}
+	})
+}
+
+// BenchmarkETag_ParseETag measures ETag parsing
+func BenchmarkETag_ParseETag(b *testing.B) {
+	cases := []struct {
+		name string
+		etag string
+	}{
+		{"Weak", `W/"abc123"`},
+		{"Strong", `"abc123"`},
+		{"NoQuotes", `abc123`},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				_, _ = ParseETag(tc.etag)
+			}
+		})
+	}
+}
+
+// BenchmarkETag_BufferPool measures buffer pooling efficiency
+func BenchmarkETag_BufferPool(b *testing.B) {
+	sizes := []int{100, 1024, 10240}
+
+	for _, size := range sizes {
+		data := make([]byte, size)
+
+		b.Run(fmt.Sprintf("Pooled_%dB", size), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				buf := etagBufferPool.Get().(*bytes.Buffer)
+				buf.Write(data)
+				_ = buf.Len()
+				buf.Reset()
+				etagBufferPool.Put(buf)
+			}
+		})
+
+		b.Run(fmt.Sprintf("New_%dB", size), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				buf := &bytes.Buffer{}
+				buf.Write(data)
+				_ = buf.Len()
+			}
+		})
+	}
+}
+
+// BenchmarkETag_Concurrent measures concurrent ETag generation
+func BenchmarkETag_Concurrent(b *testing.B) {
+	data := strings.Repeat("x", 1024)
+	handler := ETag()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(data))
+	}))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+		}
+	})
+}

--- a/middleware/hmac_auth_bench_test.go
+++ b/middleware/hmac_auth_bench_test.go
@@ -1,0 +1,295 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alexferl/zerohttp/config"
+)
+
+// BenchmarkHMAC_SignRequest measures HMAC request signing performance
+func BenchmarkHMAC_SignRequest(b *testing.B) {
+	algorithms := []config.HMACHashAlgorithm{
+		config.HMACSHA256,
+		config.HMACSHA384,
+		config.HMACSHA512,
+	}
+
+	for _, algo := range algorithms {
+		b.Run(string(algo), func(b *testing.B) {
+			secret := strings.Repeat("a", 64) // 64 bytes for SHA512
+			signer := NewHMACSignerWithAlgorithm("access-key", secret, algo)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+			req.Host = "example.com"
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				// Need fresh request each time since body is consumed
+				r := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+				r.Host = "example.com"
+				_ = signer.SignRequest(r)
+			}
+		})
+	}
+}
+
+// BenchmarkHMAC_VerifySignature measures signature verification performance
+func BenchmarkHMAC_VerifySignature(b *testing.B) {
+	algorithms := []config.HMACHashAlgorithm{
+		config.HMACSHA256,
+		config.HMACSHA384,
+		config.HMACSHA512,
+	}
+
+	for _, algo := range algorithms {
+		b.Run(string(algo), func(b *testing.B) {
+			secret := strings.Repeat("a", 64)
+			signer := NewHMACSignerWithAlgorithm("access-key", secret, algo)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+			req.Host = "example.com"
+			_ = signer.SignRequest(req)
+
+			authHeader := req.Header.Get("Authorization")
+			timestamp := req.Header.Get("X-Timestamp")
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				// Verify by computing signature
+				_ = authHeader
+				canonical := "GET\n/api/test\n\nhost:example.com\nx-timestamp:" + timestamp + "\n\nUNSIGNED-PAYLOAD"
+				_ = computeHMACSignature(secret, canonical, algo)
+			}
+		})
+	}
+}
+
+// BenchmarkHMAC_AuthMiddleware measures the full HMAC auth middleware
+func BenchmarkHMAC_AuthMiddleware(b *testing.B) {
+	secret := strings.Repeat("a", 32)
+
+	credentialStore := func(accessKeyID string) []string {
+		if accessKeyID == "test-key" {
+			return []string{secret}
+		}
+		return nil
+	}
+
+	handler := HMACAuth(config.HMACAuthConfig{
+		CredentialStore: credentialStore,
+		Algorithm:       config.HMACSHA256,
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	signer := NewHMACSigner("test-key", secret)
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	req.Host = "example.com"
+	_ = signer.SignRequest(req)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+	}
+}
+
+// BenchmarkHMAC_AuthMiddleware_Scenarios measures different HMAC auth scenarios
+func BenchmarkHMAC_AuthMiddleware_Scenarios(b *testing.B) {
+	secret := strings.Repeat("a", 32)
+
+	credentialStore := func(accessKeyID string) []string {
+		if accessKeyID == "test-key" {
+			return []string{secret}
+		}
+		return nil
+	}
+
+	scenarios := []struct {
+		name         string
+		setupRequest func(*http.Request)
+	}{
+		{
+			name: "Valid",
+			setupRequest: func(req *http.Request) {
+				signer := NewHMACSigner("test-key", secret)
+				req.Host = "example.com"
+				_ = signer.SignRequest(req)
+			},
+		},
+		{
+			name: "MissingAuth",
+			setupRequest: func(req *http.Request) {
+				// Don't add auth header
+			},
+		},
+		{
+			name: "InvalidSignature",
+			setupRequest: func(req *http.Request) {
+				signer := NewHMACSigner("test-key", secret)
+				req.Host = "example.com"
+				_ = signer.SignRequest(req)
+				req.Header.Set("Authorization", req.Header.Get("Authorization")+"tampered")
+			},
+		},
+		{
+			name: "ExpiredTimestamp",
+			setupRequest: func(req *http.Request) {
+				req.Header.Set("Authorization", "HMAC-SHA256 Credential=test-key/2020-01-01T00:00:00Z, SignedHeaders=host;x-timestamp, Signature=aW52YWxpZA==")
+				req.Header.Set("X-Timestamp", "2020-01-01T00:00:00Z")
+			},
+		},
+	}
+
+	for _, s := range scenarios {
+		b.Run(s.name, func(b *testing.B) {
+			handler := HMACAuth(config.HMACAuthConfig{
+				CredentialStore: credentialStore,
+				Algorithm:       config.HMACSHA256,
+			})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+				s.setupRequest(req)
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+			}
+		})
+	}
+}
+
+// BenchmarkHMAC_PresignedURL measures presigned URL generation and validation
+func BenchmarkHMAC_PresignedURL(b *testing.B) {
+	b.Run("Generate", func(b *testing.B) {
+		secret := strings.Repeat("a", 32)
+		signer := NewHMACSigner("test-key", secret)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/resource", nil)
+		req.Host = "example.com"
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			r := httptest.NewRequest(http.MethodGet, "/api/resource", nil)
+			r.Host = "example.com"
+			_, _ = signer.PresignURL(r, time.Hour)
+		}
+	})
+
+	b.Run("Validate", func(b *testing.B) {
+		secret := strings.Repeat("a", 32)
+		signer := NewHMACSigner("test-key", secret)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/resource", nil)
+		req.Host = "example.com"
+		presignedURL, _ := signer.PresignURL(req, time.Hour)
+
+		parsedReq := httptest.NewRequest(http.MethodGet, presignedURL, nil)
+		parsedReq.Host = "example.com"
+
+		credentialStore := func(accessKeyID string) []string {
+			if accessKeyID == "test-key" {
+				return []string{secret}
+			}
+			return nil
+		}
+
+		handler := HMACAuth(config.HMACAuthConfig{
+			CredentialStore:    credentialStore,
+			Algorithm:          config.HMACSHA256,
+			AllowPresignedURLs: true,
+		})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, parsedReq)
+		}
+	})
+}
+
+// BenchmarkHMAC_CanonicalRequest measures canonical request building
+func BenchmarkHMAC_CanonicalRequest(b *testing.B) {
+	b.Run("Simple", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+		req.Host = "example.com"
+
+		parsed := &parsedAuth{
+			Headers: []string{"host", "x-timestamp"},
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_ = buildCanonicalRequest(req, parsed, nil, nil, "UNSIGNED-PAYLOAD", "X-Timestamp")
+		}
+	})
+
+	b.Run("WithQueryParams", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "/api/test?foo=bar&baz=qux", nil)
+		req.Host = "example.com"
+
+		parsed := &parsedAuth{
+			Headers: []string{"host", "x-timestamp"},
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_ = buildCanonicalRequest(req, parsed, nil, nil, "UNSIGNED-PAYLOAD", "X-Timestamp")
+		}
+	})
+
+	b.Run("WithBody", func(b *testing.B) {
+		parsed := &parsedAuth{
+			Headers: []string{"host", "x-timestamp", "content-type"},
+		}
+
+		bodyHash := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			body := strings.NewReader(`{"key":"value"}`)
+			r := httptest.NewRequest(http.MethodPost, "/api/test", body)
+			r.Host = "example.com"
+			r.Header.Set("Content-Type", "application/json")
+			_ = buildCanonicalRequest(r, parsed, nil, nil, bodyHash, "X-Timestamp")
+		}
+	})
+}
+
+// BenchmarkHMAC_ParseAuthorizationHeader measures authorization header parsing
+func BenchmarkHMAC_ParseAuthorizationHeader(b *testing.B) {
+	header := "HMAC-SHA256 Credential=test-key/2024-01-15T10:30:00Z, SignedHeaders=host;x-timestamp, Signature=AbCdEf123="
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		_, _ = parseAuthorizationHeader(header, "X-Timestamp")
+	}
+}

--- a/middleware/jwt_auth_bench_test.go
+++ b/middleware/jwt_auth_bench_test.go
@@ -1,0 +1,292 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alexferl/zerohttp/config"
+)
+
+// BenchmarkJWT_HS256_Generate measures token generation performance
+func BenchmarkJWT_HS256_Generate(b *testing.B) {
+	store := NewHS256TokenStore([]byte("this-is-a-32-byte-secret-key-for-tests!!"), HS256Options{
+		Issuer: "test-app",
+	})
+
+	claims := HS256Claims{
+		"sub":   "user123",
+		"name":  "Test User",
+		"email": "test@example.com",
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		_, _ = store.Generate(claims, config.AccessToken)
+	}
+}
+
+// BenchmarkJWT_HS256_Validate measures token validation performance
+func BenchmarkJWT_HS256_Validate(b *testing.B) {
+	store := NewHS256TokenStore([]byte("this-is-a-32-byte-secret-key-for-tests!!"), HS256Options{
+		Issuer: "test-app",
+	})
+
+	claims := HS256Claims{
+		"sub":   "user123",
+		"name":  "Test User",
+		"email": "test@example.com",
+	}
+
+	token, _ := store.Generate(claims, config.AccessToken)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		_, _ = store.Validate(token)
+	}
+}
+
+// BenchmarkJWT_HS256_ClaimSizes measures performance with different claim sizes
+func BenchmarkJWT_HS256_ClaimSizes(b *testing.B) {
+	store := NewHS256TokenStore([]byte("this-is-a-32-byte-secret-key-for-tests!!"), HS256Options{})
+
+	sizes := []struct {
+		name   string
+		claims HS256Claims
+	}{
+		{
+			name:   "Minimal",
+			claims: HS256Claims{"sub": "user123"},
+		},
+		{
+			name: "Small",
+			claims: HS256Claims{
+				"sub":   "user123",
+				"name":  "Test User",
+				"email": "test@example.com",
+			},
+		},
+		{
+			name: "Medium",
+			claims: HS256Claims{
+				"sub":         "user123",
+				"name":        "Test User",
+				"email":       "test@example.com",
+				"role":        "admin",
+				"org":         "acme",
+				"department":  "engineering",
+				"permissions": []string{"read", "write", "delete"},
+			},
+		},
+		{
+			name: "Large",
+			claims: func() HS256Claims {
+				c := HS256Claims{
+					"sub":   "user123",
+					"name":  "Test User",
+					"email": "test@example.com",
+				}
+				for i := range 20 {
+					c[fmt.Sprintf("custom_claim_%d", i)] = fmt.Sprintf("value_%d", i)
+				}
+				return c
+			}(),
+		},
+	}
+
+	for _, s := range sizes {
+		b.Run(s.name+"/Generate", func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				_, _ = store.Generate(s.claims, config.AccessToken)
+			}
+		})
+
+		token, _ := store.Generate(s.claims, config.AccessToken)
+
+		b.Run(s.name+"/Validate", func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				_, _ = store.Validate(token)
+			}
+		})
+	}
+}
+
+// BenchmarkJWT_AuthMiddleware measures the full JWT middleware
+func BenchmarkJWT_AuthMiddleware(b *testing.B) {
+	store := NewHS256TokenStore([]byte("this-is-a-32-byte-secret-key-for-tests!!"), HS256Options{})
+
+	handler := JWTAuth(config.JWTAuthConfig{
+		TokenStore:     store,
+		RequiredClaims: []string{"sub"},
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	claims := HS256Claims{"sub": "user123", "name": "Test User"}
+	token, _ := store.Generate(claims, config.AccessToken)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+	}
+}
+
+// BenchmarkJWT_AuthMiddleware_Scenarios measures different JWT auth scenarios
+func BenchmarkJWT_AuthMiddleware_Scenarios(b *testing.B) {
+	store := NewHS256TokenStore([]byte("this-is-a-32-byte-secret-key-for-tests!!"), HS256Options{})
+
+	validClaims := HS256Claims{"sub": "user123", "name": "Test User"}
+	validToken, _ := store.Generate(validClaims, config.AccessToken)
+
+	scenarios := []struct {
+		name  string
+		token string
+	}{
+		{"Valid", validToken},
+		{"Missing", ""},
+		{"InvalidFormat", "invalid-token"},
+		{"InvalidSignature", validToken[:len(validToken)-10] + "tampered!!"},
+	}
+
+	for _, s := range scenarios {
+		b.Run(s.name, func(b *testing.B) {
+			handler := JWTAuth(config.JWTAuthConfig{
+				TokenStore: store,
+			})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			if s.token != "" {
+				req.Header.Set("Authorization", "Bearer "+s.token)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+			}
+		})
+	}
+}
+
+// BenchmarkJWT_ClaimsExtraction measures claims extraction performance
+func BenchmarkJWT_ClaimsExtraction(b *testing.B) {
+	store := NewHS256TokenStore([]byte("this-is-a-32-byte-secret-key-for-tests!!"), HS256Options{
+		Issuer:   "test-app",
+		Audience: "test-api",
+	})
+
+	claims := HS256Claims{
+		"sub":   "user123",
+		"iss":   "test-app",
+		"aud":   "test-api",
+		"jti":   "token-id-123",
+		"scope": "read write delete",
+	}
+
+	token, _ := store.Generate(claims, config.AccessToken)
+	validatedClaims, _ := store.Validate(token)
+
+	jwtClaims := JWTClaims{claims: validatedClaims}
+
+	b.Run("Subject", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = jwtClaims.Subject()
+		}
+	})
+
+	b.Run("Issuer", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = jwtClaims.Issuer()
+		}
+	})
+
+	b.Run("Audience", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = jwtClaims.Audience()
+		}
+	})
+
+	b.Run("Scopes", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = jwtClaims.Scopes()
+		}
+	})
+
+	b.Run("HasScope", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = jwtClaims.HasScope("write")
+		}
+	})
+}
+
+// BenchmarkJWT_RequiredClaims measures required claims validation overhead
+func BenchmarkJWT_RequiredClaims(b *testing.B) {
+	store := NewHS256TokenStore([]byte("this-is-a-32-byte-secret-key-for-tests!!"), HS256Options{})
+
+	claims := HS256Claims{
+		"sub":  "user123",
+		"name": "Test User",
+		"org":  "acme",
+	}
+	token, _ := store.Generate(claims, config.AccessToken)
+
+	requiredClaimsCounts := []int{1, 3, 5}
+
+	for _, count := range requiredClaimsCounts {
+		b.Run(fmt.Sprintf("Claims%d", count), func(b *testing.B) {
+			required := make([]string, count)
+			for i := range count {
+				required[i] = []string{"sub", "name", "org", "email", "role"}[i]
+			}
+
+			handler := JWTAuth(config.JWTAuthConfig{
+				TokenStore:     store,
+				RequiredClaims: required,
+			})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+			}
+		})
+	}
+}

--- a/middleware/rate_limit_store_bench_test.go
+++ b/middleware/rate_limit_store_bench_test.go
@@ -1,0 +1,308 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alexferl/zerohttp/config"
+)
+
+// BenchmarkInMemoryStore_Algorithms compares the three rate limiting algorithms
+// to help users choose the right one for their use case.
+func BenchmarkInMemoryStore_Algorithms(b *testing.B) {
+	algorithms := []struct {
+		name      string
+		algorithm config.RateLimitAlgorithm
+	}{
+		{"TokenBucket", config.TokenBucket},
+		{"FixedWindow", config.FixedWindow},
+		{"SlidingWindow", config.SlidingWindow},
+	}
+
+	for _, alg := range algorithms {
+		b.Run(alg.name, func(b *testing.B) {
+			store := NewInMemoryStore(alg.algorithm, time.Minute, 1000, 10000)
+			ctx := context.Background()
+			now := time.Now()
+			key := "single-key"
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				store.CheckAndRecord(ctx, key, now)
+			}
+		})
+	}
+}
+
+// BenchmarkInMemoryStore_KeyCount measures performance as the number of
+// tracked keys increases. This helps understand memory and lookup overhead.
+func BenchmarkInMemoryStore_KeyCount(b *testing.B) {
+	keyCounts := []int{1, 10, 100, 1000, 10000}
+
+	for _, count := range keyCounts {
+		b.Run(fmt.Sprintf("Keys%d", count), func(b *testing.B) {
+			store := NewInMemoryStore(config.TokenBucket, time.Minute, 1000, count*2)
+			ctx := context.Background()
+			now := time.Now()
+
+			// Pre-populate with keys
+			keys := make([]string, count)
+			for i := 0; i < count; i++ {
+				keys[i] = fmt.Sprintf("key-%d", i)
+				store.CheckAndRecord(ctx, keys[i], now)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			i := 0
+			for b.Loop() {
+				store.CheckAndRecord(ctx, keys[i%count], now)
+				i++
+			}
+		})
+	}
+}
+
+// BenchmarkInMemoryStore_Concurrent measures performance under concurrent access
+// which is the typical production scenario.
+func BenchmarkInMemoryStore_Concurrent(b *testing.B) {
+	concurrencyLevels := []int{1, 10, 100, 1000}
+
+	for _, concurrency := range concurrencyLevels {
+		b.Run(fmt.Sprintf("Goroutines%d", concurrency), func(b *testing.B) {
+			store := NewInMemoryStore(config.TokenBucket, time.Minute, 1000, 10000)
+			ctx := context.Background()
+			now := time.Now()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			b.RunParallel(func(pb *testing.PB) {
+				key := fmt.Sprintf("key-%d", concurrency)
+				for pb.Next() {
+					store.CheckAndRecord(ctx, key, now)
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkInMemoryStore_Concurrent_DifferentKeys measures concurrent performance
+// with different key distributions (some keys hot, others cold).
+func BenchmarkInMemoryStore_Concurrent_DifferentKeys(b *testing.B) {
+	scenarios := []struct {
+		name    string
+		numKeys int
+		hotKeys int // Number of keys that get 90% of traffic
+	}{
+		{"SingleKey", 1, 1},
+		{"10Keys_Hot", 10, 2},
+		{"100Keys_Hot", 100, 10},
+		{"1000Keys_Uniform", 1000, 1000}, // Uniform distribution
+	}
+
+	for _, scenario := range scenarios {
+		b.Run(scenario.name, func(b *testing.B) {
+			store := NewInMemoryStore(config.TokenBucket, time.Minute, 1000, scenario.numKeys*2)
+			ctx := context.Background()
+			now := time.Now()
+
+			keys := make([]string, scenario.numKeys)
+			for i := 0; i < scenario.numKeys; i++ {
+				keys[i] = fmt.Sprintf("key-%d", i)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			b.RunParallel(func(pb *testing.PB) {
+				i := 0
+				for pb.Next() {
+					// 90% of requests go to hot keys
+					var key string
+					if i%10 < 9 {
+						key = keys[i%scenario.hotKeys]
+					} else {
+						key = keys[i%scenario.numKeys]
+					}
+					store.CheckAndRecord(ctx, key, now)
+					i++
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkInMemoryStore_TokenBucketRefill measures token bucket refill performance
+// over time as tokens are consumed and refilled.
+func BenchmarkInMemoryStore_TokenBucketRefill(b *testing.B) {
+	store := NewInMemoryStore(config.TokenBucket, time.Second, 1000, 10000)
+	ctx := context.Background()
+	baseTime := time.Now()
+	key := "test-key"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		// Simulate time passing and tokens being refilled
+		now := baseTime.Add(time.Duration(b.N%1000) * time.Millisecond)
+		store.CheckAndRecord(ctx, key, now)
+	}
+}
+
+// BenchmarkInMemoryStore_SlidingWindowExpiration measures sliding window performance
+// with timestamp expiration (removing old entries).
+func BenchmarkInMemoryStore_SlidingWindowExpiration(b *testing.B) {
+	window := 100 * time.Millisecond
+	store := NewInMemoryStore(config.SlidingWindow, window, 100, 10000)
+	ctx := context.Background()
+	baseTime := time.Now()
+	key := "test-key"
+
+	// Pre-fill with some timestamps
+	for i := 0; i < 50; i++ {
+		store.CheckAndRecord(ctx, key, baseTime.Add(time.Duration(i)*time.Millisecond))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		now := baseTime.Add(time.Duration(b.N%200) * time.Millisecond)
+		store.CheckAndRecord(ctx, key, now)
+	}
+}
+
+// BenchmarkInMemoryStore_Eviction measures performance when keys are being
+// evicted due to reaching max keys limit.
+func BenchmarkInMemoryStore_Eviction(b *testing.B) {
+	maxKeys := 100
+	store := NewInMemoryStore(config.TokenBucket, time.Minute, 100, maxKeys)
+	ctx := context.Background()
+	now := time.Now()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	// Each iteration creates a new key, causing evictions
+	for b.Loop() {
+		key := fmt.Sprintf("key-%d", b.N)
+		store.CheckAndRecord(ctx, key, now)
+	}
+}
+
+// BenchmarkInMemoryStore_PerAlgorithm_Details provides detailed benchmarks
+// for each algorithm under different rates and window sizes.
+func BenchmarkInMemoryStore_PerAlgorithm_Details(b *testing.B) {
+	testCases := []struct {
+		name   string
+		alg    config.RateLimitAlgorithm
+		rate   int
+		window time.Duration
+	}{
+		{"TokenBucket_HighRate", config.TokenBucket, 10000, time.Second},
+		{"TokenBucket_LowRate", config.TokenBucket, 10, time.Second},
+		{"TokenBucket_LongWindow", config.TokenBucket, 1000, time.Hour},
+		{"FixedWindow_HighRate", config.FixedWindow, 10000, time.Second},
+		{"FixedWindow_LowRate", config.FixedWindow, 10, time.Second},
+		{"SlidingWindow_HighRate", config.SlidingWindow, 10000, time.Second},
+		{"SlidingWindow_LowRate", config.SlidingWindow, 10, time.Second},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			store := NewInMemoryStore(tc.alg, tc.window, tc.rate, 10000)
+			ctx := context.Background()
+			now := time.Now()
+			key := "test-key"
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				store.CheckAndRecord(ctx, key, now)
+			}
+		})
+	}
+}
+
+// BenchmarkInMemoryStore_AllAlgorithms_Concurrent compares all three algorithms
+// under the same concurrent workload.
+func BenchmarkInMemoryStore_AllAlgorithms_Concurrent(b *testing.B) {
+	algorithms := []config.RateLimitAlgorithm{
+		config.TokenBucket,
+		config.FixedWindow,
+		config.SlidingWindow,
+	}
+
+	for _, alg := range algorithms {
+		b.Run(string(alg), func(b *testing.B) {
+			store := NewInMemoryStore(alg, time.Minute, 1000, 10000)
+			ctx := context.Background()
+			now := time.Now()
+
+			// Simulate many different clients (IPs)
+			numKeys := 1000
+			keys := make([]string, numKeys)
+			for i := 0; i < numKeys; i++ {
+				keys[i] = fmt.Sprintf("192.168.%d.%d", i/256, i%256)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			var counter int
+			var mu sync.Mutex
+
+			b.RunParallel(func(pb *testing.PB) {
+				mu.Lock()
+				idx := counter % numKeys
+				counter++
+				mu.Unlock()
+
+				for pb.Next() {
+					store.CheckAndRecord(ctx, keys[idx], now)
+				}
+			})
+		})
+	}
+}
+
+// Benchmark evictOldest function directly to measure eviction performance
+func BenchmarkEvictOldest(b *testing.B) {
+	sizes := []int{100, 1000, 10000}
+
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("Size%d", size), func(b *testing.B) {
+			// Create a map with entries
+			entries := make(map[string]*bucketEntry, size)
+			baseTime := time.Now()
+
+			for i := 0; i < size; i++ {
+				key := fmt.Sprintf("key-%d", i)
+				entries[key] = &bucketEntry{
+					tokens:     10,
+					capacity:   10,
+					lastAccess: baseTime.Add(time.Duration(i) * time.Millisecond),
+				}
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				// Make a copy since evictOldest modifies the map
+				entriesCopy := make(map[string]*bucketEntry, len(entries))
+				for k, v := range entries {
+					entriesCopy[k] = v
+				}
+				evictOldest(entriesCopy)
+			}
+		})
+	}
+}

--- a/middleware/request_logger_bench_test.go
+++ b/middleware/request_logger_bench_test.go
@@ -1,0 +1,408 @@
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/log"
+)
+
+// noopLogger is a logger that discards all output for benchmarking
+type noopLogger struct{}
+
+func (n *noopLogger) Debug(msg string, fields ...log.Field)      {}
+func (n *noopLogger) Info(msg string, fields ...log.Field)       {}
+func (n *noopLogger) Warn(msg string, fields ...log.Field)       {}
+func (n *noopLogger) Error(msg string, fields ...log.Field)      {}
+func (n *noopLogger) Panic(msg string, fields ...log.Field)      {}
+func (n *noopLogger) Fatal(msg string, fields ...log.Field)      {}
+func (n *noopLogger) WithFields(fields ...log.Field) log.Logger  { return n }
+func (n *noopLogger) WithContext(ctx context.Context) log.Logger { return n }
+
+// BenchmarkRequestLogger_FieldConfiguration measures overhead with different field sets
+func BenchmarkRequestLogger_FieldConfiguration(b *testing.B) {
+	fieldConfigs := []struct {
+		name   string
+		fields []config.LogField
+	}{
+		{"Minimal", []config.LogField{config.FieldMethod, config.FieldPath, config.FieldStatus}},
+		{"Default", config.DefaultRequestLoggerConfig.Fields},
+		{"AllFields", []config.LogField{
+			config.FieldMethod, config.FieldURI, config.FieldPath, config.FieldHost,
+			config.FieldProtocol, config.FieldReferer, config.FieldUserAgent,
+			config.FieldStatus, config.FieldDurationNS, config.FieldDurationHuman,
+			config.FieldRemoteAddr, config.FieldClientIP, config.FieldRequestID,
+		}},
+	}
+
+	for _, fc := range fieldConfigs {
+		b.Run(fc.name, func(b *testing.B) {
+			logger := &noopLogger{}
+			mw := RequestLogger(logger, config.RequestLoggerConfig{
+				Fields: fc.fields,
+			})
+
+			handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set("X-Request-Id", "test-123")
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+			}
+		})
+	}
+}
+
+// BenchmarkRequestLogger_BodyCapturing measures body capture overhead
+func BenchmarkRequestLogger_BodyCapturing(b *testing.B) {
+	bodySizes := []struct {
+		name string
+		size int
+	}{
+		{"NoBody", 0},
+		{"100B", 100},
+		{"1KB", 1024},
+		{"10KB", 10 * 1024},
+	}
+
+	for _, bs := range bodySizes {
+		b.Run("RequestBody_"+bs.name, func(b *testing.B) {
+			logger := &noopLogger{}
+			mw := RequestLogger(logger, config.RequestLoggerConfig{
+				Fields:         []config.LogField{config.FieldMethod, config.FieldRequestBody},
+				LogRequestBody: true,
+				MaxBodySize:    1024,
+			})
+
+			bodyData := bytes.Repeat([]byte("x"), bs.size)
+
+			handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.Copy(io.Discard, r.Body)
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				rr := httptest.NewRecorder()
+				req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(bodyData))
+				handler.ServeHTTP(rr, req)
+			}
+		})
+
+		b.Run("ResponseBody_"+bs.name, func(b *testing.B) {
+			logger := &noopLogger{}
+			mw := RequestLogger(logger, config.RequestLoggerConfig{
+				Fields:          []config.LogField{config.FieldMethod, config.FieldResponseBody},
+				LogResponseBody: true,
+				MaxBodySize:     1024,
+			})
+
+			bodyData := bytes.Repeat([]byte("x"), bs.size)
+
+			handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write(bodyData)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(bs.size))
+			b.ResetTimer()
+
+			for b.Loop() {
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+			}
+		})
+	}
+}
+
+// BenchmarkRequestLogger_SensitiveDataMasking measures JSON masking performance
+func BenchmarkRequestLogger_SensitiveDataMasking(b *testing.B) {
+	testCases := []struct {
+		name string
+		json string
+	}{
+		{"SimpleObject", `{"username":"john","password":"secret123"}`},
+		{"NestedObject", `{"user":{"name":"john","password":"secret"},"data":{"token":"abc123"}}`},
+		{"ArrayOfObjects", `[{"id":1,"password":"pass1"},{"id":2,"password":"pass2"}]`},
+		{"LargeObject", `{"field1":"value1","field2":"value2","password":"secret","token":"abc","key":"xyz","field3":"value3","field4":"value4"}`},
+	}
+
+	sensitiveFields := []string{"password", "token", "key"}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			logger := &noopLogger{}
+			mw := RequestLogger(logger, config.RequestLoggerConfig{
+				Fields:          []config.LogField{config.FieldMethod, config.FieldRequestBody},
+				LogRequestBody:  true,
+				MaxBodySize:     4096,
+				SensitiveFields: sensitiveFields,
+			})
+
+			body := []byte(tc.json)
+
+			handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				rr := httptest.NewRecorder()
+				req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(body))
+				handler.ServeHTTP(rr, req)
+			}
+		})
+	}
+}
+
+// BenchmarkRequestLogger_LogLevelRouting measures log level selection overhead
+func BenchmarkRequestLogger_LogLevelRouting(b *testing.B) {
+	statusCodes := []int{http.StatusOK, http.StatusBadRequest, http.StatusInternalServerError}
+
+	for _, code := range statusCodes {
+		b.Run(http.StatusText(code), func(b *testing.B) {
+			logger := &noopLogger{}
+			mw := RequestLogger(logger, config.RequestLoggerConfig{
+				Fields:    []config.LogField{config.FieldMethod, config.FieldStatus},
+				LogErrors: true,
+			})
+
+			handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(code)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+			}
+		})
+	}
+}
+
+// BenchmarkRequestLogger_ExemptPaths measures exempt path checking overhead
+func BenchmarkRequestLogger_ExemptPaths(b *testing.B) {
+	testCases := []struct {
+		name        string
+		exemptPaths []string
+		path        string
+	}{
+		{"NoExemptions", nil, "/api/users"},
+		{"OneExemption", []string{"/health"}, "/api/users"},
+		{"ManyExemptions", []string{"/health", "/metrics", "/ready", "/live"}, "/api/users"},
+		{"ExemptMatch", []string{"/health"}, "/health"},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			logger := &noopLogger{}
+			mw := RequestLogger(logger, config.RequestLoggerConfig{
+				Fields:      []config.LogField{config.FieldMethod, config.FieldPath},
+				ExemptPaths: tc.exemptPaths,
+			})
+
+			handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+			}
+		})
+	}
+}
+
+// BenchmarkRequestLogger_Baseline compares against no middleware
+func BenchmarkRequestLogger_Baseline(b *testing.B) {
+	b.Run("NoMiddleware", func(b *testing.B) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+		}
+	})
+
+	b.Run("WithMiddleware", func(b *testing.B) {
+		logger := &noopLogger{}
+		mw := RequestLogger(logger, config.RequestLoggerConfig{
+			Fields: []config.LogField{config.FieldMethod, config.FieldPath, config.FieldStatus},
+		})
+
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+		}
+	})
+}
+
+// BenchmarkRequestLogger_Concurrent measures concurrent logging performance
+func BenchmarkRequestLogger_Concurrent(b *testing.B) {
+	concurrencyLevels := []int{1, 10, 100}
+
+	for _, concurrency := range concurrencyLevels {
+		b.Run(fmt.Sprintf("Goroutines%d", concurrency), func(b *testing.B) {
+			logger := &noopLogger{}
+			mw := RequestLogger(logger, config.RequestLoggerConfig{
+				Fields: []config.LogField{config.FieldMethod, config.FieldPath, config.FieldStatus},
+			})
+
+			handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					rr := httptest.NewRecorder()
+					handler.ServeHTTP(rr, req)
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkRequestLogger_MaskSensitiveData benchmarks the masking function directly
+func BenchmarkRequestLogger_MaskSensitiveData(b *testing.B) {
+	testCases := []struct {
+		name string
+		data string
+	}{
+		{"SmallObject", `{"password":"secret"}`},
+		{"MediumObject", `{"username":"john","password":"secret123","email":"john@example.com"}`},
+		{"NestedObject", `{"user":{"name":"john","password":"secret"},"api_key":"xyz"}`},
+		{"ArrayOfObjects", `[{"id":1,"password":"pass1"},{"id":2,"password":"pass2"},{"id":3,"password":"pass3"}]`},
+		{"NoSensitive", `{"name":"john","email":"john@example.com"}`},
+	}
+
+	sensitiveFields := []string{"password", "api_key", "secret"}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				maskSensitiveData(tc.data, sensitiveFields)
+			}
+		})
+	}
+}
+
+// BenchmarkRequestLogger_MaskObject benchmarks the maskObject function directly
+func BenchmarkRequestLogger_MaskObject(b *testing.B) {
+	obj := map[string]any{
+		"username": "john",
+		"password": "secret123",
+		"email":    "john@example.com",
+		"nested": map[string]any{
+			"token": "abc123",
+			"data":  "value",
+		},
+	}
+
+	sensitiveFields := []string{"password", "token"}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		maskObject(obj, sensitiveFields)
+	}
+}
+
+// BenchmarkRequestLogger_CaptureRequestBody benchmarks body capture directly
+func BenchmarkRequestLogger_CaptureRequestBody(b *testing.B) {
+	bodySizes := []int{0, 100, 1024, 10 * 1024}
+
+	for _, size := range bodySizes {
+		b.Run(fmt.Sprintf("Size%d", size), func(b *testing.B) {
+			data := bytes.Repeat([]byte("x"), size)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(data))
+				captureRequestBody(req, 1024)
+			}
+		})
+	}
+}
+
+// BenchmarkRequestLogger_LogRequest benchmarks the LogRequest function directly
+func BenchmarkRequestLogger_LogRequest(b *testing.B) {
+	cfg := config.RequestLoggerConfig{
+		Fields: []config.LogField{
+			config.FieldMethod, config.FieldURI, config.FieldPath,
+			config.FieldStatus, config.FieldDurationNS,
+		},
+	}
+
+	fieldMap := make(map[config.LogField]bool)
+	for _, f := range cfg.Fields {
+		fieldMap[f] = true
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/users", nil)
+	req.Header.Set("X-Request-Id", "test-123")
+
+	logger := &noopLogger{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		LogRequest(logger, cfg, fieldMap, req, http.StatusOK, 5*time.Millisecond, "", "")
+	}
+}

--- a/middleware/reverse_proxy_bench_test.go
+++ b/middleware/reverse_proxy_bench_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -8,22 +9,508 @@ import (
 	"github.com/alexferl/zerohttp/config"
 )
 
-func BenchmarkReverseProxy(b *testing.B) {
+// BenchmarkReverseProxy_Baseline measures basic proxy overhead
+func BenchmarkReverseProxy_Baseline(b *testing.B) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("response"))
 	}))
 	defer upstream.Close()
 
-	mw, _ := ReverseProxy(config.ReverseProxyConfig{
+	mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
 		Target: upstream.URL,
 	})
+	defer cleanup()
 
 	handler := mw(nil)
 
+	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
 	}
+}
+
+// BenchmarkReverseProxy_LoadBalancers compares different load balancing algorithms
+func BenchmarkReverseProxy_LoadBalancers(b *testing.B) {
+	// Create 3 upstream servers
+	upstreams := make([]*httptest.Server, 3)
+	for i := range upstreams {
+		upstreams[i] = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer upstreams[i].Close()
+	}
+
+	algorithms := []struct {
+		name string
+		algo config.LoadBalancerAlgorithm
+	}{
+		{"RoundRobin", config.RoundRobin},
+		{"Random", config.Random},
+		{"LeastConnections", config.LeastConnections},
+	}
+
+	for _, tc := range algorithms {
+		b.Run(tc.name, func(b *testing.B) {
+			targets := []config.Backend{
+				{Target: upstreams[0].URL, Weight: 1, Healthy: true},
+				{Target: upstreams[1].URL, Weight: 1, Healthy: true},
+				{Target: upstreams[2].URL, Weight: 1, Healthy: true},
+			}
+
+			mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
+				Targets:       targets,
+				LoadBalancer:  tc.algo,
+			})
+			defer cleanup()
+
+			handler := mw(nil)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+			}
+		})
+	}
+}
+
+// BenchmarkReverseProxy_BackendCount measures performance with different numbers of backends
+func BenchmarkReverseProxy_BackendCount(b *testing.B) {
+	backendCounts := []int{1, 3, 10}
+
+	for _, count := range backendCounts {
+		b.Run(fmt.Sprintf("Backends%d", count), func(b *testing.B) {
+			// Create upstream servers
+			upstreams := make([]*httptest.Server, count)
+			targets := make([]config.Backend, count)
+
+			for i := range upstreams {
+				upstreams[i] = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}))
+				defer upstreams[i].Close()
+				targets[i] = config.Backend{Target: upstreams[i].URL, Weight: 1, Healthy: true}
+			}
+
+			mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
+				Targets:      targets,
+				LoadBalancer: config.RoundRobin,
+			})
+			defer cleanup()
+
+			handler := mw(nil)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+			}
+		})
+	}
+}
+
+// BenchmarkReverseProxy_StripPrefix measures path stripping overhead
+func BenchmarkReverseProxy_StripPrefix(b *testing.B) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	b.Run("WithoutStrip", func(b *testing.B) {
+		mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
+			Target: upstream.URL,
+		})
+		defer cleanup()
+		handler := mw(nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodGet, "/api/users", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+		}
+	})
+
+	b.Run("WithStrip", func(b *testing.B) {
+		mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
+			Target:      upstream.URL,
+			StripPrefix: "/api",
+		})
+		defer cleanup()
+		handler := mw(nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodGet, "/api/users", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+		}
+	})
+}
+
+// BenchmarkReverseProxy_AddPrefix measures path prefix addition overhead
+func BenchmarkReverseProxy_AddPrefix(b *testing.B) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	b.Run("WithoutPrefix", func(b *testing.B) {
+		mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
+			Target: upstream.URL,
+		})
+		defer cleanup()
+		handler := mw(nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodGet, "/users", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+		}
+	})
+
+	b.Run("WithPrefix", func(b *testing.B) {
+		mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
+			Target:   upstream.URL,
+			AddPrefix: "/v1",
+		})
+		defer cleanup()
+		handler := mw(nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodGet, "/users", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+		}
+	})
+}
+
+// BenchmarkReverseProxy_Rewrites measures URL rewrite overhead
+func BenchmarkReverseProxy_Rewrites(b *testing.B) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	b.Run("WithoutRewrites", func(b *testing.B) {
+		mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
+			Target: upstream.URL,
+		})
+		defer cleanup()
+		handler := mw(nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodGet, "/old/path", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+		}
+	})
+
+	b.Run("WithRewrites", func(b *testing.B) {
+		mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
+			Target: upstream.URL,
+			Rewrites: []config.RewriteRule{
+				{Pattern: "/old/*", Replacement: "/new/path"},
+			},
+		})
+		defer cleanup()
+		handler := mw(nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodGet, "/old/path", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+		}
+	})
+}
+
+// BenchmarkReverseProxy_ExemptPaths measures exempt path checking overhead
+func BenchmarkReverseProxy_ExemptPaths(b *testing.B) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	testCases := []struct {
+		name        string
+		exemptPaths []string
+		path        string
+	}{
+		{"NoExemptions", nil, "/api/users"},
+		{"OneExemption_NoMatch", []string{"/health"}, "/api/users"},
+		{"ManyExemptions_NoMatch", []string{"/health", "/metrics", "/ready", "/live"}, "/api/users"},
+		{"ExemptMatch", []string{"/health"}, "/health"},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
+				Target:      upstream.URL,
+				ExemptPaths: tc.exemptPaths,
+			})
+			defer cleanup()
+			handler := mw(nextHandler)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+			}
+		})
+	}
+}
+
+// BenchmarkReverseProxy_ForwardHeaders measures X-Forwarded-* header handling
+func BenchmarkReverseProxy_ForwardHeaders(b *testing.B) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	b.Run("WithoutForwardHeaders", func(b *testing.B) {
+		mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
+			Target:         upstream.URL,
+			ForwardHeaders: false,
+		})
+		defer cleanup()
+		handler := mw(nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Host = "example.com"
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+		}
+	})
+
+	b.Run("WithForwardHeaders", func(b *testing.B) {
+		mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
+			Target:         upstream.URL,
+			ForwardHeaders: true,
+		})
+		defer cleanup()
+		handler := mw(nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Host = "example.com"
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+		}
+	})
+}
+
+// BenchmarkReverseProxy_SetHeaders measures header manipulation overhead
+func BenchmarkReverseProxy_SetHeaders(b *testing.B) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	b.Run("NoHeaders", func(b *testing.B) {
+		mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
+			Target: upstream.URL,
+		})
+		defer cleanup()
+		handler := mw(nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+		}
+	})
+
+	b.Run("SetHeaders", func(b *testing.B) {
+		mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
+			Target: upstream.URL,
+			SetHeaders: map[string]string{
+				"X-Custom-Header": "value",
+				"X-Request-ID":    "12345",
+			},
+		})
+		defer cleanup()
+		handler := mw(nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+		}
+	})
+
+	b.Run("RemoveHeaders", func(b *testing.B) {
+		mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
+			Target:        upstream.URL,
+			RemoveHeaders: []string{"X-Internal-Token", "X-Secret"},
+		})
+		defer cleanup()
+		handler := mw(nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("X-Internal-Token", "secret")
+			req.Header.Set("X-Secret", "value")
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+		}
+	})
+}
+
+// BenchmarkReverseProxy_UnhealthyBackends measures behavior when some backends are unhealthy
+func BenchmarkReverseProxy_UnhealthyBackends(b *testing.B) {
+	upstreams := make([]*httptest.Server, 5)
+	for i := range upstreams {
+		upstreams[i] = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer upstreams[i].Close()
+	}
+
+	scenarios := []struct {
+		name            string
+		healthyCount    int
+		unhealthyCount  int
+	}{
+		{"AllHealthy", 5, 0},
+		{"OneUnhealthy", 4, 1},
+		{"HalfUnhealthy", 2, 3},
+		{"OneHealthy", 1, 4},
+	}
+
+	for _, tc := range scenarios {
+		b.Run(tc.name, func(b *testing.B) {
+			targets := make([]config.Backend, 5)
+			for i := range targets {
+				targets[i] = config.Backend{
+					Target:  upstreams[i].URL,
+					Weight:  1,
+					Healthy: i < tc.healthyCount,
+				}
+			}
+
+			mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
+				Targets:      targets,
+				LoadBalancer: config.RoundRobin,
+			})
+			defer cleanup()
+			handler := mw(nil)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+			}
+		})
+	}
+}
+
+// BenchmarkReverseProxy_Concurrent measures concurrent proxy performance
+func BenchmarkReverseProxy_Concurrent(b *testing.B) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	targets := []config.Backend{
+		{Target: upstream.URL, Weight: 1, Healthy: true},
+		{Target: upstream.URL, Weight: 1, Healthy: true},
+		{Target: upstream.URL, Weight: 1, Healthy: true},
+	}
+
+	mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
+		Targets:      targets,
+		LoadBalancer: config.RoundRobin,
+	})
+	defer cleanup()
+	handler := mw(nil)
+
+	concurrencyLevels := []int{1, 10, 100}
+
+	for _, concurrency := range concurrencyLevels {
+		b.Run(fmt.Sprintf("Goroutines%d", concurrency), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					req := httptest.NewRequest(http.MethodGet, "/", nil)
+					rec := httptest.NewRecorder()
+					handler.ServeHTTP(rec, req)
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkReverseProxy_BackendSelection benchmarks just the backend selection logic
+func BenchmarkReverseProxy_BackendSelection(b *testing.B) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	targets := make([]config.Backend, 10)
+	for i := range targets {
+		targets[i] = config.Backend{
+			Target:  upstream.URL,
+			Weight:  1,
+			Healthy: true,
+		}
+	}
+
+	mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
+		Targets:      targets,
+		LoadBalancer: config.RoundRobin,
+	})
+	defer cleanup()
+
+	// Access the internal reverse proxy to benchmark selection
+	handler := mw(nil)
+
+	b.Run("RoundRobin", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+		}
+	})
 }

--- a/middleware/reverse_proxy_bench_test.go
+++ b/middleware/reverse_proxy_bench_test.go
@@ -62,8 +62,8 @@ func BenchmarkReverseProxy_LoadBalancers(b *testing.B) {
 			}
 
 			mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
-				Targets:       targets,
-				LoadBalancer:  tc.algo,
+				Targets:      targets,
+				LoadBalancer: tc.algo,
 			})
 			defer cleanup()
 
@@ -183,7 +183,7 @@ func BenchmarkReverseProxy_AddPrefix(b *testing.B) {
 
 	b.Run("WithPrefix", func(b *testing.B) {
 		mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
-			Target:   upstream.URL,
+			Target:    upstream.URL,
 			AddPrefix: "/v1",
 		})
 		defer cleanup()
@@ -402,9 +402,9 @@ func BenchmarkReverseProxy_UnhealthyBackends(b *testing.B) {
 	}
 
 	scenarios := []struct {
-		name            string
-		healthyCount    int
-		unhealthyCount  int
+		name           string
+		healthyCount   int
+		unhealthyCount int
 	}{
 		{"AllHealthy", 5, 0},
 		{"OneUnhealthy", 4, 1},

--- a/render_bench_test.go
+++ b/render_bench_test.go
@@ -1,0 +1,516 @@
+package zerohttp
+
+import (
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/alexferl/zerohttp/internal/problem"
+)
+
+// BenchmarkRenderer_JSON_Baseline compares JSON() method vs stdlib json.NewEncoder directly
+func BenchmarkRenderer_JSON_Baseline(b *testing.B) {
+	data := M{"message": "hello", "status": "ok"}
+
+	b.Run("Stdlib_NewEncoder", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(data)
+		}
+	})
+
+	b.Run("Renderer_JSON", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			_ = R.JSON(w, http.StatusOK, data)
+		}
+	})
+
+	b.Run("Stdlib_Marshal", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			w.WriteHeader(http.StatusOK)
+			bytes, _ := json.Marshal(data)
+			_, _ = w.Write(bytes)
+		}
+	})
+}
+
+// BenchmarkRenderer_JSON_PayloadSizes measures allocation patterns for different payload sizes
+func BenchmarkRenderer_JSON_PayloadSizes(b *testing.B) {
+	sizes := []struct {
+		name string
+		data any
+	}{
+		{
+			name: "Tiny_50B",
+			data: M{"msg": "hi"},
+		},
+		{
+			name: "Small_500B",
+			data: M{
+				"id":      "12345",
+				"name":    "Test User",
+				"email":   "test@example.com",
+				"status":  "active",
+				"message": strings.Repeat("a", 400),
+			},
+		},
+		{
+			name: "Medium_5KB",
+			data: func() any {
+				items := make([]M, 50)
+				for i := range 50 {
+					items[i] = M{
+						"id":    i,
+						"name":  fmt.Sprintf("Item %d", i),
+						"value": fmt.Sprintf("Value %d with some padding", i),
+					}
+				}
+				return M{"items": items, "count": 50}
+			}(),
+		},
+		{
+			name: "Medium_50KB",
+			data: func() any {
+				items := make([]M, 500)
+				for i := range 500 {
+					items[i] = M{
+						"id":    i,
+						"name":  fmt.Sprintf("Item %d", i),
+						"value": fmt.Sprintf("Value %d with some padding text here", i),
+						"data":  strings.Repeat("x", 50),
+					}
+				}
+				return M{"items": items, "count": 500}
+			}(),
+		},
+		{
+			name: "Large_100KB",
+			data: func() any {
+				items := make([]M, 1000)
+				for i := range 1000 {
+					items[i] = M{
+						"id":    i,
+						"name":  fmt.Sprintf("Item %d", i),
+						"value": fmt.Sprintf("Value %d", i),
+						"data":  strings.Repeat("y", 80),
+					}
+				}
+				return M{"items": items, "count": 1000}
+			}(),
+		},
+	}
+
+	for _, s := range sizes {
+		b.Run(s.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				w := httptest.NewRecorder()
+				_ = R.JSON(w, http.StatusOK, s.data)
+			}
+		})
+	}
+}
+
+// BenchmarkRenderer_JSON_DataTypes compares different Go types for JSON rendering
+func BenchmarkRenderer_JSON_DataTypes(b *testing.B) {
+	type User struct {
+		ID    int    `json:"id"`
+		Name  string `json:"name"`
+		Email string `json:"email"`
+	}
+
+	types := []struct {
+		name string
+		data any
+	}{
+		{
+			name: "Map",
+			data: M{"id": 1, "name": "test", "email": "test@example.com"},
+		},
+		{
+			name: "Struct",
+			data: User{ID: 1, Name: "test", Email: "test@example.com"},
+		},
+		{
+			name: "Slice",
+			data: []string{"a", "b", "c", "d", "e"},
+		},
+		{
+			name: "String",
+			data: "hello world",
+		},
+		{
+			name: "Number",
+			data: 42,
+		},
+		{
+			name: "Bool",
+			data: true,
+		},
+		{
+			name: "Nil",
+			data: nil,
+		},
+	}
+
+	for _, t := range types {
+		b.Run(t.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				w := httptest.NewRecorder()
+				_ = R.JSON(w, http.StatusOK, t.data)
+			}
+		})
+	}
+}
+
+// BenchmarkRenderer_ProblemDetail measures problem detail rendering overhead
+func BenchmarkRenderer_ProblemDetail(b *testing.B) {
+	b.Run("Simple", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			problem := NewProblemDetail(http.StatusNotFound, "Resource not found")
+			_ = R.ProblemDetail(w, problem)
+		}
+	})
+
+	b.Run("WithExtensions", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			problem := NewProblemDetail(http.StatusBadRequest, "Validation failed")
+			problem.Set("field", "email")
+			problem.Set("constraint", "required")
+			_ = R.ProblemDetail(w, problem)
+		}
+	})
+
+	b.Run("ValidationErrors", func(b *testing.B) {
+		errors := []problem.ValidationError{
+			{Detail: "Name is required", Field: "name"},
+			{Detail: "Invalid email format", Field: "email"},
+			{Detail: "Age must be positive", Field: "age"},
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			problem := problem.NewValidationDetail("Validation failed", errors)
+			_ = R.ProblemDetail(w, problem)
+		}
+	})
+
+	b.Run("StatusCodes", func(b *testing.B) {
+		codes := []int{
+			http.StatusBadRequest,
+			http.StatusUnauthorized,
+			http.StatusForbidden,
+			http.StatusNotFound,
+			http.StatusInternalServerError,
+		}
+
+		for _, code := range codes {
+			b.Run(fmt.Sprintf("Status%d", code), func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for b.Loop() {
+					w := httptest.NewRecorder()
+					problem := NewProblemDetail(code, "Test error message")
+					_ = R.ProblemDetail(w, problem)
+				}
+			})
+		}
+	})
+}
+
+// BenchmarkRenderer_Text compares Text rendering as a baseline
+func BenchmarkRenderer_Text(b *testing.B) {
+	messages := []struct {
+		name string
+		text string
+	}{
+		{"Short", "OK"},
+		{"Medium", "Hello, this is a medium length message"},
+		{"Large_1KB", strings.Repeat("x", 1024)},
+	}
+
+	for _, m := range messages {
+		b.Run(m.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				w := httptest.NewRecorder()
+				_ = R.Text(w, http.StatusOK, m.text)
+			}
+		})
+	}
+}
+
+// BenchmarkRenderer_HTML compares HTML rendering
+func BenchmarkRenderer_HTML(b *testing.B) {
+	html := []struct {
+		name string
+		data string
+	}{
+		{"Simple", "<h1>Hello</h1>"},
+		{"Medium", "<html><body><h1>Title</h1><p>Some content here</p></body></html>"},
+		{"Large_1KB", "<html><body>" + strings.Repeat("<p>Paragraph</p>", 50) + "</body></html>"},
+	}
+
+	for _, h := range html {
+		b.Run(h.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				w := httptest.NewRecorder()
+				_ = R.HTML(w, http.StatusOK, h.data)
+			}
+		})
+	}
+}
+
+// BenchmarkRenderer_Template measures template rendering performance
+func BenchmarkRenderer_Template(b *testing.B) {
+	simpleTmpl := template.Must(template.New("simple").Parse("<h1>{{.Title}}</h1>"))
+	complexTmpl := template.Must(template.New("complex").Parse(`
+<html>
+<head><title>{{.Title}}</title></head>
+<body>
+<h1>{{.Title}}</h1>
+<p>{{.Description}}</p>
+<ul>
+{{range .Items}}<li>{{.}}</li>{{end}}
+</ul>
+</body>
+</html>`))
+
+	b.Run("Simple", func(b *testing.B) {
+		data := map[string]string{"Title": "Test Page"}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			_ = R.Template(w, http.StatusOK, simpleTmpl, "simple", data)
+		}
+	})
+
+	b.Run("Complex", func(b *testing.B) {
+		data := map[string]any{
+			"Title":       "Complex Page",
+			"Description": "This is a more complex template",
+			"Items":       []string{"Item 1", "Item 2", "Item 3", "Item 4", "Item 5"},
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			_ = R.Template(w, http.StatusOK, complexTmpl, "complex", data)
+		}
+	})
+}
+
+// BenchmarkRenderer_Blob measures Blob rendering as a binary baseline
+func BenchmarkRenderer_Blob(b *testing.B) {
+	sizes := []int{100, 1024, 10240, 102400}
+
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("Size%d", size), func(b *testing.B) {
+			data := make([]byte, size)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				w := httptest.NewRecorder()
+				_ = R.Blob(w, http.StatusOK, "application/octet-stream", data)
+			}
+		})
+	}
+}
+
+// BenchmarkRenderer_NoContent measures NoContent rendering
+func BenchmarkRenderer_NoContent(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		w := httptest.NewRecorder()
+		_ = R.NoContent(w)
+	}
+}
+
+// BenchmarkRenderer_NotModified measures NotModified rendering
+func BenchmarkRenderer_NotModified(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		w := httptest.NewRecorder()
+		_ = R.NotModified(w)
+	}
+}
+
+// BenchmarkRenderer_Redirect measures redirect rendering
+func BenchmarkRenderer_Redirect(b *testing.B) {
+	r := httptest.NewRequest(http.MethodGet, "/original", nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		w := httptest.NewRecorder()
+		_ = R.Redirect(w, r, "/new-location", http.StatusFound)
+	}
+}
+
+// BenchmarkRenderer_JSON_NestedStructs measures deeply nested structures
+func BenchmarkRenderer_JSON_NestedStructs(b *testing.B) {
+	type Address struct {
+		Street string `json:"street"`
+		City   string `json:"city"`
+	}
+
+	type Person struct {
+		Name    string  `json:"name"`
+		Address Address `json:"address"`
+	}
+
+	type Company struct {
+		CEO     Person   `json:"ceo"`
+		CTO     Person   `json:"cto"`
+		Offices []string `json:"offices"`
+	}
+
+	nested := Company{
+		CEO: Person{
+			Name: "John CEO",
+			Address: Address{
+				Street: "123 Main St",
+				City:   "New York",
+			},
+		},
+		CTO: Person{
+			Name: "Jane CTO",
+			Address: Address{
+				Street: "456 Tech Ave",
+				City:   "San Francisco",
+			},
+		},
+		Offices: []string{"NYC", "SF", "London"},
+	}
+
+	b.Run("NestedStruct", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			_ = R.JSON(w, http.StatusOK, nested)
+		}
+	})
+
+	// Compare with map
+	nestedMap := M{
+		"ceo": M{
+			"name": "John CEO",
+			"address": M{
+				"street": "123 Main St",
+				"city":   "New York",
+			},
+		},
+		"cto": M{
+			"name": "Jane CTO",
+			"address": M{
+				"street": "456 Tech Ave",
+				"city":   "San Francisco",
+			},
+		},
+		"offices": []string{"NYC", "SF", "London"},
+	}
+
+	b.Run("NestedMap", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			_ = R.JSON(w, http.StatusOK, nestedMap)
+		}
+	})
+}
+
+// BenchmarkRenderer_JSON_Concurrent measures concurrent JSON rendering
+func BenchmarkRenderer_JSON_Concurrent(b *testing.B) {
+	data := M{"message": "hello", "status": "ok", "count": 42}
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			w := httptest.NewRecorder()
+			_ = R.JSON(w, http.StatusOK, data)
+		}
+	})
+}
+
+// BenchmarkRenderer_JSON_StatusCodes measures different status codes
+func BenchmarkRenderer_JSON_StatusCodes(b *testing.B) {
+	data := M{"result": "success"}
+
+	codes := []int{
+		http.StatusOK,
+		http.StatusCreated,
+		http.StatusAccepted,
+		http.StatusNoContent,
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusNotFound,
+		http.StatusInternalServerError,
+	}
+
+	for _, code := range codes {
+		b.Run(fmt.Sprintf("Status%d", code), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				w := httptest.NewRecorder()
+				_ = R.JSON(w, code, data)
+			}
+		})
+	}
+}

--- a/router_bench_test.go
+++ b/router_bench_test.go
@@ -491,3 +491,200 @@ func BenchmarkRouter_AllHTTPMethods(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkRouter_WildcardPatterns measures routing performance with wildcard
+// path patterns (Go 1.22+ "..." syntax).
+func BenchmarkRouter_WildcardPatterns(b *testing.B) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	b.Run("Baseline_ServeMux", func(b *testing.B) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /files/{path...}", handler)
+
+		req := httptest.NewRequest(http.MethodGet, "/files/docs/readme.txt", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("Zerohttp_Router", func(b *testing.B) {
+		router := NewRouter()
+		router.GET("/files/{path...}", handler)
+
+		req := httptest.NewRequest(http.MethodGet, "/files/docs/readme.txt", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("ShallowWildcard_1Segment", func(b *testing.B) {
+		router := NewRouter()
+		router.GET("/api/{path...}", handler)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/users", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("DeepWildcard_5Segments", func(b *testing.B) {
+		router := NewRouter()
+		router.GET("/files/{path...}", handler)
+
+		req := httptest.NewRequest(http.MethodGet, "/files/a/b/c/d/e.txt", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("DeepWildcard_10Segments", func(b *testing.B) {
+		router := NewRouter()
+		router.GET("/files/{path...}", handler)
+
+		req := httptest.NewRequest(http.MethodGet, "/files/a/b/c/d/e/f/g/h/i/j.txt", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+}
+
+// BenchmarkRouter_NestedRouteGroups measures the overhead of deeply nested
+// route groups (5+ levels).
+func BenchmarkRouter_NestedRouteGroups(b *testing.B) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	middleware := func(_ string) func(http.Handler) http.Handler {
+		return func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				next.ServeHTTP(w, r)
+			})
+		}
+	}
+
+	b.Run("NoGroups", func(b *testing.B) {
+		router := NewRouter()
+		router.GET("/api/v1/users", handler)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("OneGroup", func(b *testing.B) {
+		router := NewRouter()
+		router.Group(func(api Router) {
+			api.GET("/api/v1/users", handler)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("ThreeGroups", func(b *testing.B) {
+		router := NewRouter()
+		router.Group(func(api Router) {
+			api.Group(func(v1 Router) {
+				v1.Group(func(users Router) {
+					users.GET("/api/v1/users", handler)
+				})
+			})
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("FiveGroups", func(b *testing.B) {
+		router := NewRouter()
+		router.Group(func(a Router) {
+			a.Group(func(b Router) {
+				b.Group(func(c Router) {
+					c.Group(func(d Router) {
+						d.Group(func(e Router) {
+							e.GET("/api/v1/users", handler)
+						})
+					})
+				})
+			})
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("FiveGroups_WithMiddleware", func(b *testing.B) {
+		router := NewRouter()
+		router.Group(func(a Router) {
+			a.Use(middleware("level1"))
+			a.Group(func(b Router) {
+				b.Use(middleware("level2"))
+				b.Group(func(c Router) {
+					c.Use(middleware("level3"))
+					c.Group(func(d Router) {
+						d.Use(middleware("level4"))
+						d.Group(func(e Router) {
+							e.Use(middleware("level5"))
+							e.GET("/api/v1/users", handler)
+						})
+					})
+				})
+			})
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+}

--- a/sse_bench_test.go
+++ b/sse_bench_test.go
@@ -1,0 +1,922 @@
+package zerohttp
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/alexferl/zerohttp/config"
+)
+
+// BenchmarkSSE_Send measures the throughput of the Send() method
+// with different event sizes and field combinations.
+func BenchmarkSSE_Send(b *testing.B) {
+	scenarios := []struct {
+		name  string
+		event SSEEvent
+	}{
+		{
+			name: "SimpleDataOnly",
+			event: SSEEvent{
+				Data: []byte("hello world"),
+			},
+		},
+		{
+			name: "WithID",
+			event: SSEEvent{
+				ID:   "12345",
+				Data: []byte("hello world"),
+			},
+		},
+		{
+			name: "WithName",
+			event: SSEEvent{
+				Name: "update",
+				Data: []byte("hello world"),
+			},
+		},
+		{
+			name: "WithRetry",
+			event: SSEEvent{
+				Data:  []byte("hello world"),
+				Retry: 5000 * time.Millisecond,
+			},
+		},
+		{
+			name: "FullEvent",
+			event: SSEEvent{
+				ID:    "12345",
+				Name:  "update",
+				Data:  []byte("hello world"),
+				Retry: 5000 * time.Millisecond,
+			},
+		},
+		{
+			name: "LargeData_1KB",
+			event: SSEEvent{
+				Data: make([]byte, 1024),
+			},
+		},
+		{
+			name: "LargeData_10KB",
+			event: SSEEvent{
+				Data: make([]byte, 10*1024),
+			},
+		},
+		{
+			name: "MultiLineData",
+			event: SSEEvent{
+				Data: []byte("line1\nline2\nline3\nline4\nline5"),
+			},
+		},
+	}
+
+	for _, s := range scenarios {
+		b.Run(s.name, func(b *testing.B) {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+			stream, err := NewSSE(w, r)
+			if err != nil {
+				b.Fatalf("failed to create SSE: %v", err)
+			}
+			defer func() { _ = stream.Close() }()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				if err := stream.Send(s.event); err != nil {
+					b.Fatalf("send failed: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkSSE_SendComment measures the throughput of sending comments.
+func BenchmarkSSE_SendComment(b *testing.B) {
+	comments := []struct {
+		name    string
+		comment string
+	}{
+		{"Short", "ping"},
+		{"Medium", "keepalive heartbeat message"},
+		{"Long", "this is a longer comment that might be used for keepalive purposes in production scenarios"},
+	}
+
+	for _, c := range comments {
+		b.Run(c.name, func(b *testing.B) {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+			stream, err := NewSSE(w, r)
+			if err != nil {
+				b.Fatalf("failed to create SSE: %v", err)
+			}
+			defer func() { _ = stream.Close() }()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				if err := stream.SendComment(c.comment); err != nil {
+					b.Fatalf("send comment failed: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkSSEHub_Broadcast measures the scaling of SSEHub.Broadcast()
+// with different connection counts.
+func BenchmarkSSEHub_Broadcast(b *testing.B) {
+	connectionCounts := []int{10, 100, 1000}
+
+	for _, count := range connectionCounts {
+		b.Run(fmt.Sprintf("Connections%d", count), func(b *testing.B) {
+			hub := NewSSEHub()
+			r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+			// Create and register connections
+			recorders := make([]*httptest.ResponseRecorder, count)
+			streams := make([]*SSE, count)
+
+			for i := range count {
+				recorders[i] = httptest.NewRecorder()
+				stream, err := NewSSE(recorders[i], r)
+				if err != nil {
+					b.Fatalf("failed to create SSE: %v", err)
+				}
+				streams[i] = stream
+				hub.Register(stream)
+			}
+
+			// Cleanup
+			defer func() {
+				for _, s := range streams {
+					_ = s.Close()
+				}
+			}()
+
+			event := SSEEvent{Data: []byte("broadcast message")}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				hub.Broadcast(event)
+			}
+		})
+	}
+}
+
+// BenchmarkSSEHub_BroadcastTo measures topic-based broadcast performance
+// with different numbers of subscribers.
+func BenchmarkSSEHub_BroadcastTo(b *testing.B) {
+	subscriberCounts := []int{10, 100, 1000}
+
+	for _, count := range subscriberCounts {
+		b.Run(fmt.Sprintf("Subscribers%d", count), func(b *testing.B) {
+			hub := NewSSEHub()
+			r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+			// Create and subscribe connections
+			recorders := make([]*httptest.ResponseRecorder, count)
+			streams := make([]*SSE, count)
+
+			for i := range count {
+				recorders[i] = httptest.NewRecorder()
+				stream, err := NewSSE(recorders[i], r)
+				if err != nil {
+					b.Fatalf("failed to create SSE: %v", err)
+				}
+				streams[i] = stream
+				hub.Subscribe(stream, "notifications")
+			}
+
+			// Cleanup
+			defer func() {
+				for _, s := range streams {
+					_ = s.Close()
+				}
+			}()
+
+			event := SSEEvent{Data: []byte("topic message")}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				hub.BroadcastTo("notifications", event)
+			}
+		})
+	}
+}
+
+// BenchmarkSSEHub_BroadcastTo_MultipleTopics measures broadcasting to
+// different topic configurations.
+func BenchmarkSSEHub_BroadcastTo_MultipleTopics(b *testing.B) {
+	scenarios := []struct {
+		name            string
+		numTopics       int
+		subscribersEach int
+	}{
+		{"SingleTopic", 1, 100},
+		{"TenTopics", 10, 10},
+		{"HundredTopics", 100, 1},
+	}
+
+	for _, s := range scenarios {
+		b.Run(s.name, func(b *testing.B) {
+			hub := NewSSEHub()
+			r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+			// Create connections and distribute across topics
+			for i := 0; i < s.numTopics*s.subscribersEach; i++ {
+				w := httptest.NewRecorder()
+				stream, err := NewSSE(w, r)
+				if err != nil {
+					b.Fatalf("failed to create SSE: %v", err)
+				}
+				topicName := fmt.Sprintf("topic-%d", i%s.numTopics)
+				hub.Subscribe(stream, topicName)
+			}
+
+			event := SSEEvent{Data: []byte("topic message")}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				hub.BroadcastTo("topic-0", event)
+			}
+		})
+	}
+}
+
+// BenchmarkInMemoryReplayer_Store measures Store() performance
+// with different buffer sizes.
+func BenchmarkInMemoryReplayer_Store(b *testing.B) {
+	bufferSizes := []int{10, 100, 1000, 0}
+
+	for _, size := range bufferSizes {
+		name := fmt.Sprintf("MaxEvents%d", size)
+		if size == 0 {
+			name = "Unlimited"
+		}
+
+		b.Run(name, func(b *testing.B) {
+			replayer := NewInMemoryReplayer(size, 0)
+			event := SSEEvent{Data: []byte("test data")}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				replayer.Store(event)
+			}
+		})
+	}
+}
+
+// BenchmarkInMemoryReplayer_Store_WithTTL measures Store() performance
+// when TTL-based expiration is enabled.
+func BenchmarkInMemoryReplayer_Store_WithTTL(b *testing.B) {
+	ttls := []time.Duration{
+		0,               // No TTL
+		time.Minute,     // 1 minute
+		5 * time.Minute, // 5 minutes
+	}
+
+	for _, ttl := range ttls {
+		name := "NoTTL"
+		if ttl > 0 {
+			name = fmt.Sprintf("TTL%s", ttl)
+		}
+
+		b.Run(name, func(b *testing.B) {
+			replayer := NewInMemoryReplayer(1000, ttl)
+			event := SSEEvent{Data: []byte("test data")}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				replayer.Store(event)
+			}
+		})
+	}
+}
+
+// BenchmarkInMemoryReplayer_Replay measures Replay() performance
+// with different event counts.
+func BenchmarkInMemoryReplayer_Replay(b *testing.B) {
+	eventCounts := []int{10, 100, 1000}
+
+	for _, count := range eventCounts {
+		b.Run(fmt.Sprintf("Events%d", count), func(b *testing.B) {
+			replayer := NewInMemoryReplayer(count, 0)
+
+			// Pre-populate with events
+			for i := range count {
+				replayer.Store(SSEEvent{Data: fmt.Appendf(nil, "event %d", i)})
+			}
+
+			sendFunc := func(e SSEEvent) error { return nil }
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				_, _ = replayer.Replay("0", sendFunc)
+			}
+		})
+	}
+}
+
+// BenchmarkInMemoryReplayer_Replay_WithAfterID measures Replay() performance
+// when replaying from a specific ID.
+func BenchmarkInMemoryReplayer_Replay_WithAfterID(b *testing.B) {
+	eventCounts := []int{100, 1000}
+
+	for _, count := range eventCounts {
+		b.Run(fmt.Sprintf("Total%d", count), func(b *testing.B) {
+			replayer := NewInMemoryReplayer(count, 0)
+
+			// Pre-populate with events
+			for i := range count {
+				replayer.Store(SSEEvent{Data: fmt.Appendf(nil, "event %d", i)})
+			}
+
+			sendFunc := func(e SSEEvent) error { return nil }
+
+			b.Run("ReplayHalf", func(b *testing.B) {
+				afterID := fmt.Sprintf("%d", count/2)
+
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for b.Loop() {
+					_, _ = replayer.Replay(afterID, sendFunc)
+				}
+			})
+
+			b.Run("ReplayAll", func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for b.Loop() {
+					_, _ = replayer.Replay("", sendFunc)
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkSSEHub_RegisterUnregister measures the overhead of
+// connection registration and unregistration.
+func BenchmarkSSEHub_RegisterUnregister(b *testing.B) {
+	b.Run("Register", func(b *testing.B) {
+		hub := NewSSEHub()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		// Pre-create streams
+		streams := make([]*SSE, b.N)
+		for i := 0; i < b.N; i++ {
+			w := httptest.NewRecorder()
+			stream, _ := NewSSE(w, r)
+			streams[i] = stream
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			hub.Register(streams[i])
+		}
+
+		// Cleanup
+		for _, s := range streams {
+			_ = s.Close()
+		}
+	})
+
+	b.Run("Unregister", func(b *testing.B) {
+		hub := NewSSEHub()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		// Pre-create and register streams
+		streams := make([]*SSE, b.N)
+		for i := 0; i < b.N; i++ {
+			w := httptest.NewRecorder()
+			stream, _ := NewSSE(w, r)
+			streams[i] = stream
+			hub.Register(stream)
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			hub.Unregister(streams[i])
+		}
+
+		// Cleanup
+		for _, s := range streams {
+			_ = s.Close()
+		}
+	})
+
+	b.Run("Subscribe", func(b *testing.B) {
+		hub := NewSSEHub()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		// Pre-create streams
+		streams := make([]*SSE, b.N)
+		for i := 0; i < b.N; i++ {
+			w := httptest.NewRecorder()
+			stream, _ := NewSSE(w, r)
+			streams[i] = stream
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			hub.Subscribe(streams[i], "test-topic")
+		}
+
+		// Cleanup
+		for _, s := range streams {
+			_ = s.Close()
+		}
+	})
+}
+
+// BenchmarkSSEHub_RegisterUnregister_Concurrent measures concurrent
+// registration/unregistration performance.
+func BenchmarkSSEHub_RegisterUnregister_Concurrent(b *testing.B) {
+	concurrencyLevels := []int{1, 10, 100}
+
+	for _, concurrency := range concurrencyLevels {
+		b.Run(fmt.Sprintf("Goroutines%d", concurrency), func(b *testing.B) {
+			hub := NewSSEHub()
+			r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			b.RunParallel(func(pb *testing.PB) {
+				i := 0
+				for pb.Next() {
+					w := httptest.NewRecorder()
+					stream, _ := NewSSE(w, r)
+					hub.Register(stream)
+
+					// Alternate between register/unregister
+					if i%2 == 0 {
+						hub.Unregister(stream)
+					}
+					i++
+					_ = stream.Close()
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkSSE_MemoryPerConnection measures memory allocation per connection.
+func BenchmarkSSE_MemoryPerConnection(b *testing.B) {
+	b.Run("CreateAndClose", func(b *testing.B) {
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			stream, _ := NewSSE(w, r)
+			_ = stream.Close()
+			stream.WaitDone()
+		}
+	})
+
+	b.Run("MemoryGrowth_100Connections", func(b *testing.B) {
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		// Force GC and get baseline
+		runtime.GC()
+		var m1, m2 runtime.MemStats
+		runtime.ReadMemStats(&m1)
+
+		streams := make([]*SSE, 100)
+		for i := range 100 {
+			w := httptest.NewRecorder()
+			stream, _ := NewSSE(w, r)
+			streams[i] = stream
+		}
+
+		runtime.ReadMemStats(&m2)
+
+		// Cleanup
+		for _, s := range streams {
+			_ = s.Close()
+			s.WaitDone()
+		}
+
+		// Report bytes per connection
+		bytesPerConn := int64(m2.TotalAlloc-m1.TotalAlloc) / 100
+		b.ReportMetric(float64(bytesPerConn), "bytes/conn")
+	})
+}
+
+// BenchmarkSSEWriter_WriteEvent measures SSEWriter performance.
+func BenchmarkSSEWriter_WriteEvent(b *testing.B) {
+	scenarios := []struct {
+		name  string
+		event SSEEvent
+	}{
+		{
+			name: "Simple",
+			event: SSEEvent{
+				Data: []byte("hello world"),
+			},
+		},
+		{
+			name: "Full",
+			event: SSEEvent{
+				ID:    "123",
+				Name:  "update",
+				Data:  []byte("hello world"),
+				Retry: 5000 * time.Millisecond,
+			},
+		},
+	}
+
+	for _, s := range scenarios {
+		b.Run(s.name, func(b *testing.B) {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+			writer, err := NewSSEWriter(w, r)
+			if err != nil {
+				b.Fatalf("failed to create SSEWriter: %v", err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				if err := writer.WriteEvent(s.event); err != nil {
+					b.Fatalf("write event failed: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkSSE_EventTypes compares performance of different event types.
+func BenchmarkSSE_EventTypes(b *testing.B) {
+	b.Run("SmallData", func(b *testing.B) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		stream, _ := NewSSE(w, r)
+		defer func() { _ = stream.Close() }()
+
+		event := SSEEvent{Data: []byte("x")}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_ = stream.Send(event)
+		}
+	})
+
+	b.Run("MediumData", func(b *testing.B) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		stream, _ := NewSSE(w, r)
+		defer func() { _ = stream.Close() }()
+
+		event := SSEEvent{Data: []byte("this is a medium sized message")}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_ = stream.Send(event)
+		}
+	})
+
+	b.Run("JSONData", func(b *testing.B) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		stream, _ := NewSSE(w, r)
+		defer func() { _ = stream.Close() }()
+
+		event := SSEEvent{
+			Name: "update",
+			Data: []byte(`{"id":123,"type":"notification","message":"Hello World","timestamp":"2024-01-01T00:00:00Z"}`),
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_ = stream.Send(event)
+		}
+	})
+}
+
+// BenchmarkSSEProvider compares SSE provider implementations.
+func BenchmarkSSEProvider(b *testing.B) {
+	providers := []struct {
+		name     string
+		provider config.SSEProvider
+	}{
+		{"DefaultProvider", NewDefaultProvider()},
+	}
+
+	for _, p := range providers {
+		b.Run(p.name, func(b *testing.B) {
+			r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				w := httptest.NewRecorder()
+				conn, err := p.provider.NewSSE(w, r)
+				if err != nil {
+					b.Fatalf("failed to create SSE: %v", err)
+				}
+				_ = conn.Close()
+			}
+		})
+	}
+}
+
+// BenchmarkSSEHub_Broadcast_Stress stress tests the broadcast mechanism
+// with many concurrent broadcasts.
+func BenchmarkSSEHub_Broadcast_Stress(b *testing.B) {
+	b.Run("ConcurrentBroadcasts", func(b *testing.B) {
+		hub := NewSSEHub()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		// Create 100 connections
+		streams := make([]*SSE, 100)
+		for i := range 100 {
+			w := httptest.NewRecorder()
+			stream, _ := NewSSE(w, r)
+			streams[i] = stream
+			hub.Register(stream)
+		}
+
+		defer func() {
+			for _, s := range streams {
+				_ = s.Close()
+			}
+		}()
+
+		event := SSEEvent{Data: []byte("stress test")}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				hub.Broadcast(event)
+			}
+		})
+	})
+}
+
+// BenchmarkSSE_Baseline compares SSE performance against raw http.ResponseWriter
+// to measure the overhead of the SSE implementation.
+func BenchmarkSSE_Baseline(b *testing.B) {
+	b.Run("RawResponseWriter_Write", func(b *testing.B) {
+		data := []byte("data: hello world\n\n")
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+		}
+	})
+
+	b.Run("RawResponseWriter_WriteWithFlush", func(b *testing.B) {
+		data := []byte("data: hello world\n\n")
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			handler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				rw.Header().Set("Content-Type", "text/event-stream")
+				rw.WriteHeader(http.StatusOK)
+				_, _ = rw.Write(data)
+				if f, ok := rw.(http.Flusher); ok {
+					f.Flush()
+				}
+			})
+			handler.ServeHTTP(w, r)
+		}
+	})
+
+	b.Run("SSE_Send_SimpleData", func(b *testing.B) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+		stream, err := NewSSE(w, r)
+		if err != nil {
+			b.Fatalf("failed to create SSE: %v", err)
+		}
+		defer func() { _ = stream.Close() }()
+
+		event := SSEEvent{Data: []byte("hello world")}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			if err := stream.Send(event); err != nil {
+				b.Fatalf("send failed: %v", err)
+			}
+		}
+	})
+
+	b.Run("SSE_OverheadFactor", func(b *testing.B) {
+		// Measure the overhead ratio of SSE vs raw writes
+		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+		data := []byte("data: hello world\n\n")
+		event := SSEEvent{Data: []byte("hello world")}
+
+		b.Run("Raw", func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				w := httptest.NewRecorder()
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(data)
+			}
+		})
+
+		b.Run("SSE", func(b *testing.B) {
+			w := httptest.NewRecorder()
+			stream, _ := NewSSE(w, r)
+			defer func() { _ = stream.Close() }()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				_ = stream.Send(event)
+			}
+		})
+	})
+}
+
+// BenchmarkSSEHub_Baseline compares SSEHub broadcast against naive iteration
+// to measure the management overhead.
+func BenchmarkSSEHub_Baseline(b *testing.B) {
+	connectionCounts := []int{10, 100}
+
+	for _, count := range connectionCounts {
+		b.Run(fmt.Sprintf("Connections%d", count), func(b *testing.B) {
+			b.Run("NaiveIteration", func(b *testing.B) {
+				r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+				// Create connections
+				recorders := make([]*httptest.ResponseRecorder, count)
+				streams := make([]*SSE, count)
+				for i := range count {
+					recorders[i] = httptest.NewRecorder()
+					stream, _ := NewSSE(recorders[i], r)
+					streams[i] = stream
+				}
+
+				defer func() {
+					for _, s := range streams {
+						_ = s.Close()
+					}
+				}()
+
+				event := SSEEvent{Data: []byte("broadcast message")}
+
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for b.Loop() {
+					for _, s := range streams {
+						_ = s.Send(event)
+					}
+				}
+			})
+
+			b.Run("SSEHub", func(b *testing.B) {
+				hub := NewSSEHub()
+				r := httptest.NewRequest(http.MethodGet, "/sse", nil)
+
+				// Create and register connections
+				recorders := make([]*httptest.ResponseRecorder, count)
+				streams := make([]*SSE, count)
+				for i := range count {
+					recorders[i] = httptest.NewRecorder()
+					stream, _ := NewSSE(recorders[i], r)
+					streams[i] = stream
+					hub.Register(stream)
+				}
+
+				defer func() {
+					for _, s := range streams {
+						_ = s.Close()
+					}
+				}()
+
+				event := SSEEvent{Data: []byte("broadcast message")}
+
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for b.Loop() {
+					hub.Broadcast(event)
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkInMemoryReplayer_Baseline compares replayer against a simple slice.
+func BenchmarkInMemoryReplayer_Baseline(b *testing.B) {
+	b.Run("SimpleSlice_Store", func(b *testing.B) {
+		events := make([]SSEEvent, 0, 1000)
+		event := SSEEvent{Data: []byte("test data")}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			events = append(events, event)
+			// Reset when full to simulate circular buffer
+			if len(events) >= 1000 {
+				events = events[:0]
+			}
+		}
+	})
+
+	b.Run("InMemoryReplayer_Store", func(b *testing.B) {
+		replayer := NewInMemoryReplayer(1000, 0)
+		event := SSEEvent{Data: []byte("test data")}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			replayer.Store(event)
+		}
+	})
+
+	b.Run("SimpleSlice_Iteration", func(b *testing.B) {
+		events := make([]SSEEvent, 100)
+		for i := range 100 {
+			events[i] = SSEEvent{ID: fmt.Sprintf("%d", i+1), Data: []byte("test")}
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			for _, e := range events {
+				_ = e
+			}
+		}
+	})
+
+	b.Run("InMemoryReplayer_Replay", func(b *testing.B) {
+		replayer := NewInMemoryReplayer(100, 0)
+		for range 100 {
+			replayer.Store(SSEEvent{Data: []byte("test")})
+		}
+
+		sendFunc := func(e SSEEvent) error { return nil }
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_, _ = replayer.Replay("", sendFunc)
+		}
+	})
+}

--- a/static_bench_test.go
+++ b/static_bench_test.go
@@ -1,0 +1,367 @@
+package zerohttp
+
+import (
+	"embed"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/alexferl/zerohttp/config"
+)
+
+//go:embed testdata/static
+var benchStaticFS embed.FS
+
+//go:embed testdata/files
+var benchFilesFS embed.FS
+
+// BenchmarkStatic_EmbeddedFSVsDirectory compares serving static files
+// from embedded FS vs directory serving.
+func BenchmarkStatic_EmbeddedFSVsDirectory(b *testing.B) {
+	b.Run("EmbeddedFS", func(b *testing.B) {
+		router := NewRouter()
+		router.SetLogger(&noopLogger{})
+		router.Static(benchStaticFS, "testdata/static", false)
+
+		req := httptest.NewRequest(http.MethodGet, "/app.js", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("Directory", func(b *testing.B) {
+		router := NewRouter()
+		router.SetLogger(&noopLogger{})
+		router.StaticDir("testdata/static", false)
+
+		req := httptest.NewRequest(http.MethodGet, "/app.js", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+}
+
+// BenchmarkStatic_FallbackBehavior measures the overhead of SPA mode
+// fallback (serving index.html for non-existent files).
+func BenchmarkStatic_FallbackBehavior(b *testing.B) {
+	b.Run("WithoutFallback_ExistingFile", func(b *testing.B) {
+		router := NewRouter()
+		router.SetLogger(&noopLogger{})
+		router.Static(benchStaticFS, "testdata/static", false)
+
+		req := httptest.NewRequest(http.MethodGet, "/app.js", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("WithFallback_ExistingFile", func(b *testing.B) {
+		router := NewRouter()
+		router.SetLogger(&noopLogger{})
+		router.Static(benchStaticFS, "testdata/static", true)
+
+		req := httptest.NewRequest(http.MethodGet, "/app.js", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("WithFallback_FallbackToIndex", func(b *testing.B) {
+		router := NewRouter()
+		router.SetLogger(&noopLogger{})
+		router.Static(benchStaticFS, "testdata/static", true)
+
+		// Non-existent path that triggers fallback to index.html
+		req := httptest.NewRequest(http.MethodGet, "/some/client/route", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("WithoutFallback_FileNotFound", func(b *testing.B) {
+		router := NewRouter()
+		router.SetLogger(&noopLogger{})
+		router.Static(benchStaticFS, "testdata/static", false)
+
+		// Non-existent path that returns 404
+		req := httptest.NewRequest(http.MethodGet, "/nonexistent/file", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+}
+
+// BenchmarkStatic_APIPrefixMatching measures the overhead of API prefix
+// checking for exclusions (e.g., /api/ routes).
+func BenchmarkStatic_APIPrefixMatching(b *testing.B) {
+	testCases := []struct {
+		name        string
+		apiPrefixes []string
+		path        string
+	}{
+		{"NoPrefixes", nil, "/app.js"},
+		{"OnePrefix_NoMatch", []string{"/api/"}, "/app.js"},
+		{"OnePrefix_Match", []string{"/api/"}, "/api/users"},
+		{"ManyPrefixes_NoMatch", []string{"/api/", "/v1/", "/v2/", "/internal/", "/admin/"}, "/app.js"},
+		{"ManyPrefixes_FirstMatch", []string{"/api/", "/v1/", "/v2/", "/internal/", "/admin/"}, "/api/users"},
+		{"ManyPrefixes_LastMatch", []string{"/api/", "/v1/", "/v2/", "/internal/", "/admin/"}, "/admin/users"},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			router := NewRouter()
+			router.SetLogger(&noopLogger{})
+			router.Static(benchStaticFS, "testdata/static", true, tc.apiPrefixes...)
+
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
+			}
+		})
+	}
+}
+
+// BenchmarkStatic_FileNotFoundHandling measures 404 response handling
+// for different file serving methods.
+func BenchmarkStatic_FileNotFoundHandling(b *testing.B) {
+	b.Run("EmbeddedFS_Static", func(b *testing.B) {
+		router := NewRouter()
+		router.SetLogger(&noopLogger{})
+		router.Static(benchStaticFS, "testdata/static", false)
+
+		req := httptest.NewRequest(http.MethodGet, "/nonexistent.js", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("Directory_StaticDir", func(b *testing.B) {
+		router := NewRouter()
+		router.SetLogger(&noopLogger{})
+		router.StaticDir("testdata/static", false)
+
+		req := httptest.NewRequest(http.MethodGet, "/nonexistent.js", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("EmbeddedFS_Files", func(b *testing.B) {
+		router := NewRouter()
+		router.SetLogger(&noopLogger{})
+		router.Files("/static/", benchFilesFS, "testdata/files")
+
+		req := httptest.NewRequest(http.MethodGet, "/static/nonexistent.txt", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("Directory_FilesDir", func(b *testing.B) {
+		router := NewRouter()
+		router.SetLogger(&noopLogger{})
+		router.FilesDir("/files/", "testdata/files")
+
+		req := httptest.NewRequest(http.MethodGet, "/files/nonexistent.txt", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+}
+
+// BenchmarkStatic_ETagGeneration measures ETag generation overhead when
+// serving static files.
+func BenchmarkStatic_ETagGeneration(b *testing.B) {
+	b.Run("WithETag", func(b *testing.B) {
+		router := NewRouter()
+		router.SetLogger(&noopLogger{})
+		cfg := config.DefaultConfig
+		cfg.RequestLogger.LogRequestBody = false
+		cfg.RequestLogger.LogResponseBody = false
+		router.SetConfig(cfg)
+		router.Static(benchStaticFS, "testdata/static", false)
+
+		req := httptest.NewRequest(http.MethodGet, "/app.js", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("ConditionalRequest", func(b *testing.B) {
+		router := NewRouter()
+		router.SetLogger(&noopLogger{})
+		router.Static(benchStaticFS, "testdata/static", false)
+
+		// First request to get the ETag
+		req := httptest.NewRequest(http.MethodGet, "/app.js", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		etag := w.Header().Get("Etag")
+
+		// Now benchmark conditional requests with If-None-Match
+		req = httptest.NewRequest(http.MethodGet, "/app.js", nil)
+		req.Header.Set("If-None-Match", etag)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		}
+	})
+}
+
+// BenchmarkStatic_FileTypes measures serving different file types.
+func BenchmarkStatic_FileTypes(b *testing.B) {
+	// Create temporary files of different types for benchmarking
+	tmpDir := b.TempDir()
+
+	files := map[string]struct {
+		name    string
+		content []byte
+	}{
+		"SmallJS":   {"small.js", []byte("console.log('hello');")},
+		"SmallHTML": {"small.html", []byte("<!DOCTYPE html><html><body>Hi</body></html>")},
+		"LargeJS":   {"large.js", make([]byte, 50000)},
+		"LargeHTML": {"large.html", make([]byte, 50000)},
+	}
+
+	// Fill large files with content
+	for i := range files["LargeJS"].content {
+		files["LargeJS"].content[i] = byte('a' + i%26)
+	}
+	for i := range files["LargeHTML"].content {
+		files["LargeHTML"].content[i] = byte('a' + i%26)
+	}
+
+	for name, file := range files {
+		path := filepath.Join(tmpDir, file.name)
+		if err := os.WriteFile(path, file.content, 0o644); err != nil {
+			b.Fatalf("failed to create test file: %v", err)
+		}
+
+		b.Run(name, func(b *testing.B) {
+			router := NewRouter()
+			router.SetLogger(&noopLogger{})
+			router.FilesDir("/files/", tmpDir)
+
+			req := httptest.NewRequest(http.MethodGet, "/files/"+file.name, nil)
+			b.SetBytes(int64(len(file.content)))
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
+			}
+		})
+	}
+}
+
+// BenchmarkStatic_Concurrent measures concurrent static file serving performance.
+func BenchmarkStatic_Concurrent(b *testing.B) {
+	concurrencyLevels := []int{1, 10, 100}
+
+	for _, concurrency := range concurrencyLevels {
+		b.Run(fmt.Sprintf("Goroutines%d", concurrency), func(b *testing.B) {
+			router := NewRouter()
+			router.SetLogger(&noopLogger{})
+			router.Static(benchStaticFS, "testdata/static", false)
+
+			req := httptest.NewRequest(http.MethodGet, "/app.js", nil)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, req)
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkStatic_DirectoryTraversal measures overhead of path cleaning
+// and directory traversal prevention.
+func BenchmarkStatic_DirectoryTraversal(b *testing.B) {
+	testPaths := []struct {
+		name string
+		path string
+	}{
+		{"CleanPath", "/app.js"},
+		{"WithDotSlash", "/./app.js"},
+		{"WithDoubleSlash", "//app.js"},
+		{"WithParentDir", "/../../app.js"},
+		{"DeepNested", "/a/b/c/../../../app.js"},
+	}
+
+	for _, tc := range testPaths {
+		b.Run(tc.name, func(b *testing.B) {
+			router := NewRouter()
+			router.SetLogger(&noopLogger{})
+			router.Static(benchStaticFS, "testdata/static", false)
+
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
+			}
+		})
+	}
+}

--- a/validate_bench_test.go
+++ b/validate_bench_test.go
@@ -1,0 +1,559 @@
+package zerohttp
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// BenchmarkValidator_SimpleStruct measures basic struct validation overhead.
+func BenchmarkValidator_SimpleStruct(b *testing.B) {
+	type SimpleUser struct {
+		Name  string `validate:"required"`
+		Email string `validate:"required,email"`
+		Age   int    `validate:"required,min=18,max=120"`
+	}
+
+	validUser := SimpleUser{
+		Name:  "John Doe",
+		Email: "john@example.com",
+		Age:   30,
+	}
+
+	validator := NewValidator()
+
+	b.Run("Valid", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validator.Struct(validUser)
+		}
+	})
+
+	b.Run("Invalid", func(b *testing.B) {
+		invalidUser := SimpleUser{
+			Name:  "",
+			Email: "invalid-email",
+			Age:   10,
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validator.Struct(invalidUser)
+		}
+	})
+}
+
+// BenchmarkValidator_FieldCount measures validation with different field counts.
+func BenchmarkValidator_FieldCount(b *testing.B) {
+	b.Run("5Fields", func(b *testing.B) {
+		type SmallStruct struct {
+			F1 string `validate:"required"`
+			F2 string `validate:"required"`
+			F3 int    `validate:"required,min=0"`
+			F4 int    `validate:"required,max=100"`
+			F5 string `validate:"email"`
+		}
+
+		s := SmallStruct{
+			F1: "val1",
+			F2: "val2",
+			F3: 50,
+			F4: 50,
+			F5: "test@example.com",
+		}
+
+		validator := NewValidator()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validator.Struct(s)
+		}
+	})
+
+	b.Run("20Fields", func(b *testing.B) {
+		type LargeStruct struct {
+			F1  string `validate:"required"`
+			F2  string `validate:"required"`
+			F3  string `validate:"required"`
+			F4  string `validate:"required"`
+			F5  string `validate:"required"`
+			F6  int    `validate:"required,min=0"`
+			F7  int    `validate:"required,min=0"`
+			F8  int    `validate:"required,min=0"`
+			F9  int    `validate:"required,min=0"`
+			F10 int    `validate:"required,min=0"`
+			F11 string `validate:"email"`
+			F12 string `validate:"email"`
+			F13 string `validate:"email"`
+			F14 string `validate:"email"`
+			F15 string `validate:"email"`
+			F16 string `validate:"url"`
+			F17 string `validate:"url"`
+			F18 string `validate:"url"`
+			F19 string `validate:"url"`
+			F20 string `validate:"url"`
+		}
+
+		s := LargeStruct{
+			F1: "val1", F2: "val2", F3: "val3", F4: "val4", F5: "val5",
+			F6: 10, F7: 20, F8: 30, F9: 40, F10: 50,
+			F11: "a@b.com", F12: "c@d.com", F13: "e@f.com", F14: "g@h.com", F15: "i@j.com",
+			F16: "http://a.com", F17: "http://b.com", F18: "http://c.com", F19: "http://d.com", F20: "http://e.com",
+		}
+
+		validator := NewValidator()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validator.Struct(s)
+		}
+	})
+}
+
+// BenchmarkValidator_NestedStruct measures nested struct validation performance.
+func BenchmarkValidator_NestedStruct(b *testing.B) {
+	type Address struct {
+		Street string `validate:"required"`
+		City   string `validate:"required"`
+		Zip    string `validate:"required,len=5"`
+	}
+
+	type Person struct {
+		Name    string  `validate:"required"`
+		Email   string  `validate:"required,email"`
+		Address Address `validate:"required"`
+	}
+
+	type Company struct {
+		Name    string  `validate:"required"`
+		CEO     Person  `validate:"required"`
+		CTO     Person  `validate:"required"`
+		Address Address `validate:"required"`
+	}
+
+	company := Company{
+		Name: "Acme Inc",
+		CEO: Person{
+			Name:  "John Doe",
+			Email: "john@acme.com",
+			Address: Address{
+				Street: "123 Main St",
+				City:   "New York",
+				Zip:    "10001",
+			},
+		},
+		CTO: Person{
+			Name:  "Jane Smith",
+			Email: "jane@acme.com",
+			Address: Address{
+				Street: "456 Tech Ave",
+				City:   "San Francisco",
+				Zip:    "94102",
+			},
+		},
+		Address: Address{
+			Street: "789 Corp Blvd",
+			City:   "Chicago",
+			Zip:    "60601",
+		},
+	}
+
+	validator := NewValidator()
+
+	b.Run("Shallow_1Level", func(b *testing.B) {
+		person := company.CEO
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validator.Struct(person)
+		}
+	})
+
+	b.Run("Deep_3Levels", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validator.Struct(company)
+		}
+	})
+}
+
+// BenchmarkValidator_SliceValidation measures slice/collection validation.
+func BenchmarkValidator_SliceValidation(b *testing.B) {
+	type Tag struct {
+		Name string `validate:"required"`
+	}
+
+	type Post struct {
+		Title string `validate:"required"`
+		Tags  []Tag  `validate:"dive"`
+	}
+
+	type Blog struct {
+		Posts []Post `validate:"dive"`
+	}
+
+	b.Run("SmallSlice_5Items", func(b *testing.B) {
+		tags := make([]Tag, 5)
+		for i := range 5 {
+			tags[i] = Tag{Name: fmt.Sprintf("tag%d", i)}
+		}
+		post := Post{Title: "Test Post", Tags: tags}
+
+		validator := NewValidator()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validator.Struct(post)
+		}
+	})
+
+	b.Run("LargeSlice_100Items", func(b *testing.B) {
+		tags := make([]Tag, 100)
+		for i := range 100 {
+			tags[i] = Tag{Name: fmt.Sprintf("tag%d", i)}
+		}
+		post := Post{Title: "Test Post", Tags: tags}
+
+		validator := NewValidator()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validator.Struct(post)
+		}
+	})
+
+	b.Run("NestedSlice", func(b *testing.B) {
+		posts := make([]Post, 10)
+		for i := range 10 {
+			tags := make([]Tag, 5)
+			for j := range 5 {
+				tags[j] = Tag{Name: fmt.Sprintf("tag%d-%d", i, j)}
+			}
+			posts[i] = Post{Title: fmt.Sprintf("Post %d", i), Tags: tags}
+		}
+		blog := Blog{Posts: posts}
+
+		validator := NewValidator()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validator.Struct(blog)
+		}
+	})
+}
+
+// BenchmarkValidator_IndividualValidators measures specific validator performance.
+func BenchmarkValidator_IndividualValidators(b *testing.B) {
+	validator := NewValidator()
+
+	type RequiredField struct {
+		Value string `validate:"required"`
+	}
+
+	type EmailField struct {
+		Value string `validate:"email"`
+	}
+
+	type URLField struct {
+		Value string `validate:"url"`
+	}
+
+	type UUIDField struct {
+		Value string `validate:"uuid"`
+	}
+
+	type NumericField struct {
+		Value int `validate:"min=10,max=100"`
+	}
+
+	type AlphaField struct {
+		Value string `validate:"alpha"`
+	}
+
+	type AlphanumericField struct {
+		Value string `validate:"alphanum"`
+	}
+
+	type LenField struct {
+		Value string `validate:"len=10"`
+	}
+
+	tests := []struct {
+		name     string
+		value    any
+		validVal any
+	}{
+		{"Required", RequiredField{"test"}, RequiredField{""}},
+		{"Email", EmailField{"test@example.com"}, EmailField{"invalid-email"}},
+		{"URL", URLField{"https://example.com"}, URLField{"not-a-url"}},
+		{"UUID", UUIDField{"550e8400-e29b-41d4-a716-446655440000"}, UUIDField{"not-a-uuid"}},
+		{"NumericMinMax", NumericField{50}, NumericField{5}},
+		{"Alpha", AlphaField{"abcdef"}, AlphaField{"abc123"}},
+		{"Alphanum", AlphanumericField{"abc123"}, AlphanumericField{"abc-123"}},
+		{"Len", LenField{"1234567890"}, LenField{"short"}},
+	}
+
+	for _, tc := range tests {
+		b.Run(tc.name+"_Valid", func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				_ = validator.Struct(tc.value)
+			}
+		})
+	}
+}
+
+// BenchmarkValidator_MapValidation measures map validation performance.
+func BenchmarkValidator_MapValidation(b *testing.B) {
+	type Config struct {
+		Settings map[string]string `validate:"required"`
+	}
+
+	b.Run("SmallMap_5Items", func(b *testing.B) {
+		settings := make(map[string]string, 5)
+		for i := range 5 {
+			settings[fmt.Sprintf("key%d", i)] = fmt.Sprintf("value%d", i)
+		}
+		cfg := Config{Settings: settings}
+
+		validator := NewValidator()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validator.Struct(cfg)
+		}
+	})
+
+	b.Run("LargeMap_100Items", func(b *testing.B) {
+		settings := make(map[string]string, 100)
+		for i := range 100 {
+			settings[fmt.Sprintf("key%d", i)] = fmt.Sprintf("value%d", i)
+		}
+		cfg := Config{Settings: settings}
+
+		validator := NewValidator()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validator.Struct(cfg)
+		}
+	})
+}
+
+// BenchmarkValidator_Concurrent measures concurrent validation performance.
+func BenchmarkValidator_Concurrent(b *testing.B) {
+	type User struct {
+		Name  string `validate:"required"`
+		Email string `validate:"required,email"`
+		Age   int    `validate:"min=18,max=120"`
+	}
+
+	user := User{
+		Name:  "John Doe",
+		Email: "john@example.com",
+		Age:   30,
+	}
+
+	validator := NewValidator()
+
+	b.Run("SharedValidator", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				_ = validator.Struct(user)
+			}
+		})
+	})
+
+	b.Run("NewValidatorPerGoroutine", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			v := NewValidator()
+			for pb.Next() {
+				_ = v.Struct(user)
+			}
+		})
+	})
+}
+
+// BenchmarkValidator_CustomValidator measures custom validator registration and use.
+func BenchmarkValidator_CustomValidator(b *testing.B) {
+	type CustomValidated struct {
+		Value string `validate:"customRule"`
+	}
+
+	validator := NewValidator()
+	validator.Register("customRule", func(value reflect.Value, param string) error {
+		if value.String() == "forbidden" {
+			return fmt.Errorf("value is forbidden")
+		}
+		return nil
+	})
+
+	s := CustomValidated{Value: "allowed"}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = validator.Struct(s)
+	}
+}
+
+// BenchmarkValidator_OneOf measures oneof validation performance.
+func BenchmarkValidator_OneOf(b *testing.B) {
+	type StatusField struct {
+		Status string `validate:"oneof=active inactive pending"`
+	}
+
+	validator := NewValidator()
+
+	b.Run("MatchFirst", func(b *testing.B) {
+		s := StatusField{Status: "active"}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validator.Struct(s)
+		}
+	})
+
+	b.Run("MatchLast", func(b *testing.B) {
+		s := StatusField{Status: "pending"}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validator.Struct(s)
+		}
+	})
+}
+
+// BenchmarkValidator_PointerValidation measures pointer field validation.
+func BenchmarkValidator_PointerValidation(b *testing.B) {
+	name := "John"
+	email := "john@example.com"
+	age := 30
+
+	type PointerFields struct {
+		Name  *string `validate:"required"`
+		Email *string `validate:"required,email"`
+		Age   *int    `validate:"required,min=0"`
+	}
+
+	s := PointerFields{
+		Name:  &name,
+		Email: &email,
+		Age:   &age,
+	}
+
+	validator := NewValidator()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = validator.Struct(s)
+	}
+}
+
+// BenchmarkValidator_StringValidation measures various string validators.
+func BenchmarkValidator_StringValidation(b *testing.B) {
+	validator := NewValidator()
+
+	b.Run("Lowercase", func(b *testing.B) {
+		type S struct {
+			Field string `validate:"lowercase"`
+		}
+		s := S{Field: "hello world"}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validator.Struct(s)
+		}
+	})
+
+	b.Run("Uppercase", func(b *testing.B) {
+		type S struct {
+			Field string `validate:"uppercase"`
+		}
+		s := S{Field: "HELLO WORLD"}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validator.Struct(s)
+		}
+	})
+
+	b.Run("Contains", func(b *testing.B) {
+		type S struct {
+			Field string `validate:"contains=world"`
+		}
+		s := S{Field: "hello world"}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validator.Struct(s)
+		}
+	})
+
+	b.Run("ContainsAny", func(b *testing.B) {
+		type S struct {
+			Field string `validate:"containsany=xyz"`
+		}
+		s := S{Field: "hello world"}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validator.Struct(s)
+		}
+	})
+
+	b.Run("IP", func(b *testing.B) {
+		type S struct {
+			Field string `validate:"ip"`
+		}
+		s := S{Field: "192.168.1.1"}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validator.Struct(s)
+		}
+	})
+
+	b.Run("Base64", func(b *testing.B) {
+		type S struct {
+			Field string `validate:"base64"`
+		}
+		s := S{Field: "aGVsbG8="}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validator.Struct(s)
+		}
+	})
+
+	b.Run("Hexadecimal", func(b *testing.B) {
+		type S struct {
+			Field string `validate:"hexadecimal"`
+		}
+		s := S{Field: "deadbeef"}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validator.Struct(s)
+		}
+	})
+}


### PR DESCRIPTION
Add benchmarks for router, binding, rendering, validation, SSE, static files, and all middleware components. Each benchmark includes baseline comparisons, payload size variations, concurrent scenarios, and allocation metrics.