### PR TITLE
feat: add HTTP cache middleware and update JWT TokenStore interface

### DIFF
--- a/config/basic_auth.go
+++ b/config/basic_auth.go
@@ -4,10 +4,13 @@ package config
 type BasicAuthConfig struct {
 	// Realm is the authentication realm (defaults to "Restricted")
 	Realm string
+
 	// Credentials is a map of username -> password
 	Credentials map[string]string
+
 	// Validator is a custom function to validate credentials (optional)
 	Validator func(username, password string) bool
+
 	// ExemptPaths contains paths that skip basic auth (e.g., /health, /login, /signup)
 	ExemptPaths []string
 }

--- a/config/cache.go
+++ b/config/cache.go
@@ -1,0 +1,90 @@
+package config
+
+import (
+	"context"
+	"time"
+)
+
+// CacheStore is the interface for cache storage backends.
+// Users can implement this interface to provide their own storage
+// (e.g., Redis, database, or distributed cache).
+type CacheStore interface {
+	// Get retrieves a cached response by key.
+	// Returns the cached record, true if found, and any error.
+	// If not found, returns false and nil error.
+	// If an error occurs (e.g., network error), returns false and the error.
+	Get(ctx context.Context, key string) (CacheRecord, bool, error)
+
+	// Set stores a response in the cache with the given TTL.
+	// Returns an error if the operation fails (e.g., network error for external stores).
+	Set(ctx context.Context, key string, record CacheRecord, ttl time.Duration) error
+}
+
+// CacheRecord represents a cached HTTP response.
+type CacheRecord struct {
+	StatusCode   int
+	Headers      map[string][]string
+	Body         []byte
+	ETag         string
+	LastModified time.Time
+	VaryHeaders  map[string]string
+}
+
+// CacheConfig configures the HTTP cache middleware.
+type CacheConfig struct {
+	// CacheControl sets the Cache-Control header on responses.
+	// Default: "private, max-age=60"
+	CacheControl string
+
+	// DefaultTTL is the default cache duration.
+	// Default: 1m
+	DefaultTTL time.Duration
+
+	// MaxBodySize is the maximum response body size to cache (in bytes).
+	// Responses larger than this are not cached.
+	// Default: 10MB
+	MaxBodySize int64
+
+	// MaxEntries is the maximum number of entries to keep in the in-memory cache.
+	// Set to 0 for unlimited (not recommended for production).
+	// Default: 10000
+	MaxEntries int
+
+	// ETag enables automatic ETag generation (SHA256 hash of body).
+	// Default: true
+	ETag bool
+
+	// LastModified enables automatic Last-Modified timestamp.
+	// Default: true
+	LastModified bool
+
+	// Vary headers that should be included in the cache key.
+	// Default: ["Accept", "Accept-Encoding", "Accept-Language"]
+	Vary []string
+
+	// Store is a custom cache store implementation.
+	// If nil, an in-memory LRU cache is used.
+	// Default: nil
+	Store CacheStore
+
+	// ExemptPaths are paths that should not be cached.
+	// Default: []
+	ExemptPaths []string
+
+	// StatusCodes is a list of status codes that can be cached.
+	// Default: [200, 201, 204, 301, 302, 304, 307, 308]
+	StatusCodes []int
+}
+
+// DefaultCacheConfig is the default configuration for the cache middleware.
+var DefaultCacheConfig = CacheConfig{
+	CacheControl: "private, max-age=60",
+	DefaultTTL:   time.Minute,
+	MaxBodySize:  10 * 1024 * 1024,
+	MaxEntries:   10000,
+	ETag:         true,
+	LastModified: true,
+	Vary:         []string{"Accept", "Accept-Encoding", "Accept-Language"},
+	ExemptPaths:  []string{},
+	StatusCodes:  []int{200, 201, 204, 301, 302, 304, 307, 308},
+}

--- a/config/cache_test.go
+++ b/config/cache_test.go
@@ -1,0 +1,147 @@
+package config
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestDefaultCacheConfig(t *testing.T) {
+	t.Run("default values are set", func(t *testing.T) {
+		cfg := DefaultCacheConfig
+
+		if cfg.CacheControl != "private, max-age=60" {
+			t.Errorf("expected CacheControl 'private, max-age=60', got %q", cfg.CacheControl)
+		}
+
+		if cfg.DefaultTTL != time.Minute {
+			t.Errorf("expected DefaultTTL 1m, got %v", cfg.DefaultTTL)
+		}
+
+		if cfg.MaxBodySize != 10*1024*1024 {
+			t.Errorf("expected MaxBodySize 10MB, got %d", cfg.MaxBodySize)
+		}
+
+		if cfg.MaxEntries != 10000 {
+			t.Errorf("expected MaxEntries 10000, got %d", cfg.MaxEntries)
+		}
+
+		if !cfg.ETag {
+			t.Error("expected ETag to be true by default")
+		}
+
+		if !cfg.LastModified {
+			t.Error("expected LastModified to be true by default")
+		}
+
+		expectedVary := []string{"Accept", "Accept-Encoding", "Accept-Language"}
+		if len(cfg.Vary) != len(expectedVary) {
+			t.Errorf("expected Vary %v, got %v", expectedVary, cfg.Vary)
+		}
+		for i, v := range expectedVary {
+			if cfg.Vary[i] != v {
+				t.Errorf("expected Vary[%d] %q, got %q", i, v, cfg.Vary[i])
+			}
+		}
+
+		if cfg.Store != nil {
+			t.Error("expected Store to be nil by default")
+		}
+
+		if len(cfg.ExemptPaths) != 0 {
+			t.Errorf("expected ExemptPaths to be empty, got %v", cfg.ExemptPaths)
+		}
+
+		expectedStatusCodes := []int{200, 201, 204, 301, 302, 304, 307, 308}
+		if len(cfg.StatusCodes) != len(expectedStatusCodes) {
+			t.Errorf("expected %d status codes, got %d", len(expectedStatusCodes), len(cfg.StatusCodes))
+		}
+	})
+}
+
+func TestCacheRecord(t *testing.T) {
+	t.Run("cache record fields", func(t *testing.T) {
+		record := CacheRecord{
+			StatusCode:   200,
+			Headers:      map[string][]string{"Content-Type": {"application/json"}},
+			Body:         []byte(`{"message":"hello"}`),
+			ETag:         `"abc123"`,
+			LastModified: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			VaryHeaders:  map[string]string{"Accept": "application/json"},
+		}
+
+		if record.StatusCode != 200 {
+			t.Errorf("expected StatusCode 200, got %d", record.StatusCode)
+		}
+
+		if string(record.Body) != `{"message":"hello"}` {
+			t.Errorf("expected Body %q, got %q", `{"message":"hello"}`, string(record.Body))
+		}
+
+		if record.ETag != `"abc123"` {
+			t.Errorf("expected ETag %q, got %q", `"abc123"`, record.ETag)
+		}
+	})
+}
+
+func TestCacheConfigCustomization(t *testing.T) {
+	t.Run("custom config values", func(t *testing.T) {
+		customStore := &mockCacheStore{}
+
+		cfg := CacheConfig{
+			CacheControl: "public, max-age=3600",
+			DefaultTTL:   time.Hour,
+			MaxBodySize:  5 * 1024 * 1024,
+			MaxEntries:   5000,
+			ETag:         false,
+			LastModified: false,
+			Vary:         []string{"Accept"},
+			Store:        customStore,
+			ExemptPaths:  []string{"/api/live", "/health"},
+			StatusCodes:  []int{200, 201},
+		}
+
+		if cfg.CacheControl != "public, max-age=3600" {
+			t.Errorf("expected CacheControl 'public, max-age=3600', got %q", cfg.CacheControl)
+		}
+
+		if cfg.DefaultTTL != time.Hour {
+			t.Errorf("expected DefaultTTL 1h, got %v", cfg.DefaultTTL)
+		}
+
+		if cfg.MaxBodySize != 5*1024*1024 {
+			t.Errorf("expected MaxBodySize 5MB, got %d", cfg.MaxBodySize)
+		}
+
+		if cfg.MaxEntries != 5000 {
+			t.Errorf("expected MaxEntries 5000, got %d", cfg.MaxEntries)
+		}
+
+		if cfg.ETag {
+			t.Error("expected ETag to be false")
+		}
+
+		if cfg.LastModified {
+			t.Error("expected LastModified to be false")
+		}
+
+		if cfg.Store != customStore {
+			t.Error("expected custom store to be set")
+		}
+
+		if len(cfg.ExemptPaths) != 2 {
+			t.Errorf("expected 2 exempt paths, got %d", len(cfg.ExemptPaths))
+		}
+	})
+}
+
+// mockCacheStore is a minimal implementation for testing
+type mockCacheStore struct{}
+
+func (m *mockCacheStore) Get(ctx context.Context, key string) (CacheRecord, bool, error) {
+	return CacheRecord{}, false, nil
+}
+
+func (m *mockCacheStore) Set(ctx context.Context, key string, record CacheRecord, ttl time.Duration) error {
+	return nil
+}

