### PR TITLE
feat: add path traversal protection to static file handler

### DIFF
--- a/router.go
+++ b/router.go
@@ -451,7 +451,6 @@ func (r *defaultRouter) StaticDir(dir string, fallback bool, apiPrefix ...string
 	r.mux.Handle("GET /{path...}", r.wrap(handler, nil))
 }
 
-// createStaticHandler creates an HTTP handler for static routing with API prefix exclusions.
 func (r *defaultRouter) createStaticHandler(filesystem fs.FS, fallback bool, apiPrefixes []string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		start := time.Now()
@@ -461,7 +460,17 @@ func (r *defaultRouter) createStaticHandler(filesystem fs.FS, fallback bool, api
 		}
 		w.Header().Set(r.config.RequestID.Header, requestID)
 
-		cleanPath := path.Clean(req.URL.Path)
+		// Security: reject any request whose raw path contains ".." before
+		// it can be resolved away by cleaning. fs.FS also enforces this at
+		// Open time via fs.ValidPath, but blocking early allows accurate logging.
+		if strings.Contains(req.URL.Path, "..") {
+			r.logger.Warn("Path traversal attempt blocked", log.F("path", req.URL.Path))
+			r.notFoundHandler.ServeHTTP(w, req)
+			middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusNotFound, time.Since(start), "", "")
+			return
+		}
+
+		cleanPath := path.Clean(req.URL.Path) // ✅ path.Clean, not filepath.Clean
 
 		// Skip API routes - return 404
 		for _, prefix := range apiPrefixes {
@@ -488,12 +497,10 @@ func (r *defaultRouter) createStaticHandler(filesystem fs.FS, fallback bool, api
 		}
 
 		if fallback {
-			// Fallback to index.html for client-side routing
 			req.URL.Path = "/"
 			http.FileServer(http.FS(filesystem)).ServeHTTP(w, req)
 			middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusOK, time.Since(start), "", "")
 		} else {
-			// Use custom 404 handler for missing files
 			r.notFoundHandler.ServeHTTP(w, req)
 			middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusNotFound, time.Since(start), "", "")
 		}

--- a/router_test.go
+++ b/router_test.go
@@ -934,6 +934,19 @@ func TestRouter_Static(t *testing.T) {
 
 		zhtest.AssertWith(t, w).Status(http.StatusNotFound)
 	})
+
+	t.Run("Static - path traversal blocked", func(t *testing.T) {
+		router := NewRouter()
+		router.Static(testStaticFS, "testdata/static", false)
+
+		// URL-encoded traversal - should be blocked (decoded to .. before check)
+		req := httptest.NewRequest(http.MethodGet, "/..%2f..%2f..%2fetc/passwd", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		// Should return 404, not serve any file
+		zhtest.AssertWith(t, w).Status(http.StatusNotFound)
+	})
 }
 
 func TestRouter_ServeMux(t *testing.T) {


### PR DESCRIPTION
Add check for ".." in raw URL path before cleaning. Blocks traversal attempts early with logging. Uses path.Clean (not filepath.Clean) for URL paths. fs.FS enforces this via fs.ValidPath at Open time as defense in depth. Includes test for encoded traversal attempts.