### PR TITLE
feat: auto-generate OPTIONS responses with Allow header

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A lightweight HTTP framework for Go built on top of the standard `net/http` libr
 - [Error Handling](#error-handling)
   - [Validation Errors](#validation-errors)
 - [Route Groups](#route-groups)
+- [Automatic OPTIONS Responses](#automatic-options-responses)
 - [Middleware](#middleware)
   - [Available Middlewares](#available-middlewares)
 - [Graceful Shutdown](#graceful-shutdown)
@@ -51,7 +52,7 @@ A lightweight HTTP framework for Go built on top of the standard `net/http` libr
 - **Request Binding**: JSON, form, multipart form, and query parameter parsing with struct tag binding
 - **Validation**: Built-in struct tag-based validation with 40+ validators
 - **Problem Details**: RFC 9457 Problem Details for HTTP APIs error responses
-- **Flexible Routing**: Method-based routing with route groups and parameter support
+- **Flexible Routing**: Method-based routing with route groups, parameter support, and automatic OPTIONS responses
 - **Middleware Support**: Comprehensive middleware system with built-in security, logging, and utility middlewares
 - **Built-in Security**: CORS, rate limiting, request body size limits, security headers, and more
 - **HTTP/2 & HTTP/3**: Automatic HTTP/2 support for TLS; optional HTTP/3 via pluggable interface
@@ -245,6 +246,30 @@ app.Group(func(api zh.Router) {
     api.PUT("/users/{id}", updateUser)
     api.DELETE("/users/{id}", deleteUser)
 })
+```
+
+## Automatic OPTIONS Responses
+
+The router automatically responds to OPTIONS requests with accurate `Allow` headers listing the registered methods for each path:
+
+```
+OPTIONS /api/users HTTP/1.1
+
+HTTP/1.1 204 No Content
+Allow: DELETE, GET, HEAD, OPTIONS, POST, PUT
+```
+
+- **Implicit HEAD**: Automatically included when GET is registered
+- **Always includes OPTIONS**: OPTIONS is always listed as an allowed method
+- **Explicit handlers take precedence**: Register your own OPTIONS handler to customize behavior
+
+```go
+// Custom OPTIONS handler - takes precedence over auto-generated response
+app.OPTIONS("/api/special", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    w.Header().Set("Allow", "GET, POST, CUSTOM")
+    w.Header().Set("X-Custom-Header", "value")
+    w.WriteHeader(http.StatusNoContent)
+}))
 ```
 
 ## Middleware

--- a/router.go
+++ b/router.go
@@ -635,6 +635,16 @@ func (r *defaultRouter) catchAllHandler() http.HandlerFunc {
 		}
 
 		if methods, exists := r.registeredRoutes[req.URL.Path]; exists {
+			// Auto-generate OPTIONS response
+			if req.Method == http.MethodOptions {
+				w.Header().Set(HeaderAllow, allowedMethods(methods))
+				w.WriteHeader(http.StatusNoContent)
+				if shouldLog {
+					middleware.LogRequest(r.logger, r.config.RequestLogger, nil, req, http.StatusNoContent, time.Since(start), "", "")
+				}
+				return
+			}
+
 			if !methods[req.Method] {
 				w.Header().Set(HeaderAllow, allowedMethods(methods))
 
@@ -697,10 +707,20 @@ func jsonMethodNotAllowedHandler(w http.ResponseWriter, r *http.Request) {
 
 // allowedMethods converts a map of HTTP methods to a comma-separated string
 // suitable for the "Allow" header in 405 Method Not Allowed responses.
+// Implicit HEAD is included if GET is present. OPTIONS is always included.
 func allowedMethods(methods map[string]bool) string {
-	var result []string
+	result := make([]string, 0, len(methods)+2)
 	for method := range methods {
 		result = append(result, method)
 	}
+	// Implicit HEAD when GET is registered
+	if methods[http.MethodGet] && !methods[http.MethodHead] {
+		result = append(result, http.MethodHead)
+	}
+	// OPTIONS is always implicitly allowed
+	if !methods[http.MethodOptions] {
+		result = append(result, http.MethodOptions)
+	}
+	slices.Sort(result)
 	return strings.Join(result, ", ")
 }

--- a/router_test.go
+++ b/router_test.go
@@ -547,6 +547,69 @@ func TestRouter_ErrorHandlers(t *testing.T) {
 			Body("Custom 405")
 	})
 
+	t.Run("auto OPTIONS response", func(t *testing.T) {
+		router := NewRouter()
+		router.GET("/test", testHandler("get"))
+		router.POST("/test", testHandler("post"))
+
+		req := httptest.NewRequest(http.MethodOptions, "/test", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		zhtest.AssertWith(t, w).Status(http.StatusNoContent)
+
+		allowHeader := w.Header().Get("Allow")
+		if allowHeader == "" {
+			t.Error("Expected Allow header to be set")
+		}
+		// Should contain GET, POST, and implicit HEAD and OPTIONS
+		if !strings.Contains(allowHeader, http.MethodGet) {
+			t.Errorf("Expected Allow header to contain GET, got '%s'", allowHeader)
+		}
+		if !strings.Contains(allowHeader, http.MethodPost) {
+			t.Errorf("Expected Allow header to contain POST, got '%s'", allowHeader)
+		}
+		if !strings.Contains(allowHeader, http.MethodHead) {
+			t.Errorf("Expected Allow header to contain implicit HEAD, got '%s'", allowHeader)
+		}
+		if !strings.Contains(allowHeader, http.MethodOptions) {
+			t.Errorf("Expected Allow header to contain OPTIONS, got '%s'", allowHeader)
+		}
+	})
+
+	t.Run("auto OPTIONS for unknown path returns 404", func(t *testing.T) {
+		router := NewRouter()
+		router.GET("/test", testHandler("get"))
+
+		req := httptest.NewRequest(http.MethodOptions, "/unknown", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		zhtest.AssertWith(t, w).Status(http.StatusNotFound)
+	})
+
+	t.Run("explicit OPTIONS handler takes precedence", func(t *testing.T) {
+		router := NewRouter()
+		router.GET("/test", testHandler("get"))
+		router.OPTIONS("/test", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Allow", "CUSTOM")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("custom options"))
+		}))
+
+		req := httptest.NewRequest(http.MethodOptions, "/test", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		zhtest.AssertWith(t, w).
+			Status(http.StatusOK).
+			Body("custom options")
+
+		if w.Header().Get("Allow") != "CUSTOM" {
+			t.Errorf("Expected Allow header to be 'CUSTOM', got '%s'", w.Header().Get("Allow"))
+		}
+	})
+
 	// Test fallback path when ProblemDetail fails
 	t.Run("default not found handler fallback", func(t *testing.T) {
 		// Use a response writer that fails when writing the JSON body
@@ -727,9 +790,20 @@ func TestUtilityFunctions(t *testing.T) {
 			}
 		}
 
+		// Implicit HEAD is added when GET is present
+		if !strings.Contains(result, http.MethodHead) {
+			t.Errorf("Expected result to contain implicit HEAD, got '%s'", result)
+		}
+
+		// OPTIONS is always implicitly allowed
+		if !strings.Contains(result, http.MethodOptions) {
+			t.Errorf("Expected result to contain OPTIONS, got '%s'", result)
+		}
+
 		parts := strings.Split(result, ", ")
-		if len(parts) != 3 {
-			t.Errorf("Expected 3 methods separated by commas, got %d parts", len(parts))
+		// 3 registered + implicit HEAD + implicit OPTIONS = 5
+		if len(parts) != 5 {
+			t.Errorf("Expected 5 methods separated by commas, got %d parts: %s", len(parts), result)
 		}
 	})
 }


### PR DESCRIPTION
Router now automatically handles OPTIONS requests for registered paths, returning 204 No Content with an accurate Allow header. Explicit OPTIONS handlers take precedence.