### PR TITLE
fix: remove silent fallback to predictable request IDs

### DIFF
--- a/config/request_id.go
+++ b/config/request_id.go
@@ -3,8 +3,6 @@ package config
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"fmt"
-	"time"
 )
 
 // RequestIDContextKey is a custom type for context keys to avoid collisions.
@@ -15,6 +13,7 @@ type RequestIDConfig struct {
 	// Header is the header name for the request ID (defaults to "X-Request-Id").
 	Header string
 	// Generator is a custom function to generate request IDs.
+	// The default generator uses crypto/rand (CSPRNG) for 128 bits of entropy.
 	Generator func() string
 	// ContextKey is the key to store the request ID in context (defaults to "request_id").
 	ContextKey RequestIDContextKey
@@ -27,12 +26,10 @@ var DefaultRequestIDConfig = RequestIDConfig{
 	ContextKey: RequestIDContextKey("request_id"),
 }
 
-// GenerateRequestID creates a unique request ID.
+// GenerateRequestID creates a unique request ID using crypto/rand.
+// Returns a 32-character hex string with 128 bits of entropy.
 func GenerateRequestID() string {
 	bytes := make([]byte, 16)
-	if _, err := rand.Read(bytes); err != nil {
-		// Fallback to timestamp-based ID
-		return fmt.Sprintf("request-%d", time.Now().UnixNano())
-	}
+	_, _ = rand.Read(bytes)
 	return hex.EncodeToString(bytes)
 }

--- a/config/request_id_test.go
+++ b/config/request_id_test.go
@@ -55,14 +55,6 @@ func TestGenerateRequestID(t *testing.T) {
 		}
 	})
 
-	t.Run("fallback format", func(t *testing.T) {
-		timestampPattern := regexp.MustCompile(`^request-\d+$`)
-		fallbackID := "request-1640995200000000000"
-		if !timestampPattern.MatchString(fallbackID) {
-			t.Errorf("fallback ID format should match 'request-', example: %s", fallbackID)
-		}
-	})
-
 	t.Run("performance", func(t *testing.T) {
 		start := time.Now()
 		iterations := 1000


### PR DESCRIPTION
  The GenerateRequestID() function previously fell back to time.Now().UnixNano()
  if crypto/rand failed, producing predictable sequential IDs without logging.

  On Go 1.20+, crypto/rand.Read never returns an error on supported platforms,
  so the fallback has been removed entirely.