--- a/config/circuit_breaker.go
+++ b/config/circuit_breaker.go
@@ -9,19 +9,26 @@ import (
 type CircuitBreakerConfig struct {
 	// FailureThreshold is the number of consecutive failures before opening the circuit
 	FailureThreshold int
+
 	// RecoveryTimeout is how long to wait before trying to close the circuit
 	RecoveryTimeout time.Duration
+
 	// SuccessThreshold is the number of consecutive successes needed to close the circuit from half-open
 	SuccessThreshold int
+
 	// MaxHalfOpenRequests is the maximum number of concurrent requests allowed in half-open state.
 	// This prevents thundering herd when service recovers. Default is 1.
 	MaxHalfOpenRequests int
+
 	// IsFailure determines if a response should be considered a failure
 	IsFailure func(*http.Request, int) bool
+
 	// KeyExtractor extracts the circuit breaker key from the request (for per-endpoint circuits)
 	KeyExtractor func(*http.Request) string
+
 	// OpenStatusCode is the status code to return when circuit is open
 	OpenStatusCode int
+
 	// OpenMessage is the message to return when circuit is open
 	OpenMessage string
 }

--- a/config/compress.go
+++ b/config/compress.go
@@ -25,6 +25,7 @@ type CompressionEncoder interface {
 	// Encode wraps the provided io.Writer with compression.
 	// The level parameter is algorithm-specific (e.g., 1-9 for gzip, 0-11 for brotli).
 	Encode(w io.Writer, level int) io.Writer
+
 	// Encoding returns the encoding name used in Accept-Encoding/Content-Encoding headers.
 	// Common values: "gzip", "deflate", "br" (brotli), "zstd".
 	Encoding() string
@@ -59,12 +60,16 @@ type CompressionProvider interface {
 type CompressConfig struct {
 	// Level is the compression level (1-9 for gzip/deflate)
 	Level int
+
 	// Types are MIME types to compress (defaults to common text types)
 	Types []string
+
 	// Algorithms are compression algorithms to support (defaults to gzip, deflate)
 	Algorithms []CompressionAlgorithm
+
 	// ExemptPaths contains paths to skip compression
 	ExemptPaths []string
+
 	// Provider is an optional custom compression provider.
 	// If set, the provider's encoders will be used in addition to built-in gzip/deflate.
 	// This allows users to add Brotli, zstd, or other algorithms without core dependencies.

--- a/config/content_encoding.go
+++ b/config/content_encoding.go
@@ -4,6 +4,7 @@ package config
 type ContentEncodingConfig struct {
 	// Encodings is a list of allowed content encodings (gzip, deflate, br, etc.)
 	Encodings []string
+
 	// ExemptPaths contains paths that skip content encoding validation
 	ExemptPaths []string
 }

--- a/config/content_type.go
+++ b/config/content_type.go
@@ -4,6 +4,7 @@ package config
 type ContentTypeConfig struct {
 	// ContentTypes is a list of allowed content types
 	ContentTypes []string
+
 	// ExemptPaths contains paths that skip content type validation
 	ExemptPaths []string
 }

--- a/config/cors.go
+++ b/config/cors.go
@@ -10,20 +10,28 @@ type OriginValidator func(origin string) bool
 type CORSConfig struct {
 	// AllowedOrigins is a list of allowed origins. Use ["*"] to allow all origins
 	AllowedOrigins []string
+
 	// AllowedMethods is a list of allowed HTTP methods (defaults to common methods)
 	AllowedMethods []string
+
 	// AllowedHeaders is a list of allowed request headers (defaults to common headers)
 	AllowedHeaders []string
+
 	// ExposedHeaders is a list of headers exposed to the client
 	ExposedHeaders []string
+
 	// AllowCredentials indicates whether credentials are allowed
 	AllowCredentials bool
+
 	// MaxAge indicates how long preflight requests can be cached (in seconds)
 	MaxAge int
+
 	// OptionsPassthrough allows OPTIONS requests to be passed to the next handler
 	OptionsPassthrough bool
+
 	// ExemptPaths contains paths that skip CORS processing
 	ExemptPaths []string
+
 	// AllowOriginFunc is a custom function to validate origins dynamically.
 	// If set, this takes precedence over AllowedOrigins matching.
 	AllowOriginFunc OriginValidator

--- a/config/csrf.go
+++ b/config/csrf.go
@@ -2,8 +2,6 @@ package config
 
 import (
 	"net/http"
-
-	"github.com/alexferl/zerohttp/log"
 )
 
 // CSRFConfig holds configuration for CSRF protection
@@ -59,11 +57,6 @@ type CSRFConfig struct {
 	// TokenGenerator is an optional function for generating CSRF tokens.
 	// Defaults to crypto-secure random generation.
 	TokenGenerator func(key []byte) (string, error)
-
-	// Logger is used to log errors during CSRF token generation.
-	// If nil, the global logger will be used.
-	// Default: nil
-	Logger log.Logger
 }
 
 // DefaultCSRFConfig contains the default values for CSRF configuration

--- a/config/etag.go
+++ b/config/etag.go
@@ -16,17 +16,23 @@ const (
 type ETagConfig struct {
 	// Algorithm selects the hashing function (defaults to FNV)
 	Algorithm ETagAlgorithm
+
 	// Weak determines if ETags should be prefixed with "W/" (defaults to true)
 	// Use a pointer to distinguish between "not set" and "explicitly set to false"
 	Weak *bool
+
 	// MaxBufferSize is the maximum response body size to buffer for ETag generation (defaults to 1MB)
 	MaxBufferSize int
+
 	// SkipStatusCodes contains status codes that should not have ETags generated (defaults to error status codes)
 	SkipStatusCodes map[int]struct{}
+
 	// SkipContentTypes contains content types that should not have ETags generated
 	SkipContentTypes map[string]struct{}
+
 	// ExemptPaths contains paths to skip ETag generation
 	ExemptPaths []string
+
 	// ExemptFunc is a custom function to determine if ETag generation should be skipped for a request
 	ExemptFunc func(r *http.Request) bool
 }

--- a/config/jwt_auth.go
+++ b/config/jwt_auth.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"time"
@@ -24,21 +25,22 @@ const (
 type TokenStore interface {
 	// Validate parses and validates a JWT token, returning the claims.
 	// Returns (claims, nil) on valid token, (nil, error) on invalid.
-	Validate(token string) (JWTClaims, error)
+	Validate(ctx context.Context, token string) (JWTClaims, error)
 
 	// Generate creates a new signed JWT token for the given claims.
 	// Used for access tokens and refresh tokens.
-	Generate(claims JWTClaims, tokenType TokenType) (string, error)
+	Generate(ctx context.Context, claims JWTClaims, tokenType TokenType) (string, error)
 
 	// Revoke invalidates a refresh token (called during logout).
 	// Implement this to store revoked token identifiers (e.g., jti) in database/Redis.
 	// Return nil if revocation succeeds or if token doesn't need revocation.
-	Revoke(claims JWTClaims) error
+	Revoke(ctx context.Context, claims JWTClaims) error
 
 	// IsRevoked checks if a refresh token has been revoked.
-	// Return true if token was revoked, false otherwise.
+	// Return (true, nil) if token was revoked, (false, nil) if not revoked.
+	// Return error if the check fails (e.g., database connection error).
 	// Called during token refresh to prevent use of revoked tokens.
-	IsRevoked(claims JWTClaims) bool
+	IsRevoked(ctx context.Context, claims JWTClaims) (bool, error)
 }
 
 // JWTAuthConfig configures JWT authentication middleware

--- a/config/rate_limit.go
+++ b/config/rate_limit.go
@@ -32,23 +32,32 @@ type KeyExtractor func(*http.Request) string
 type RateLimitConfig struct {
 	// Rate is requests per window (defaults to 100)
 	Rate int
+
 	// Window is the time window duration (defaults to 1 minute)
 	Window time.Duration
+
 	// Algorithm to use (defaults to TokenBucket)
 	Algorithm RateLimitAlgorithm
+
 	// KeyExtractor function to get rate limit key (defaults to IP-based)
 	KeyExtractor KeyExtractor
+
 	// StatusCode to return when rate limited (defaults to 429)
 	StatusCode int
+
 	// Message to return when rate limited
 	Message string
+
 	// Headers to include in response
 	IncludeHeaders bool
+
 	// ExemptPaths contains paths to skip rate limiting
 	ExemptPaths []string
+
 	// Store is the storage backend for rate limiting.
 	// If nil, a secure in-memory store is used.
 	Store RateLimitStore
+
 	// MaxKeys limits the number of unique keys stored in the default
 	// in-memory store. Defaults to 10000. Set to 0 for unlimited (not recommended).
 	MaxKeys int

--- a/config/recover.go
+++ b/config/recover.go
@@ -4,8 +4,10 @@ package config
 type RecoverConfig struct {
 	// StackSize is the maximum size of the stack trace in bytes (defaults to 4KB)
 	StackSize int64
+
 	// EnableStackTrace determines if stack traces should be included (defaults to true)
 	EnableStackTrace bool
+
 	// RequestIDHeader is the header name for the request ID (defaults to "X-Request-Id")
 	// This should match the header configured in RequestIDConfig
 	RequestIDHeader string

--- a/config/request_body_size.go
+++ b/config/request_body_size.go
@@ -4,6 +4,7 @@ package config
 type RequestBodySizeConfig struct {
 	// MaxBytes is the maximum request body size in bytes.
 	MaxBytes int64
+
 	// ExemptPaths contains paths that skip body size limiting.
 	ExemptPaths []string
 }

--- a/config/request_id.go
+++ b/config/request_id.go
@@ -12,9 +12,11 @@ type RequestIDContextKey string
 type RequestIDConfig struct {
 	// Header is the header name for the request ID (defaults to "X-Request-Id").
 	Header string
+
 	// Generator is a custom function to generate request IDs.
 	// The default generator uses crypto/rand (CSPRNG) for 128 bits of entropy.
 	Generator func() string
+
 	// ContextKey is the key to store the request ID in context (defaults to "request_id").
 	ContextKey RequestIDContextKey
 }

--- a/config/request_logger.go
+++ b/config/request_logger.go
@@ -28,27 +28,35 @@ type RequestLoggerConfig struct {
 	// Use a pointer to distinguish between "not set" and "explicitly set to false".
 	// Default: true
 	Enabled *bool
+
 	// LogErrors determines if errors should be logged (defaults to true).
 	LogErrors bool
+
 	// Fields to include in logs (defaults to all fields).
 	Fields []LogField
+
 	// ExemptPaths contains paths to skip logging (e.g., health checks).
 	ExemptPaths []string
+
 	// AllowedPaths contains paths where body logging is explicitly allowed.
 	// If set, body logging (LogRequestBody/LogResponseBody) will only occur
 	// for paths matching these patterns. Supports exact matches and prefixes (ending with /).
 	// If empty, body logging applies to all paths (subject to ExemptPaths).
 	AllowedPaths []string
+
 	// LogRequestBody enables logging of request bodies (defaults to false).
 	// This is opt-in due to performance and security considerations.
 	LogRequestBody bool
+
 	// LogResponseBody enables logging of response bodies (defaults to false).
 	// This is opt-in due to performance and security considerations.
 	LogResponseBody bool
+
 	// MaxBodySize is the maximum number of bytes to log for request/response bodies.
 	// If 0, body logging is disabled (default for safety).
 	// Must be a positive value to enable body logging.
 	MaxBodySize int
+
 	// SensitiveFields contains field names (case-insensitive) whose values should be
 	// masked in request/response body logs (e.g., "password", "token", "secret").
 	// Defaults to common sensitive field names if nil.

--- a/config/reverse_proxy.go
+++ b/config/reverse_proxy.go
@@ -21,8 +21,10 @@ const (
 type Backend struct {
 	// Target is the upstream URL (e.g., "http://localhost:8081")
 	Target string
+
 	// Weight is used for weighted load balancing (defaults to 1)
 	Weight int
+
 	// Healthy indicates if the backend is currently healthy
 	Healthy bool
 }
@@ -31,6 +33,7 @@ type Backend struct {
 type RewriteRule struct {
 	// Pattern is a glob pattern to match (e.g., "/api/v1/*")
 	Pattern string
+
 	// Replacement is the replacement path (e.g., "/api/v2/$1")
 	// Use $1, $2, etc. to reference glob captures
 	Replacement string

--- a/config/security_headers.go
+++ b/config/security_headers.go
@@ -32,8 +32,10 @@ type StrictTransportSecurity struct {
 	// MaxAge sets the time, in seconds, that the browser should remember that a site is only to be accessed using HTTPS.
 	// A value of 0 disables HSTS.
 	MaxAge int
+
 	// ExcludeSubdomains specifies whether the HSTS policy applies to all subdomains.
 	ExcludeSubdomains bool
+
 	// PreloadEnabled adds the preload directive to the header.
 	PreloadEnabled bool
 }
@@ -49,26 +51,37 @@ var DefaultStrictTransportSecurity = StrictTransportSecurity{
 type SecurityHeadersConfig struct {
 	// ContentSecurityPolicy sets the `Content-Security-Policy` header
 	ContentSecurityPolicy string
+
 	// ContentSecurityPolicyReportOnly sets the policy in report-only mode
 	ContentSecurityPolicyReportOnly bool
+
 	// CrossOriginEmbedderPolicy sets the `Cross-Origin-Embedder-Policy` header
 	CrossOriginEmbedderPolicy string
+
 	// CrossOriginOpenerPolicy sets the `Cross-Origin-Opener-Policy` header
 	CrossOriginOpenerPolicy string
+
 	// CrossOriginResourcePolicy sets the `Cross-Origin-Resource-Policy` header
 	CrossOriginResourcePolicy string
+
 	// PermissionsPolicy sets the `Permissions-Policy` header
 	PermissionsPolicy string
+
 	// ReferrerPolicy sets the `Referrer-Policy` header
 	ReferrerPolicy string
+
 	// Server sets the `Server` header (empty string to hide server info)
 	Server string
+
 	// StrictTransportSecurity configures HSTS header
 	StrictTransportSecurity StrictTransportSecurity
+
 	// XContentTypeOptions sets the `X-Content-Type-Options` header
 	XContentTypeOptions string
+
 	// XFrameOptions sets the `X-Frame-Options` header
 	XFrameOptions string
+
 	// ExemptPaths contains paths to skip security headers
 	ExemptPaths []string
 }

--- a/config/timeout.go
+++ b/config/timeout.go
@@ -9,10 +9,13 @@ import (
 type TimeoutConfig struct {
 	// Timeout duration for the request (defaults to 30 seconds)
 	Timeout time.Duration
+
 	// StatusCode to return on timeout (defaults to 504 Gateway Timeout)
 	StatusCode int
+
 	// Message to write on timeout (optional)
 	Message string
+
 	// ExemptPaths contains paths that skip timeout enforcement
 	ExemptPaths []string
 }

--- a/config/trailing_slash.go
+++ b/config/trailing_slash.go
@@ -18,8 +18,10 @@ const (
 type TrailingSlashConfig struct {
 	// Action to take when trailing slash doesn't match preference (defaults to redirect)
 	Action TrailingSlashAction
+
 	// PreferTrailingSlash determines if URLs should have trailing slashes (defaults to false)
 	PreferTrailingSlash bool
+
 	// RedirectCode for redirects (defaults to 301 Moved Permanently)
 	RedirectCode int
 }

--- a/examples/cache/README.md
+++ b/examples/cache/README.md
@@ -1,0 +1,105 @@
+# HTTP Cache Example
+
+This example demonstrates the HTTP cache middleware with automatic ETag generation, conditional requests, and Cache-Control handling.
+
+## Features Demonstrated
+
+- **Automatic ETag generation** - SHA256-based content hashes
+- **Conditional requests** - 304 Not Modified responses
+- **Cache-Control headers** - public, private, max-age directives
+- **Vary header support** - Different cache entries per Accept/Accept-Encoding
+- **TTL-based expiration** - Automatic cache cleanup
+- **Per-route configuration** - Different cache settings per endpoint
+
+## Running the Example
+
+```bash
+go run main.go
+```
+
+## Test Commands
+
+### 1. Basic Cached Request (30s TTL)
+```bash
+curl -i http://localhost:8080/api/public/data
+```
+Notice the `ETag` and `Last-Modified` headers in the response.
+
+### 2. Conditional Request (304 Not Modified)
+```bash
+# Copy the ETag from the previous response
+curl -i http://localhost:8080/api/public/data -H 'If-None-Match: "abc123..."'
+```
+Returns `304 Not Modified` with no body if content hasn't changed.
+
+### 3. Private Cache (User Profile)
+```bash
+curl -i http://localhost:8080/api/users/123
+curl -i http://localhost:8080/api/users/123 -H 'Accept: application/xml'
+```
+Each Accept header gets its own cache entry (Vary header support).
+
+### 4. Non-Cached Endpoint (Live/Health)
+```bash
+curl -i http://localhost:8080/api/live
+```
+Timestamp changes on every request (no cache middleware applied).
+
+### 5. Long-Term Cache (1 hour TTL)
+```bash
+curl -i http://localhost:8080/api/config
+```
+Uses `immutable` directive - browsers won't revalidate during page session.
+
+### 6. HTML Caching
+```bash
+curl -i http://localhost:8080/page/info
+```
+HTML content cached with 2-minute TTL.
+
+## Cache Headers Explained
+
+- `Cache-Control: public` - Response may be cached by any cache
+- `Cache-Control: private` - Response may only be cached by browser
+- `Cache-Control: max-age=N` - Cache for N seconds
+- `Cache-Control: immutable` - Content will never change (during page session)
+- `ETag` - Content identifier for conditional requests
+- `Last-Modified` - Timestamp for conditional requests
+
+## Production Considerations
+
+For multi-instance deployments, use a shared cache store like Redis:
+
+```go
+type RedisCacheStore struct {
+    client *redis.Client
+}
+
+func (s *RedisCacheStore) Get(ctx context.Context, key string) (config.CacheRecord, bool, error) {
+    data, err := s.client.Get(ctx, "cache:"+key).Bytes()
+    if err == redis.Nil {
+        return config.CacheRecord{}, false, nil
+    }
+    if err != nil {
+        return config.CacheRecord{}, false, err
+    }
+    var record config.CacheRecord
+    if err := json.Unmarshal(data, &record); err != nil {
+        return config.CacheRecord{}, false, err
+    }
+    return record, true, nil
+}
+
+func (s *RedisCacheStore) Set(ctx context.Context, key string, record config.CacheRecord, ttl time.Duration) error {
+    data, err := json.Marshal(record)
+    if err != nil {
+        return err
+    }
+    return s.client.Set(ctx, "cache:"+key, data, ttl).Err()
+}
+
+// Usage
+app.Use(middleware.Cache(config.CacheConfig{
+    Store: &RedisCacheStore{client: redisClient},
+}))
+```

--- a/examples/cache/main.go
+++ b/examples/cache/main.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/middleware"
+)
+
+func main() {
+	app := zh.New()
+
+	// Public API endpoint - cached for 30 seconds
+	// Demonstrates automatic ETag and Last-Modified generation
+	app.GET("/api/public/data", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		data := map[string]any{
+			"timestamp": time.Now().Unix(),
+			"message":   "This response is cached with ETag support",
+			"hits":      1,
+		}
+		return zh.R.JSON(w, http.StatusOK, data)
+	}),
+		middleware.Cache(config.CacheConfig{
+			CacheControl: "public, max-age=30",
+			DefaultTTL:   30 * time.Second,
+			ETag:         true,
+			LastModified: true,
+		}),
+	)
+
+	// User profile - cached privately per user
+	// Demonstrates Vary header support (different cache per Accept)
+	app.GET("/api/users/{id}", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		userID := r.PathValue("id")
+		data := map[string]any{
+			"id":        userID,
+			"name":      "User " + userID,
+			"email":     fmt.Sprintf("user%s@example.com", userID),
+			"fetchedAt": time.Now().Format(time.RFC3339),
+		}
+		return zh.R.JSON(w, http.StatusOK, data)
+	}),
+		middleware.Cache(config.CacheConfig{
+			CacheControl: "private, max-age=60",
+			DefaultTTL:   time.Minute,
+			ETag:         true,
+			Vary:         []string{"Accept", "Accept-Encoding"},
+		}),
+	)
+
+	// Live/health endpoint - never cached
+	// Demonstrates exempt paths (or you could just not apply the middleware)
+	app.GET("/api/live", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return zh.R.JSON(w, http.StatusOK, map[string]string{
+			"status":    "ok",
+			"timestamp": time.Now().Format(time.RFC3339Nano),
+		})
+	}),
+	// No cache middleware - this endpoint is never cached
+	)
+
+	// Static content - aggressively cached
+	// Demonstrates long-term caching with immutable directive
+	app.GET("/api/config", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return zh.R.JSON(w, http.StatusOK, map[string]any{
+			"version":     "1.0.0",
+			"features":    []string{"cache", "etag", "ratelimit"},
+			"maintenance": false,
+		})
+	}),
+		middleware.Cache(config.CacheConfig{
+			CacheControl: "public, max-age=3600, immutable",
+			DefaultTTL:   time.Hour,
+		}),
+	)
+
+	// HTML response - demonstrates text/html caching
+	app.GET("/page/info", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		html := fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<head><title>Cache Demo</title></head>
+<body>
+<h1>Cached HTML Page</h1>
+<p>Generated at: %s</p>
+<p>This page is cached for 2 minutes.</p>
+</body>
+</html>`, time.Now().Format(time.RFC3339))
+		return zh.R.HTML(w, http.StatusOK, html)
+	}),
+		middleware.Cache(config.CacheConfig{
+			CacheControl: "public, max-age=120",
+			DefaultTTL:   2 * time.Minute,
+		}),
+	)
+
+	// Stats endpoint - demonstrates custom store usage (in-memory here)
+	// This also shows how to exempt specific paths from caching
+	app.GET("/api/stats", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return zh.R.JSON(w, http.StatusOK, map[string]any{
+			"requests":    12345,
+			"cacheHits":   9876,
+			"cacheMisses": 2469,
+			"updatedAt":   time.Now().Unix(),
+		})
+	}),
+		middleware.Cache(config.CacheConfig{
+			CacheControl: "public, max-age=10",
+			DefaultTTL:   10 * time.Second,
+			MaxEntries:   1000, // Smaller cache for this route
+		}),
+	)
+
+	fmt.Println("HTTP Cache Example Server")
+	fmt.Println("=========================")
+	fmt.Println()
+	fmt.Println("Test commands:")
+	fmt.Println()
+	fmt.Println("1. Basic cached request (30s TTL):")
+	fmt.Println("   curl -i http://localhost:8080/api/public/data")
+	fmt.Println()
+	fmt.Println("2. Conditional request with ETag (returns 304 if not modified):")
+	fmt.Println("   curl -i http://localhost:8080/api/public/data -H 'If-None-Match: \"<etag-from-above>\"'")
+	fmt.Println()
+	fmt.Println("3. User profile (private cache):")
+	fmt.Println("   curl -i http://localhost:8080/api/users/123")
+	fmt.Println()
+	fmt.Println("4. Live endpoint (never cached):")
+	fmt.Println("   curl -i http://localhost:8080/api/live")
+	fmt.Println("   curl -i http://localhost:8080/api/live")
+	fmt.Println("   (Notice the timestamps are always different)")
+	fmt.Println()
+	fmt.Println("5. Static config (1h TTL):")
+	fmt.Println("   curl -i http://localhost:8080/api/config")
+	fmt.Println()
+	fmt.Println("6. HTML page (2m TTL):")
+	fmt.Println("   curl -i http://localhost:8080/page/info")
+	fmt.Println()
+	fmt.Println("7. Stats endpoint (10s TTL):")
+	fmt.Println("   curl -i http://localhost:8080/api/stats")
+	fmt.Println()
+	fmt.Println("Server starting on http://localhost:8080")
+	fmt.Println()
+
+	log.Fatal(app.Start())
+}

--- a/examples/jwt/refresh.go
+++ b/examples/jwt/refresh.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -36,17 +37,17 @@ func NewJWTTokenStore(secret []byte, opts middleware.HS256Options) *JWTTokenStor
 }
 
 // Validate parses and validates a JWT token
-func (s *JWTTokenStore) Validate(token string) (config.JWTClaims, error) {
-	return s.hs256.Validate(token)
+func (s *JWTTokenStore) Validate(_ context.Context, token string) (config.JWTClaims, error) {
+	return s.hs256.Validate(context.Background(), token)
 }
 
 // Generate creates a new JWT token
-func (s *JWTTokenStore) Generate(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
-	return s.hs256.Generate(claims, tokenType)
+func (s *JWTTokenStore) Generate(_ context.Context, claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+	return s.hs256.Generate(context.Background(), claims, tokenType)
 }
 
 // Revoke invalidates a refresh token by its jti claim
-func (s *JWTTokenStore) Revoke(claims config.JWTClaims) error {
+func (s *JWTTokenStore) Revoke(_ context.Context, claims config.JWTClaims) error {
 	jti := getJTI(claims)
 	if jti != "" {
 		s.mu.Lock()
@@ -57,14 +58,14 @@ func (s *JWTTokenStore) Revoke(claims config.JWTClaims) error {
 }
 
 // IsRevoked checks if a refresh token has been revoked
-func (s *JWTTokenStore) IsRevoked(claims config.JWTClaims) bool {
+func (s *JWTTokenStore) IsRevoked(_ context.Context, claims config.JWTClaims) (bool, error) {
 	jti := getJTI(claims)
 	if jti == "" {
-		return false
+		return false, nil
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.revoked[jti]
+	return s.revoked[jti], nil
 }
 
 // getJTI extracts the jti claim from claims

--- a/log/logger.go
+++ b/log/logger.go
@@ -11,19 +11,25 @@ import (
 type Logger interface {
 	// Debug logs a debug message
 	Debug(msg string, fields ...Field)
+
 	// Info logs an info message
 	Info(msg string, fields ...Field)
+
 	// Warn logs a warning message
 	Warn(msg string, fields ...Field)
+
 	// Error logs an error message
 	Error(msg string, fields ...Field)
+
 	// Panic logs a panic message and panics
 	Panic(msg string, fields ...Field)
+
 	// Fatal logs a fatal message and exits
 	Fatal(msg string, fields ...Field)
 
 	// WithFields returns a logger with additional fields
 	WithFields(fields ...Field) Logger
+
 	// WithContext returns a logger with context
 	WithContext(ctx context.Context) Logger
 }

--- a/middleware/cache.go
+++ b/middleware/cache.go
@@ -1,0 +1,254 @@
+package middleware
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/log"
+	"github.com/alexferl/zerohttp/metrics"
+)
+
+// Cache creates HTTP caching middleware with automatic ETag generation,
+// conditional requests, and Cache-Control handling.
+func Cache(cfg ...config.CacheConfig) func(http.Handler) http.Handler {
+	c := config.DefaultCacheConfig
+	if len(cfg) > 0 {
+		c = cfg[0]
+	}
+
+	if c.CacheControl == "" {
+		c.CacheControl = config.DefaultCacheConfig.CacheControl
+	}
+	if c.DefaultTTL == 0 {
+		c.DefaultTTL = config.DefaultCacheConfig.DefaultTTL
+	}
+	if c.MaxBodySize == 0 {
+		c.MaxBodySize = config.DefaultCacheConfig.MaxBodySize
+	}
+	if c.Vary == nil {
+		c.Vary = config.DefaultCacheConfig.Vary
+	}
+	if c.StatusCodes == nil {
+		c.StatusCodes = config.DefaultCacheConfig.StatusCodes
+	}
+
+	statusCodeMap := make(map[int]bool)
+	for _, code := range c.StatusCodes {
+		statusCodeMap[code] = true
+	}
+
+	var store CacheStore
+	if c.Store != nil {
+		store = c.Store
+	} else {
+		store = NewCacheMemoryStore(c.MaxEntries)
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			reg := metrics.SafeRegistry(metrics.GetRegistry(r.Context()))
+
+			if r.Method != http.MethodGet && r.Method != http.MethodHead {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			for _, exemptPath := range c.ExemptPaths {
+				if pathMatches(r.URL.Path, exemptPath) {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+
+			if r.Header.Get("Cache-Control") == "no-cache" || r.Header.Get("Cache-Control") == "no-store" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			key := generateCacheKey(r, c.Vary)
+
+			ifNoneMatch := r.Header.Get("If-None-Match")
+			ifModifiedSince := r.Header.Get("If-Modified-Since")
+
+			record, found, err := store.Get(r.Context(), key)
+			if err != nil {
+				// Log error and continue to handler on cache fetch failure
+				// (fail open - better to serve fresh content than error)
+				log.GetGlobalLogger().Error("Cache store get failed", log.E(err), log.F("key", key))
+			} else if found {
+				reg.Counter("cache_requests_total", "result").WithLabelValues("hit").Inc()
+				if ifNoneMatch != "" && ifNoneMatch == record.ETag {
+					w.Header().Set("ETag", record.ETag)
+					w.WriteHeader(http.StatusNotModified)
+					return
+				}
+
+				if ifModifiedSince != "" {
+					if parsedTime, err := http.ParseTime(ifModifiedSince); err == nil {
+						if !record.LastModified.IsZero() && !record.LastModified.After(parsedTime) {
+							w.Header().Set("Last-Modified", record.LastModified.UTC().Format(http.TimeFormat))
+							w.WriteHeader(http.StatusNotModified)
+							return
+						}
+					}
+				}
+
+				for k, v := range record.Headers {
+					for _, val := range v {
+						w.Header().Add(k, val)
+					}
+				}
+				w.Header().Set("ETag", record.ETag)
+				w.Header().Set("Cache-Control", c.CacheControl)
+				w.WriteHeader(record.StatusCode)
+				if r.Method != http.MethodHead {
+					_, _ = w.Write(record.Body)
+				}
+				return
+			}
+
+			reg.Counter("cache_requests_total", "result").WithLabelValues("miss").Inc()
+
+			recorder := &cacheResponseRecorder{
+				ResponseWriter: w,
+				maxBodySize:    c.MaxBodySize,
+				statusCodeMap:  statusCodeMap,
+			}
+
+			next.ServeHTTP(recorder, r)
+
+			if recorder.shouldCache {
+				record := config.CacheRecord{
+					StatusCode:   recorder.statusCode,
+					Headers:      recorder.headers,
+					Body:         recorder.body.Bytes(),
+					LastModified: time.Now().UTC().Truncate(time.Second),
+					VaryHeaders:  extractVaryHeaders(r, c.Vary),
+				}
+
+				if c.ETag {
+					hash := sha256.Sum256(record.Body)
+					record.ETag = fmt.Sprintf(`"%s"`, hex.EncodeToString(hash[:])[:16])
+				}
+
+				if err := store.Set(r.Context(), key, record, c.DefaultTTL); err != nil {
+					// Log error but don't fail the request
+					// (better to serve the response than fail because cache is unavailable)
+					log.GetGlobalLogger().Error("Cache store set failed", log.E(err), log.F("key", key))
+				}
+
+				if c.ETag && record.ETag != "" {
+					w.Header().Set("ETag", record.ETag)
+				}
+				if c.LastModified {
+					w.Header().Set("Last-Modified", record.LastModified.UTC().Format(http.TimeFormat))
+				}
+				w.Header().Set("Cache-Control", c.CacheControl)
+			}
+		})
+	}
+}
+
+// cacheResponseRecorder captures response data for caching.
+type cacheResponseRecorder struct {
+	http.ResponseWriter
+	statusCode    int
+	headers       map[string][]string
+	body          bytes.Buffer
+	maxBodySize   int64
+	shouldCache   bool
+	statusCodeMap map[int]bool
+	written       bool
+}
+
+func (c *cacheResponseRecorder) WriteHeader(statusCode int) {
+	if c.written {
+		return
+	}
+	c.written = true
+	c.statusCode = statusCode
+	c.shouldCache = c.statusCodeMap[statusCode]
+
+	if c.shouldCache {
+		c.headers = make(map[string][]string)
+		for k, v := range c.Header() {
+			// Skip headers that shouldn't be cached
+			if k == "Set-Cookie" || k == "Connection" || k == "Keep-Alive" {
+				continue
+			}
+			c.headers[k] = v
+		}
+	}
+
+	c.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (c *cacheResponseRecorder) Write(p []byte) (int, error) {
+	if !c.written {
+		c.WriteHeader(http.StatusOK)
+	}
+
+	if c.shouldCache && int64(c.body.Len()+len(p)) <= c.maxBodySize {
+		c.body.Write(p)
+	} else if c.shouldCache {
+		c.shouldCache = false
+	}
+
+	return c.ResponseWriter.Write(p)
+}
+
+func (c *cacheResponseRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := c.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("response writer does not support hijacking")
+	}
+	return hijacker.Hijack()
+}
+
+func (c *cacheResponseRecorder) Flush() {
+	if flusher, ok := c.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+// generateCacheKey creates a cache key from request method, URL, and vary headers.
+// GET and HEAD share the same cache key per RFC 7231.
+func generateCacheKey(r *http.Request, vary []string) string {
+	var parts []string
+	// Treat HEAD as GET for cache key purposes
+	method := r.Method
+	if method == http.MethodHead {
+		method = http.MethodGet
+	}
+	parts = append(parts, method)
+	parts = append(parts, r.URL.Path)
+	parts = append(parts, r.URL.RawQuery)
+
+	for _, header := range vary {
+		if value := r.Header.Get(header); value != "" {
+			parts = append(parts, fmt.Sprintf("%s=%s", header, value))
+		}
+	}
+
+	hash := sha256.Sum256([]byte(strings.Join(parts, "|")))
+	return hex.EncodeToString(hash[:])
+}
+
+// extractVaryHeaders extracts vary header values from request.
+func extractVaryHeaders(r *http.Request, vary []string) map[string]string {
+	result := make(map[string]string)
+	for _, header := range vary {
+		if value := r.Header.Get(header); value != "" {
+			result[header] = value
+		}
+	}
+	return result
+}

--- a/middleware/cache_store.go
+++ b/middleware/cache_store.go
@@ -1,0 +1,113 @@
+package middleware
+
+import (
+	"container/list"
+	"context"
+	"sync"
+	"time"
+
+	"github.com/alexferl/zerohttp/config"
+)
+
+// CacheStore is an alias for config.CacheStore.
+type CacheStore = config.CacheStore
+
+// CacheRecord is an alias for config.CacheRecord.
+type CacheRecord = config.CacheRecord
+
+// cacheEntry represents a single cached entry with expiry and LRU tracking.
+type cacheEntry struct {
+	key        string
+	record     CacheRecord
+	expiry     time.Time
+	lruElement *list.Element
+}
+
+// CacheMemoryStore is a thread-safe in-memory cache with LRU eviction.
+type CacheMemoryStore struct {
+	mu         sync.RWMutex
+	entries    map[string]*cacheEntry
+	lruList    *list.List
+	lruIndex   map[string]*list.Element
+	maxEntries int
+}
+
+// NewCacheMemoryStore creates a new in-memory cache store.
+// If maxEntries is 0, the cache has unlimited capacity (not recommended for production).
+func NewCacheMemoryStore(maxEntries int) *CacheMemoryStore {
+	return &CacheMemoryStore{
+		entries:    make(map[string]*cacheEntry),
+		lruList:    list.New(),
+		lruIndex:   make(map[string]*list.Element),
+		maxEntries: maxEntries,
+	}
+}
+
+// Get retrieves a cached entry by key.
+// Returns the record, true if found and not expired, and nil error.
+// Returns false and nil error if not found or expired.
+// The context is accepted for interface compatibility but not used by the in-memory store.
+func (c *CacheMemoryStore) Get(ctx context.Context, key string) (CacheRecord, bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, exists := c.entries[key]
+	if !exists {
+		return CacheRecord{}, false, nil
+	}
+
+	if time.Now().After(entry.expiry) {
+		c.removeEntry(entry)
+		return CacheRecord{}, false, nil
+	}
+
+	c.lruList.MoveToFront(entry.lruElement)
+
+	return entry.record, true, nil
+}
+
+// Set stores a record in the cache with the given TTL.
+// Returns nil error on success.
+// The context is accepted for interface compatibility but not used by the in-memory store.
+func (c *CacheMemoryStore) Set(ctx context.Context, key string, record CacheRecord, ttl time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if elem, exists := c.lruIndex[key]; exists {
+		c.lruList.MoveToFront(elem)
+		entry := elem.Value.(*cacheEntry)
+		entry.record = record
+		entry.expiry = time.Now().Add(ttl)
+		return nil
+	}
+
+	if c.maxEntries > 0 && len(c.entries) >= c.maxEntries {
+		c.evictOldest()
+	}
+
+	entry := &cacheEntry{
+		key:    key,
+		record: record,
+		expiry: time.Now().Add(ttl),
+	}
+	elem := c.lruList.PushFront(entry)
+	entry.lruElement = elem
+	c.lruIndex[key] = elem
+	c.entries[key] = entry
+	return nil
+}
+
+// removeEntry removes an entry from all internal data structures.
+func (c *CacheMemoryStore) removeEntry(entry *cacheEntry) {
+	delete(c.entries, entry.key)
+	delete(c.lruIndex, entry.key)
+	c.lruList.Remove(entry.lruElement)
+}
+
+// evictOldest removes the least recently used entry.
+func (c *CacheMemoryStore) evictOldest() {
+	if elem := c.lruList.Back(); elem != nil {
+		entry := elem.Value.(*cacheEntry)
+		c.removeEntry(entry)
+	}
+}

--- a/middleware/cache_store.go
+++ b/middleware/cache_store.go
@@ -47,7 +47,7 @@ func NewCacheMemoryStore(maxEntries int) *CacheMemoryStore {
 // Returns the record, true if found and not expired, and nil error.
 // Returns false and nil error if not found or expired.
 // The context is accepted for interface compatibility but not used by the in-memory store.
-func (c *CacheMemoryStore) Get(ctx context.Context, key string) (CacheRecord, bool, error) {
+func (c *CacheMemoryStore) Get(_ context.Context, key string) (CacheRecord, bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -69,7 +69,7 @@ func (c *CacheMemoryStore) Get(ctx context.Context, key string) (CacheRecord, bo
 // Set stores a record in the cache with the given TTL.
 // Returns nil error on success.
 // The context is accepted for interface compatibility but not used by the in-memory store.
-func (c *CacheMemoryStore) Set(ctx context.Context, key string, record CacheRecord, ttl time.Duration) error {
+func (c *CacheMemoryStore) Set(_ context.Context, key string, record CacheRecord, ttl time.Duration) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/middleware/cache_store_test.go
+++ b/middleware/cache_store_test.go
@@ -1,0 +1,175 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alexferl/zerohttp/config"
+)
+
+func TestCacheMemoryStore(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("basic get and set", func(t *testing.T) {
+		store := NewCacheMemoryStore(100)
+
+		record := config.CacheRecord{
+			StatusCode: 200,
+			Body:       []byte("test"),
+		}
+
+		if err := store.Set(ctx, "key1", record, time.Minute); err != nil {
+			t.Errorf("Unexpected error setting key: %v", err)
+		}
+
+		retrieved, found, err := store.Get(ctx, "key1")
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if !found {
+			t.Error("Expected to find key1")
+		}
+		if string(retrieved.Body) != "test" {
+			t.Errorf("Expected body 'test', got %q", string(retrieved.Body))
+		}
+	})
+
+	t.Run("expired entry not returned", func(t *testing.T) {
+		store := NewCacheMemoryStore(100)
+
+		record := config.CacheRecord{
+			StatusCode: 200,
+			Body:       []byte("test"),
+		}
+
+		if err := store.Set(ctx, "key1", record, 1*time.Millisecond); err != nil {
+			t.Errorf("Unexpected error setting key: %v", err)
+		}
+		time.Sleep(2 * time.Millisecond)
+
+		_, found, err := store.Get(ctx, "key1")
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if found {
+			t.Error("Expected expired entry to not be found")
+		}
+	})
+
+	t.Run("LRU eviction", func(t *testing.T) {
+		store := NewCacheMemoryStore(2)
+
+		if err := store.Set(ctx, "key1", config.CacheRecord{StatusCode: 200}, time.Minute); err != nil {
+			t.Errorf("Unexpected error setting key: %v", err)
+		}
+		if err := store.Set(ctx, "key2", config.CacheRecord{StatusCode: 200}, time.Minute); err != nil {
+			t.Errorf("Unexpected error setting key: %v", err)
+		}
+		if err := store.Set(ctx, "key3", config.CacheRecord{StatusCode: 200}, time.Minute); err != nil {
+			t.Errorf("Unexpected error setting key: %v", err)
+		}
+
+		// key1 should be evicted
+		_, found, _ := store.Get(ctx, "key1")
+		if found {
+			t.Error("Expected key1 to be evicted")
+		}
+
+		// key2 and key3 should exist
+		_, found, _ = store.Get(ctx, "key2")
+		if !found {
+			t.Error("Expected key2 to exist")
+		}
+		_, found, _ = store.Get(ctx, "key3")
+		if !found {
+			t.Error("Expected key3 to exist")
+		}
+	})
+
+	t.Run("update existing key moves to front", func(t *testing.T) {
+		store := NewCacheMemoryStore(2)
+
+		if err := store.Set(ctx, "key1", config.CacheRecord{StatusCode: 200}, time.Minute); err != nil {
+			t.Errorf("Unexpected error setting key: %v", err)
+		}
+		if err := store.Set(ctx, "key2", config.CacheRecord{StatusCode: 200}, time.Minute); err != nil {
+			t.Errorf("Unexpected error setting key: %v", err)
+		}
+
+		// Access key1 to make it most recently used
+		_, _, _ = store.Get(ctx, "key1")
+
+		// Add key3 - key2 should be evicted (least recently used)
+		if err := store.Set(ctx, "key3", config.CacheRecord{StatusCode: 200}, time.Minute); err != nil {
+			t.Errorf("Unexpected error setting key: %v", err)
+		}
+
+		// key1 should still exist (was accessed)
+		_, found, _ := store.Get(ctx, "key1")
+		if !found {
+			t.Error("Expected key1 to exist (was accessed recently)")
+		}
+
+		// key2 should be evicted
+		_, found, _ = store.Get(ctx, "key2")
+		if found {
+			t.Error("Expected key2 to be evicted (was not accessed)")
+		}
+	})
+
+	t.Run("unlimited capacity when maxEntries is 0", func(t *testing.T) {
+		store := NewCacheMemoryStore(0)
+
+		// Add many entries
+		for i := 0; i < 100; i++ {
+			if err := store.Set(ctx, string(rune('a'+i)), config.CacheRecord{StatusCode: 200}, time.Minute); err != nil {
+				t.Errorf("Unexpected error setting key: %v", err)
+			}
+		}
+
+		// All should exist
+		for i := 0; i < 100; i++ {
+			_, found, _ := store.Get(ctx, string(rune('a'+i)))
+			if !found {
+				t.Errorf("Expected key %c to exist", 'a'+i)
+			}
+		}
+	})
+
+	t.Run("update preserves expiry", func(t *testing.T) {
+		store := NewCacheMemoryStore(100)
+
+		record1 := config.CacheRecord{
+			StatusCode: 200,
+			Body:       []byte("v1"),
+		}
+		if err := store.Set(ctx, "key1", record1, 1*time.Millisecond); err != nil {
+			t.Errorf("Unexpected error setting key: %v", err)
+		}
+
+		// Wait for original to nearly expire
+		time.Sleep(500 * time.Microsecond)
+
+		// Update with new TTL
+		record2 := config.CacheRecord{
+			StatusCode: 200,
+			Body:       []byte("v2"),
+		}
+		if err := store.Set(ctx, "key1", record2, time.Minute); err != nil {
+			t.Errorf("Unexpected error setting key: %v", err)
+		}
+
+		// Wait for original TTL to expire
+		time.Sleep(1 * time.Millisecond)
+
+		// Should still exist due to updated TTL
+		retrieved, found, _ := store.Get(ctx, "key1")
+		if !found {
+			t.Error("Expected key1 to exist after TTL update")
+		}
+		if string(retrieved.Body) != "v2" {
+			t.Errorf("Expected body 'v2', got %q", string(retrieved.Body))
+		}
+	})
+}

--- a/middleware/cache_test.go
+++ b/middleware/cache_test.go
@@ -1,0 +1,333 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/metrics"
+	"github.com/alexferl/zerohttp/zhtest"
+)
+
+func TestCache_Basic(t *testing.T) {
+	t.Run("caches GET responses", func(t *testing.T) {
+		callCount := 0
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("response " + r.URL.Query().Get("id")))
+		})
+
+		cacheMiddleware := Cache(config.CacheConfig{
+			DefaultTTL:   time.Minute,
+			CacheControl: "public, max-age=60",
+		})
+
+		// First request - should hit handler
+		req1 := httptest.NewRequest(http.MethodGet, "/test?id=1", nil)
+		w1 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w1, req1)
+		zhtest.AssertWith(t, w1).Status(http.StatusOK).Body("response 1")
+		if callCount != 1 {
+			t.Errorf("Expected 1 handler call, got %d", callCount)
+		}
+
+		// Second request - should be cached
+		req2 := httptest.NewRequest(http.MethodGet, "/test?id=1", nil)
+		w2 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w2, req2)
+		zhtest.AssertWith(t, w2).Status(http.StatusOK).Body("response 1")
+		if callCount != 1 {
+			t.Errorf("Expected still 1 handler call, got %d (should be cached)", callCount)
+		}
+
+		// Different query - should hit handler
+		req3 := httptest.NewRequest(http.MethodGet, "/test?id=2", nil)
+		w3 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w3, req3)
+		zhtest.AssertWith(t, w3).Status(http.StatusOK).Body("response 2")
+		if callCount != 2 {
+			t.Errorf("Expected 2 handler calls, got %d", callCount)
+		}
+	})
+
+	t.Run("does not cache POST requests", func(t *testing.T) {
+		callCount := 0
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("post response"))
+		})
+
+		cacheMiddleware := Cache(config.CacheConfig{
+			DefaultTTL: time.Minute,
+		})
+
+		req1 := httptest.NewRequest(http.MethodPost, "/test", nil)
+		w1 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w1, req1)
+
+		req2 := httptest.NewRequest(http.MethodPost, "/test", nil)
+		w2 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w2, req2)
+
+		if callCount != 2 {
+			t.Errorf("Expected 2 handler calls for POST, got %d", callCount)
+		}
+	})
+
+	t.Run("respects no-cache header", func(t *testing.T) {
+		callCount := 0
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("response"))
+		})
+
+		cacheMiddleware := Cache(config.CacheConfig{
+			DefaultTTL: time.Minute,
+		})
+
+		// First request
+		req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		w1 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w1, req1)
+
+		// Second request with no-cache
+		req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req2.Header.Set("Cache-Control", "no-cache")
+		w2 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w2, req2)
+
+		if callCount != 2 {
+			t.Errorf("Expected 2 handler calls with no-cache, got %d", callCount)
+		}
+	})
+
+	t.Run("respects exempt paths", func(t *testing.T) {
+		callCount := 0
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.WriteHeader(http.StatusOK)
+		})
+
+		cacheMiddleware := Cache(config.CacheConfig{
+			DefaultTTL:  time.Minute,
+			ExemptPaths: []string{"/api/live*"},
+		})
+
+		req1 := httptest.NewRequest(http.MethodGet, "/api/live", nil)
+		w1 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w1, req1)
+
+		req2 := httptest.NewRequest(http.MethodGet, "/api/live", nil)
+		w2 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w2, req2)
+
+		if callCount != 2 {
+			t.Errorf("Expected 2 handler calls for exempt path, got %d", callCount)
+		}
+	})
+}
+
+func TestCache_ConditionalRequests(t *testing.T) {
+	t.Run("returns 304 on ETag match", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("hello world"))
+		})
+
+		cacheMiddleware := Cache(config.CacheConfig{
+			DefaultTTL: time.Minute,
+			ETag:       true,
+		})
+
+		// First request to cache
+		req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		w1 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w1, req1)
+
+		etag := w1.Header().Get("ETag")
+		if etag == "" {
+			t.Fatal("Expected ETag to be set")
+		}
+
+		// Second request with If-None-Match
+		req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req2.Header.Set("If-None-Match", etag)
+		w2 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w2, req2)
+
+		zhtest.AssertWith(t, w2).Status(http.StatusNotModified)
+		if w2.Body.String() != "" {
+			t.Errorf("Expected empty body for 304, got %q", w2.Body.String())
+		}
+	})
+
+	t.Run("returns 304 on Last-Modified match", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("hello world"))
+		})
+
+		cacheMiddleware := Cache(config.CacheConfig{
+			DefaultTTL:   time.Minute,
+			LastModified: true,
+		})
+
+		// First request
+		req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		w1 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w1, req1)
+
+		lastModified := w1.Header().Get("Last-Modified")
+		if lastModified == "" {
+			t.Fatal("Expected Last-Modified to be set")
+		}
+
+		// Second request with If-Modified-Since
+		req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req2.Header.Set("If-Modified-Since", lastModified)
+		w2 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w2, req2)
+
+		zhtest.AssertWith(t, w2).Status(http.StatusNotModified)
+	})
+}
+
+func TestCache_VaryHeaders(t *testing.T) {
+	t.Run("caches separately for different Accept headers", func(t *testing.T) {
+		callCount := 0
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", r.Header.Get("Accept"))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("response"))
+		})
+
+		cacheMiddleware := Cache(config.CacheConfig{
+			DefaultTTL: time.Minute,
+			Vary:       []string{"Accept"},
+		})
+
+		// JSON request
+		req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req1.Header.Set("Accept", "application/json")
+		w1 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w1, req1)
+
+		// XML request - should hit handler again
+		req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req2.Header.Set("Accept", "application/xml")
+		w2 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w2, req2)
+
+		if callCount != 2 {
+			t.Errorf("Expected 2 handler calls for different Accept headers, got %d", callCount)
+		}
+
+		// Same JSON request - should be cached
+		req3 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req3.Header.Set("Accept", "application/json")
+		w3 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w3, req3)
+
+		if callCount != 2 {
+			t.Errorf("Expected still 2 calls, got %d", callCount)
+		}
+	})
+}
+
+func TestCache_HEAD(t *testing.T) {
+	t.Run("HEAD returns cached headers without body", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Custom", "value")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("hello world"))
+		})
+
+		cacheMiddleware := Cache(config.CacheConfig{
+			DefaultTTL: time.Minute,
+		})
+
+		// GET to populate cache
+		req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		w1 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w1, req1)
+
+		// HEAD should return headers without body
+		req2 := httptest.NewRequest(http.MethodHead, "/test", nil)
+		w2 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w2, req2)
+
+		zhtest.AssertWith(t, w2).Status(http.StatusOK)
+		if w2.Body.String() != "" {
+			t.Errorf("HEAD should have empty body, got %q", w2.Body.String())
+		}
+		if w2.Header().Get("X-Custom") != "value" {
+			t.Error("HEAD should have cached headers")
+		}
+	})
+}
+
+func TestCache_Metrics(t *testing.T) {
+	t.Run("emits cache hit and miss metrics", func(t *testing.T) {
+		reg := metrics.NewRegistry()
+		ctx := metrics.WithRegistry(context.Background(), reg)
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("response"))
+		})
+
+		cacheMiddleware := Cache(config.CacheConfig{
+			DefaultTTL: time.Minute,
+		})
+
+		// First request - cache miss
+		req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req1 = req1.WithContext(ctx)
+		w1 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w1, req1)
+
+		// Second request - cache hit
+		req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req2 = req2.WithContext(ctx)
+		w2 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w2, req2)
+
+		// Third request - cache hit
+		req3 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req3 = req3.WithContext(ctx)
+		w3 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w3, req3)
+
+		// Check metrics
+		families := reg.Gather()
+		var counter *metrics.MetricFamily
+		for _, f := range families {
+			if f.Name == "cache_requests_total" {
+				counter = &f
+				break
+			}
+		}
+		if counter == nil {
+			t.Fatal("expected cache_requests_total metric")
+		}
+
+		results := make(map[string]uint64)
+		for _, m := range counter.Metrics {
+			results[m.Labels["result"]] = m.Counter
+		}
+
+		if results["miss"] != 1 {
+			t.Errorf("expected 1 miss, got %d", results["miss"])
+		}
+		if results["hit"] != 2 {
+			t.Errorf("expected 2 hits, got %d", results["hit"])
+		}
+	})
+}

--- a/middleware/csrf.go
+++ b/middleware/csrf.go
@@ -85,12 +85,6 @@ func CSRF(cfg ...config.CSRFConfig) func(http.Handler) http.Handler {
 		tokenGenerator = generateToken
 	}
 
-	// Use injected logger or global
-	logger := c.Logger
-	if logger == nil {
-		logger = log.GetGlobalLogger()
-	}
-
 	exemptMethodMap := make(map[string]bool)
 	for _, method := range c.ExemptMethods {
 		exemptMethodMap[strings.ToUpper(method)] = true
@@ -121,7 +115,7 @@ func CSRF(cfg ...config.CSRFConfig) func(http.Handler) http.Handler {
 					token, err = tokenGenerator(hmacKey)
 					if err != nil {
 						// Fail closed: reject request if we can't generate a token
-						logger.Error("CSRF token generation failed", log.E(err))
+						log.GetGlobalLogger().Error("CSRF token generation failed", log.E(err))
 						reg.Counter("csrf_rejected_total", "reason").WithLabelValues("token_generation_failed").Inc()
 						errorHandler(w, r)
 						return
@@ -161,7 +155,7 @@ func CSRF(cfg ...config.CSRFConfig) func(http.Handler) http.Handler {
 			newToken, err := tokenGenerator(hmacKey)
 			if err != nil {
 				// Fail closed: reject request if we can't generate a token
-				logger.Error("CSRF token generation failed", log.E(err))
+				log.GetGlobalLogger().Error("CSRF token generation failed", log.E(err))
 				reg.Counter("csrf_rejected_total", "reason").WithLabelValues("token_generation_failed").Inc()
 				errorHandler(w, r)
 				return

--- a/middleware/jwt_auth.go
+++ b/middleware/jwt_auth.go
@@ -166,14 +166,24 @@ func JWTAuth(cfg ...config.JWTAuthConfig) func(http.Handler) http.Handler {
 				return
 			}
 
-			claims, err := c.TokenStore.Validate(tokenString)
+			claims, err := c.TokenStore.Validate(r.Context(), tokenString)
 			if err != nil {
 				reg.Counter("jwt_auth_requests_total", "result").WithLabelValues("invalid").Inc()
 				handleJWTError(w, r, errInvalidToken, errorHandler)
 				return
 			}
 
-			if c.TokenStore.IsRevoked(claims) {
+			revoked, err := c.TokenStore.IsRevoked(r.Context(), claims)
+			if err != nil {
+				reg.Counter("jwt_auth_requests_total", "result").WithLabelValues("invalid").Inc()
+				handleJWTError(w, r, &JWTAuthError{
+					Title:  "Token Revocation Check Failed",
+					Status: http.StatusInternalServerError,
+					Detail: err.Error(),
+				}, errorHandler)
+				return
+			}
+			if revoked {
 				reg.Counter("jwt_auth_requests_total", "result").WithLabelValues("invalid").Inc()
 				handleJWTError(w, r, &JWTAuthError{
 					Title:  "Token Revoked",
@@ -394,7 +404,7 @@ func GenerateAccessToken(r *http.Request, claims config.JWTClaims, cfg config.JW
 
 	claims = addExpirationToClaims(claims, ttl)
 
-	return cfg.TokenStore.Generate(claims, config.AccessToken)
+	return cfg.TokenStore.Generate(r.Context(), claims, config.AccessToken)
 }
 
 // GenerateRefreshToken generates a new refresh token for the given claims.
@@ -414,7 +424,7 @@ func GenerateRefreshToken(r *http.Request, claims config.JWTClaims, cfg config.J
 	claims = addExpirationToClaims(claims, ttl)
 	claims = addTypeToClaims(claims, config.TokenTypeRefresh)
 
-	return cfg.TokenStore.Generate(claims, config.RefreshToken)
+	return cfg.TokenStore.Generate(r.Context(), claims, config.RefreshToken)
 }
 
 // writeJWTError writes a JWTAuthError response
@@ -460,7 +470,7 @@ func tokenHandlerRequest(w http.ResponseWriter, r *http.Request, cfg config.JWTA
 		return nil, false
 	}
 
-	claims, err := cfg.TokenStore.Validate(req.RefreshToken)
+	claims, err := cfg.TokenStore.Validate(r.Context(), req.RefreshToken)
 	if err != nil {
 		writeJWTError(w, errInvalidToken)
 		return nil, false
@@ -475,7 +485,16 @@ func tokenHandlerRequest(w http.ResponseWriter, r *http.Request, cfg config.JWTA
 		return nil, false
 	}
 
-	if cfg.TokenStore.IsRevoked(claims) {
+	revoked, err := cfg.TokenStore.IsRevoked(r.Context(), claims)
+	if err != nil {
+		writeJWTError(w, &JWTAuthError{
+			Title:  "Token Revocation Check Failed",
+			Status: http.StatusInternalServerError,
+			Detail: err.Error(),
+		})
+		return nil, false
+	}
+	if revoked {
 		writeJWTError(w, &JWTAuthError{
 			Title:  "Token Revoked",
 			Status: http.StatusUnauthorized,
@@ -484,7 +503,7 @@ func tokenHandlerRequest(w http.ResponseWriter, r *http.Request, cfg config.JWTA
 		return nil, false
 	}
 
-	if err := cfg.TokenStore.Revoke(claims); err != nil {
+	if err := cfg.TokenStore.Revoke(r.Context(), claims); err != nil {
 		writeJWTError(w, &JWTAuthError{
 			Title:  "Token Revocation Failed",
 			Status: http.StatusInternalServerError,

--- a/middleware/jwt_auth_bench_test.go
+++ b/middleware/jwt_auth_bench_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -25,7 +26,7 @@ func BenchmarkJWT_HS256_Generate(b *testing.B) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		_, _ = store.Generate(claims, config.AccessToken)
+		_, _ = store.Generate(context.Background(), claims, config.AccessToken)
 	}
 }
 
@@ -41,13 +42,13 @@ func BenchmarkJWT_HS256_Validate(b *testing.B) {
 		"email": "test@example.com",
 	}
 
-	token, _ := store.Generate(claims, config.AccessToken)
+	token, _ := store.Generate(context.Background(), claims, config.AccessToken)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for b.Loop() {
-		_, _ = store.Validate(token)
+		_, _ = store.Validate(context.Background(), token)
 	}
 }
 
@@ -105,18 +106,18 @@ func BenchmarkJWT_HS256_ClaimSizes(b *testing.B) {
 			b.ResetTimer()
 
 			for b.Loop() {
-				_, _ = store.Generate(s.claims, config.AccessToken)
+				_, _ = store.Generate(context.Background(), s.claims, config.AccessToken)
 			}
 		})
 
-		token, _ := store.Generate(s.claims, config.AccessToken)
+		token, _ := store.Generate(context.Background(), s.claims, config.AccessToken)
 
 		b.Run(s.name+"/Validate", func(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 
 			for b.Loop() {
-				_, _ = store.Validate(token)
+				_, _ = store.Validate(context.Background(), token)
 			}
 		})
 	}
@@ -134,7 +135,7 @@ func BenchmarkJWT_AuthMiddleware(b *testing.B) {
 	}))
 
 	claims := HS256Claims{"sub": "user123", "name": "Test User"}
-	token, _ := store.Generate(claims, config.AccessToken)
+	token, _ := store.Generate(context.Background(), claims, config.AccessToken)
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
@@ -153,7 +154,7 @@ func BenchmarkJWT_AuthMiddleware_Scenarios(b *testing.B) {
 	store := NewHS256TokenStore([]byte("this-is-a-32-byte-secret-key-for-tests!!"), HS256Options{})
 
 	validClaims := HS256Claims{"sub": "user123", "name": "Test User"}
-	validToken, _ := store.Generate(validClaims, config.AccessToken)
+	validToken, _ := store.Generate(context.Background(), validClaims, config.AccessToken)
 
 	scenarios := []struct {
 		name  string
@@ -204,8 +205,8 @@ func BenchmarkJWT_ClaimsExtraction(b *testing.B) {
 		"scope": "read write delete",
 	}
 
-	token, _ := store.Generate(claims, config.AccessToken)
-	validatedClaims, _ := store.Validate(token)
+	token, _ := store.Generate(context.Background(), claims, config.AccessToken)
+	validatedClaims, _ := store.Validate(context.Background(), token)
 
 	jwtClaims := JWTClaims{claims: validatedClaims}
 
@@ -259,7 +260,7 @@ func BenchmarkJWT_RequiredClaims(b *testing.B) {
 		"name": "Test User",
 		"org":  "acme",
 	}
-	token, _ := store.Generate(claims, config.AccessToken)
+	token, _ := store.Generate(context.Background(), claims, config.AccessToken)
 
 	requiredClaimsCounts := []int{1, 3, 5}
 

--- a/middleware/jwt_auth_test.go
+++ b/middleware/jwt_auth_test.go
@@ -29,40 +29,40 @@ func slicesEqual(a, b []string) bool {
 
 // mockTokenStore is a test implementation of config.TokenStore
 type mockTokenStore struct {
-	validateFunc func(token string) (config.JWTClaims, error)
-	generateFunc func(claims config.JWTClaims, tokenType config.TokenType) (string, error)
-	revokeFunc   func(claims config.JWTClaims) error
+	validateFunc func(ctx context.Context, token string) (config.JWTClaims, error)
+	generateFunc func(ctx context.Context, claims config.JWTClaims, tokenType config.TokenType) (string, error)
+	revokeFunc   func(ctx context.Context, claims config.JWTClaims) error
 	isRevoked    bool
 }
 
-func (m *mockTokenStore) Validate(token string) (config.JWTClaims, error) {
+func (m *mockTokenStore) Validate(ctx context.Context, token string) (config.JWTClaims, error) {
 	if m.validateFunc != nil {
-		return m.validateFunc(token)
+		return m.validateFunc(ctx, token)
 	}
 	return nil, errors.New("validator not configured")
 }
 
-func (m *mockTokenStore) Generate(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+func (m *mockTokenStore) Generate(ctx context.Context, claims config.JWTClaims, tokenType config.TokenType) (string, error) {
 	if m.generateFunc != nil {
-		return m.generateFunc(claims, tokenType)
+		return m.generateFunc(ctx, claims, tokenType)
 	}
 	return "", errors.New("generator not configured")
 }
 
-func (m *mockTokenStore) Revoke(claims config.JWTClaims) error {
+func (m *mockTokenStore) Revoke(ctx context.Context, claims config.JWTClaims) error {
 	if m.revokeFunc != nil {
-		return m.revokeFunc(claims)
+		return m.revokeFunc(ctx, claims)
 	}
 	return nil
 }
 
-func (m *mockTokenStore) IsRevoked(claims config.JWTClaims) bool {
-	return m.isRevoked
+func (m *mockTokenStore) IsRevoked(ctx context.Context, claims config.JWTClaims) (bool, error) {
+	return m.isRevoked, nil
 }
 
 func TestJWTAuth_MissingToken(t *testing.T) {
 	store := &mockTokenStore{
-		validateFunc: func(token string) (config.JWTClaims, error) {
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
 			return map[string]any{"sub": "user123"}, nil
 		},
 	}
@@ -92,7 +92,7 @@ func TestJWTAuth_MissingToken(t *testing.T) {
 
 func TestJWTAuth_InvalidToken(t *testing.T) {
 	store := &mockTokenStore{
-		validateFunc: func(token string) (config.JWTClaims, error) {
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
 			return nil, errors.New("invalid token")
 		},
 	}
@@ -146,7 +146,7 @@ func TestJWTAuth_Success(t *testing.T) {
 	}
 
 	store := &mockTokenStore{
-		validateFunc: func(token string) (config.JWTClaims, error) {
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
 			return expectedClaims, nil
 		},
 	}
@@ -245,7 +245,7 @@ func TestJWTAuth_ExemptMethod(t *testing.T) {
 
 func TestJWTAuth_RequiredClaims(t *testing.T) {
 	store := &mockTokenStore{
-		validateFunc: func(token string) (config.JWTClaims, error) {
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
 			return map[string]any{
 				"sub": "user123",
 			}, nil
@@ -307,7 +307,7 @@ func TestJWTAuth_OnSuccess(t *testing.T) {
 	var receivedClaims config.JWTClaims
 
 	store := &mockTokenStore{
-		validateFunc: func(token string) (config.JWTClaims, error) {
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
 			return map[string]any{"sub": "user123"}, nil
 		},
 	}
@@ -677,7 +677,7 @@ func TestGenerateRefreshToken_NoStore(t *testing.T) {
 
 func TestGenerateAccessToken_Success(t *testing.T) {
 	store := &mockTokenStore{
-		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+		generateFunc: func(ctx context.Context, claims config.JWTClaims, tokenType config.TokenType) (string, error) {
 			return "generated-access-token", nil
 		},
 	}
@@ -699,7 +699,7 @@ func TestGenerateAccessToken_Success(t *testing.T) {
 
 func TestGenerateRefreshToken_Success(t *testing.T) {
 	store := &mockTokenStore{
-		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+		generateFunc: func(ctx context.Context, claims config.JWTClaims, tokenType config.TokenType) (string, error) {
 			return "generated-refresh-token", nil
 		},
 	}
@@ -721,7 +721,7 @@ func TestGenerateRefreshToken_Success(t *testing.T) {
 
 func TestGenerateAccessToken_StoreError(t *testing.T) {
 	store := &mockTokenStore{
-		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+		generateFunc: func(ctx context.Context, claims config.JWTClaims, tokenType config.TokenType) (string, error) {
 			return "", errors.New("token generation failed")
 		},
 	}
@@ -743,7 +743,7 @@ func TestGenerateAccessToken_StoreError(t *testing.T) {
 
 func TestGenerateRefreshToken_StoreError(t *testing.T) {
 	store := &mockTokenStore{
-		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+		generateFunc: func(ctx context.Context, claims config.JWTClaims, tokenType config.TokenType) (string, error) {
 			return "", errors.New("token generation failed")
 		},
 	}
@@ -765,7 +765,7 @@ func TestGenerateRefreshToken_StoreError(t *testing.T) {
 
 func TestRefreshTokenHandler(t *testing.T) {
 	store := &mockTokenStore{
-		validateFunc: func(token string) (config.JWTClaims, error) {
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
 			if token == "valid-refresh-token" {
 				return map[string]any{
 					"sub":  "user123",
@@ -774,7 +774,7 @@ func TestRefreshTokenHandler(t *testing.T) {
 			}
 			return nil, errors.New("invalid token")
 		},
-		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+		generateFunc: func(ctx context.Context, claims config.JWTClaims, tokenType config.TokenType) (string, error) {
 			if tokenType == config.AccessToken {
 				return "new-access-token", nil
 			}
@@ -833,10 +833,10 @@ func TestRefreshTokenHandler_InvalidMethod(t *testing.T) {
 
 func TestRefreshTokenHandler_MissingToken(t *testing.T) {
 	store := &mockTokenStore{
-		validateFunc: func(token string) (config.JWTClaims, error) {
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
 			return nil, errors.New("invalid token")
 		},
-		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+		generateFunc: func(ctx context.Context, claims config.JWTClaims, tokenType config.TokenType) (string, error) {
 			return "token", nil
 		},
 	}
@@ -859,10 +859,10 @@ func TestRefreshTokenHandler_MissingToken(t *testing.T) {
 
 func TestRefreshTokenHandler_InvalidToken(t *testing.T) {
 	store := &mockTokenStore{
-		validateFunc: func(token string) (config.JWTClaims, error) {
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
 			return nil, errors.New("invalid token")
 		},
-		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+		generateFunc: func(ctx context.Context, claims config.JWTClaims, tokenType config.TokenType) (string, error) {
 			return "token", nil
 		},
 	}
@@ -887,13 +887,13 @@ func TestRefreshTokenHandler_InvalidToken(t *testing.T) {
 
 func TestRefreshTokenHandler_NotRefreshToken(t *testing.T) {
 	store := &mockTokenStore{
-		validateFunc: func(token string) (config.JWTClaims, error) {
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
 			return map[string]any{
 				"sub":  "user123",
 				"type": "access",
 			}, nil
 		},
-		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+		generateFunc: func(ctx context.Context, claims config.JWTClaims, tokenType config.TokenType) (string, error) {
 			return "token", nil
 		},
 	}
@@ -918,14 +918,14 @@ func TestRefreshTokenHandler_NotRefreshToken(t *testing.T) {
 
 func TestRefreshTokenHandler_TokenRevoked(t *testing.T) {
 	store := &mockTokenStore{
-		validateFunc: func(token string) (config.JWTClaims, error) {
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
 			return map[string]any{
 				"sub":  "user123",
 				"type": config.TokenTypeRefresh,
 				"jti":  "token-id-123",
 			}, nil
 		},
-		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+		generateFunc: func(ctx context.Context, claims config.JWTClaims, tokenType config.TokenType) (string, error) {
 			return "token", nil
 		},
 		isRevoked: true,
@@ -956,14 +956,14 @@ func TestRefreshTokenHandler_TokenRevoked(t *testing.T) {
 
 func TestRefreshTokenHandler_TokenAllowed(t *testing.T) {
 	store := &mockTokenStore{
-		validateFunc: func(token string) (config.JWTClaims, error) {
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
 			return map[string]any{
 				"sub":  "user123",
 				"type": config.TokenTypeRefresh,
 				"jti":  "valid-token-id",
 			}, nil
 		},
-		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+		generateFunc: func(ctx context.Context, claims config.JWTClaims, tokenType config.TokenType) (string, error) {
 			if tokenType == config.AccessToken {
 				return "new-access-token", nil
 			}
@@ -994,14 +994,14 @@ func TestRefreshTokenHandler_TokenAllowed(t *testing.T) {
 func TestLogoutTokenHandler(t *testing.T) {
 	revokeCalled := false
 	store := &mockTokenStore{
-		validateFunc: func(token string) (config.JWTClaims, error) {
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
 			return map[string]any{
 				"sub":  "user123",
 				"type": config.TokenTypeRefresh,
 				"jti":  "token-id-123",
 			}, nil
 		},
-		revokeFunc: func(claims config.JWTClaims) error {
+		revokeFunc: func(ctx context.Context, claims config.JWTClaims) error {
 			revokeCalled = true
 			return nil
 		},
@@ -1070,7 +1070,7 @@ func TestLogoutTokenHandler_NoTokenStore(t *testing.T) {
 
 func TestLogoutTokenHandler_MissingToken(t *testing.T) {
 	store := &mockTokenStore{
-		validateFunc: func(token string) (config.JWTClaims, error) {
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
 			return nil, errors.New("invalid token")
 		},
 	}
@@ -1094,7 +1094,7 @@ func TestLogoutTokenHandler_MissingToken(t *testing.T) {
 
 func TestLogoutTokenHandler_InvalidToken(t *testing.T) {
 	store := &mockTokenStore{
-		validateFunc: func(token string) (config.JWTClaims, error) {
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
 			return nil, errors.New("invalid token")
 		},
 	}
@@ -1119,7 +1119,7 @@ func TestLogoutTokenHandler_InvalidToken(t *testing.T) {
 
 func TestLogoutTokenHandler_NotRefreshToken(t *testing.T) {
 	store := &mockTokenStore{
-		validateFunc: func(token string) (config.JWTClaims, error) {
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
 			return map[string]any{
 				"sub":  "user123",
 				"type": "access",
@@ -1147,14 +1147,14 @@ func TestLogoutTokenHandler_NotRefreshToken(t *testing.T) {
 
 func TestLogoutTokenHandler_RevokeError(t *testing.T) {
 	store := &mockTokenStore{
-		validateFunc: func(token string) (config.JWTClaims, error) {
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
 			return map[string]any{
 				"sub":  "user123",
 				"type": config.TokenTypeRefresh,
 				"jti":  "token-id-123",
 			}, nil
 		},
-		revokeFunc: func(claims config.JWTClaims) error {
+		revokeFunc: func(ctx context.Context, claims config.JWTClaims) error {
 			return errors.New("database error")
 		},
 	}
@@ -1814,7 +1814,7 @@ func TestAddTypeToClaims_NonMap(t *testing.T) {
 
 func TestGenerateAccessToken_DefaultTTL(t *testing.T) {
 	store := &mockTokenStore{
-		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+		generateFunc: func(ctx context.Context, claims config.JWTClaims, tokenType config.TokenType) (string, error) {
 			return "token", nil
 		},
 	}
@@ -1824,7 +1824,8 @@ func TestGenerateAccessToken_DefaultTTL(t *testing.T) {
 	}
 	claims := map[string]any{"sub": "user123"}
 
-	token, err := GenerateAccessToken(nil, claims, cfg)
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	token, err := GenerateAccessToken(req, claims, cfg)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -1835,13 +1836,13 @@ func TestGenerateAccessToken_DefaultTTL(t *testing.T) {
 
 func TestRefreshTokenHandler_StoreError(t *testing.T) {
 	store := &mockTokenStore{
-		validateFunc: func(token string) (config.JWTClaims, error) {
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
 			return map[string]any{
 				"sub":  "user123",
 				"type": config.TokenTypeRefresh,
 			}, nil
 		},
-		generateFunc: func(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+		generateFunc: func(ctx context.Context, claims config.JWTClaims, tokenType config.TokenType) (string, error) {
 			if tokenType == config.AccessToken {
 				return "", errors.New("generate failed")
 			}
@@ -1867,7 +1868,7 @@ func TestRefreshTokenHandler_StoreError(t *testing.T) {
 
 func TestLogoutTokenHandler_AlreadyRevoked(t *testing.T) {
 	store := &mockTokenStore{
-		validateFunc: func(token string) (config.JWTClaims, error) {
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
 			return map[string]any{
 				"sub":  "user123",
 				"type": config.TokenTypeRefresh,
@@ -1894,7 +1895,7 @@ func TestLogoutTokenHandler_AlreadyRevoked(t *testing.T) {
 
 func TestJWTAuth_RevokedToken(t *testing.T) {
 	store := &mockTokenStore{
-		validateFunc: func(token string) (config.JWTClaims, error) {
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
 			return map[string]any{"sub": "user123"}, nil
 		},
 		isRevoked: true,
@@ -1926,7 +1927,7 @@ func TestJWTAuth_RevokedToken(t *testing.T) {
 
 func TestJWTAuth_RefreshTokenAsAccessToken(t *testing.T) {
 	store := &mockTokenStore{
-		validateFunc: func(token string) (config.JWTClaims, error) {
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
 			return map[string]any{
 				"sub":  "user123",
 				"type": config.TokenTypeRefresh,
@@ -1961,7 +1962,7 @@ func TestJWTAuth_RefreshTokenAsAccessToken(t *testing.T) {
 func TestJWTAuth_Metrics(t *testing.T) {
 	reg := metrics.NewRegistry()
 	store := &mockTokenStore{
-		validateFunc: func(token string) (config.JWTClaims, error) {
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
 			if token == "valid-token" {
 				return map[string]any{"sub": "user123"}, nil
 			}

--- a/middleware/jwt_hs256.go
+++ b/middleware/jwt_hs256.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
@@ -43,29 +44,29 @@ func NewHS256TokenStore(secret []byte, opts HS256Options) *HS256TokenStore {
 }
 
 // Validate parses and validates an HS256 JWT token.
-func (s *HS256TokenStore) Validate(token string) (config.JWTClaims, error) {
+func (s *HS256TokenStore) Validate(_ context.Context, token string) (config.JWTClaims, error) {
 	return parseHS256Token(token, s.secret, s.opts)
 }
 
 // Generate creates a new HS256 JWT token for the given claims.
-func (s *HS256TokenStore) Generate(claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+func (s *HS256TokenStore) Generate(_ context.Context, claims config.JWTClaims, tokenType config.TokenType) (string, error) {
 	return generateHS256Token(claims, s.secret, s.opts)
 }
 
 // Revoke is a no-op for HS256TokenStore. In-memory revocation is not supported.
 // Use a database-backed TokenStore implementation for revocation support.
-func (s *HS256TokenStore) Revoke(claims config.JWTClaims) error {
+func (s *HS256TokenStore) Revoke(_ context.Context, claims config.JWTClaims) error {
 	// No-op: HS256TokenStore doesn't support revocation
 	// Users should implement their own TokenStore with Redis/DB for revocation
 	return nil
 }
 
-// IsRevoked always returns false for HS256TokenStore.
+// IsRevoked always returns (false, nil) for HS256TokenStore.
 // Use a database-backed TokenStore implementation for revocation support.
-func (s *HS256TokenStore) IsRevoked(claims config.JWTClaims) bool {
+func (s *HS256TokenStore) IsRevoked(_ context.Context, claims config.JWTClaims) (bool, error) {
 	// Always returns false: HS256TokenStore doesn't support revocation
 	// Users should implement their own TokenStore with Redis/DB for revocation
-	return false
+	return false, nil
 }
 
 // HS256Options configures the built-in HS256 JWT implementation.

--- a/middleware/jwt_hs256_test.go
+++ b/middleware/jwt_hs256_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"strings"
@@ -384,13 +385,13 @@ func TestHS256TokenStore_Validate(t *testing.T) {
 		"exp": float64(time.Now().Add(time.Hour).Unix()),
 	}
 
-	token, err := store.Generate(claims, config.AccessToken)
+	token, err := store.Generate(context.Background(), claims, config.AccessToken)
 	if err != nil {
 		t.Fatalf("failed to generate token: %v", err)
 	}
 
 	// Validate the token
-	validatedClaims, err := store.Validate(token)
+	validatedClaims, err := store.Validate(context.Background(), token)
 	if err != nil {
 		t.Fatalf("failed to validate token: %v", err)
 	}
@@ -410,7 +411,7 @@ func TestHS256TokenStore_Validate_InvalidToken(t *testing.T) {
 	opts := HS256Options{}
 	store := NewHS256TokenStore(secret, opts)
 
-	_, err := store.Validate("invalid.token.here")
+	_, err := store.Validate(context.Background(), "invalid.token.here")
 	if err == nil {
 		t.Error("expected error for invalid token")
 	}
@@ -428,7 +429,7 @@ func TestHS256TokenStore_Generate(t *testing.T) {
 		"exp": float64(time.Now().Add(time.Hour).Unix()),
 	}
 
-	token, err := store.Generate(claims, config.AccessToken)
+	token, err := store.Generate(context.Background(), claims, config.AccessToken)
 	if err != nil {
 		t.Fatalf("failed to generate token: %v", err)
 	}
@@ -451,7 +452,7 @@ func TestHS256TokenStore_Generate_WithMapClaims(t *testing.T) {
 		"exp": time.Now().Add(time.Hour).Unix(),
 	}
 
-	token, err := store.Generate(claims, config.AccessToken)
+	token, err := store.Generate(context.Background(), claims, config.AccessToken)
 	if err != nil {
 		t.Fatalf("failed to generate token: %v", err)
 	}
@@ -469,7 +470,7 @@ func TestHS256TokenStore_Generate_UnsupportedClaimsType(t *testing.T) {
 	store := NewHS256TokenStore(secret, opts)
 
 	// Use unsupported claims type
-	_, err := store.Generate("not a map", config.AccessToken)
+	_, err := store.Generate(context.Background(), "not a map", config.AccessToken)
 	if err == nil {
 		t.Error("expected error for unsupported claims type")
 	}
@@ -482,7 +483,7 @@ func TestHS256TokenStore_Revoke(t *testing.T) {
 
 	// Revoke is a no-op for HS256TokenStore
 	claims := HS256Claims{"sub": "user123"}
-	err := store.Revoke(claims)
+	err := store.Revoke(context.Background(), claims)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
@@ -495,7 +496,8 @@ func TestHS256TokenStore_IsRevoked(t *testing.T) {
 
 	// IsRevoked always returns false for HS256TokenStore
 	claims := HS256Claims{"sub": "user123", "jti": "token-id"}
-	if store.IsRevoked(claims) {
+	revoked, _ := store.IsRevoked(context.Background(), claims)
+	if revoked {
 		t.Error("expected IsRevoked to return false")
 	}
 }
@@ -515,13 +517,13 @@ func TestHS256TokenStore_RoundTrip(t *testing.T) {
 		"exp":   float64(time.Now().Add(time.Hour).Unix()),
 	}
 
-	token, err := store.Generate(claims, config.AccessToken)
+	token, err := store.Generate(context.Background(), claims, config.AccessToken)
 	if err != nil {
 		t.Fatalf("failed to generate token: %v", err)
 	}
 
 	// Validate token
-	validatedClaims, err := store.Validate(token)
+	validatedClaims, err := store.Validate(context.Background(), token)
 	if err != nil {
 		t.Fatalf("failed to validate token: %v", err)
 	}
@@ -739,13 +741,13 @@ func TestGenerateHS256Token_NoIssuer(t *testing.T) {
 		"exp": float64(time.Now().Add(time.Hour).Unix()),
 	}
 
-	token, err := store.Generate(claims, config.AccessToken)
+	token, err := store.Generate(context.Background(), claims, config.AccessToken)
 	if err != nil {
 		t.Fatalf("failed to generate token: %v", err)
 	}
 
 	// Validate and check issuer wasn't added
-	validatedClaims, err := store.Validate(token)
+	validatedClaims, err := store.Validate(context.Background(), token)
 	if err != nil {
 		t.Fatalf("failed to validate token: %v", err)
 	}
@@ -769,13 +771,13 @@ func TestGenerateHS256Token_NoAudience(t *testing.T) {
 		"exp": float64(time.Now().Add(time.Hour).Unix()),
 	}
 
-	token, err := store.Generate(claims, config.AccessToken)
+	token, err := store.Generate(context.Background(), claims, config.AccessToken)
 	if err != nil {
 		t.Fatalf("failed to generate token: %v", err)
 	}
 
 	// Validate and check audience wasn't added
-	validatedClaims, err := store.Validate(token)
+	validatedClaims, err := store.Validate(context.Background(), token)
 	if err != nil {
 		t.Fatalf("failed to validate token: %v", err)
 	}

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -23,11 +23,22 @@ func DefaultMiddlewares(cfg config.Config, logger log.Logger) []func(http.Handle
 }
 
 // pathMatches checks if a request path matches an exempt path.
-// Supports exact matches and prefix matches (paths ending with /).
-// For example, "/api/public/" matches "/api/public", "/api/public/users", and "/api/public/status".
+// Supports:
+//   - Exact matches
+//   - Prefix matches (paths ending with /)
+//   - Wildcard suffix matches (paths ending with *)
+//
+// For example:
+//   - "/api/public/" matches "/api/public", "/api/public/users", "/api/public/status"
+//   - "/api/live*" matches "/api/live", "/api/livez", "/api/health/live"
 func pathMatches(requestPath, exemptPath string) bool {
 	if exemptPath == requestPath {
 		return true
+	}
+
+	// Support wildcard suffix matching for paths ending with *
+	if base, hasSuffix := strings.CutSuffix(exemptPath, "*"); hasSuffix {
+		return strings.HasPrefix(requestPath, base)
 	}
 
 	// Support prefix matching for paths ending with /

--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -16,6 +16,7 @@ import (
 type PProf struct {
 	// Config is the configuration used
 	Config Config
+
 	// Auth contains the actual authentication config used (auto-generated or provided)
 	Auth *AuthConfig
 }
@@ -84,6 +85,7 @@ type AuthConfig struct {
 	// Username for basic auth
 	// Default: "pprof"
 	Username string
+
 	// Password for basic auth
 	// Default: auto-generated secure random password
 	Password string

--- a/websocket.go
+++ b/websocket.go
@@ -7,8 +7,6 @@ import (
 	"github.com/alexferl/zerohttp/config"
 )
 
-// Re-export WebSocket types from config package for convenience.
-
 // MessageType represents the type of WebSocket message.
 type MessageType = config.MessageType
 


### PR DESCRIPTION
- Add Cache middleware with ETag, conditional requests, and LRU store
- Add CacheStore interface with context support for pluggable backends
- Update JWT TokenStore interface to accept context and return errors
- Remove Logger fields from configs, use global logger instead
- Add cache hit/miss metrics
- Add cache example with README