### PR TITLE
fix: router duplicate route detection and static file status logging

### DIFF
--- a/router.go
+++ b/router.go
@@ -492,6 +492,24 @@ func (r *defaultRouter) StaticDir(dir string, fallback bool, apiPrefix ...string
 	r.mux.Handle("GET /{path...}", r.wrap(handler, nil))
 }
 
+// statusCapture wraps http.ResponseWriter to capture the status code.
+// Used by static file handler to log actual response status instead of hardcoded 200.
+type statusCapture struct {
+	http.ResponseWriter
+	status int
+}
+
+func (s *statusCapture) WriteHeader(code int) {
+	s.status = code
+	s.ResponseWriter.WriteHeader(code)
+}
+
+func (s *statusCapture) Flush() {
+	if f, ok := s.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 func (r *defaultRouter) createStaticHandler(filesystem fs.FS, fallback bool, apiPrefixes []string) http.Handler {
 	// Capture config values at handler creation time to avoid data races.
 	// notFoundHandler is protected by handlerMu and accessed with locking.
@@ -539,8 +557,9 @@ func (r *defaultRouter) createStaticHandler(filesystem fs.FS, fallback bool, api
 			stat, statErr := file.Stat()
 			_ = file.Close() // Close immediately - http.FileServer will open it again
 			if statErr == nil && !stat.IsDir() {
-				http.FileServer(http.FS(filesystem)).ServeHTTP(w, req)
-				middleware.LogRequest(logger, requestLoggerConfig, nil, req, http.StatusOK, time.Since(start), "", "")
+				rec := &statusCapture{ResponseWriter: w, status: http.StatusOK}
+				http.FileServer(http.FS(filesystem)).ServeHTTP(rec, req)
+				middleware.LogRequest(logger, requestLoggerConfig, nil, req, rec.status, time.Since(start), "", "")
 				return
 			}
 		}
@@ -549,10 +568,11 @@ func (r *defaultRouter) createStaticHandler(filesystem fs.FS, fallback bool, api
 			// Preserve original path for accurate logging and deferred middleware
 			originalPath := req.URL.Path
 			req.URL.Path = "/"
-			http.FileServer(http.FS(filesystem)).ServeHTTP(w, req)
+			rec := &statusCapture{ResponseWriter: w, status: http.StatusOK}
+			http.FileServer(http.FS(filesystem)).ServeHTTP(rec, req)
 			// Restore path before logging so SPA fallbacks are logged with their real URL
 			req.URL.Path = originalPath
-			middleware.LogRequest(logger, requestLoggerConfig, nil, req, http.StatusOK, time.Since(start), "", "")
+			middleware.LogRequest(logger, requestLoggerConfig, nil, req, rec.status, time.Since(start), "", "")
 		} else {
 			notFoundHandler.ServeHTTP(w, req)
 			middleware.LogRequest(logger, requestLoggerConfig, nil, req, http.StatusNotFound, time.Since(start), "", "")
@@ -636,6 +656,11 @@ func (r *defaultRouter) handle(method, path string, fn http.Handler, mw []func(h
 	r.routesMu.Lock()
 	if r.registeredRoutes[path] == nil {
 		r.registeredRoutes[path] = make(map[string]bool)
+	}
+	// Detect duplicate route registration before overwriting
+	if r.registeredRoutes[path][method] {
+		r.routesMu.Unlock()
+		panic(fmt.Sprintf("zerohttp: route %s %s already registered", method, path))
 	}
 	r.registeredRoutes[path][method] = true
 	r.routesMu.Unlock()

--- a/router_test.go
+++ b/router_test.go
@@ -1082,6 +1082,85 @@ func TestRouter_Static(t *testing.T) {
 
 		router.StaticDir("testdata/static", false)
 	})
+
+	t.Run("Duplicate route registration panics with clear message", func(t *testing.T) {
+		router := NewRouter()
+		router.GET("/test", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("first"))
+		}))
+
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("Expected panic on duplicate route registration")
+			} else {
+				msg := fmt.Sprintf("%v", r)
+				if !strings.Contains(msg, "GET /test already registered") {
+					t.Errorf("Expected clear panic message with route details, got: %v", r)
+				}
+			}
+		}()
+
+		router.GET("/test", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("second"))
+		}))
+	})
+
+	t.Run("Static file handler logs actual status codes", func(t *testing.T) {
+		// This test verifies statusCapture captures actual response codes
+		// rather than hardcoding 200
+		router := NewRouter()
+		router.StaticDir("testdata/static", false)
+
+		// Request non-existent file - should log 404, not 200
+		req := httptest.NewRequest(http.MethodGet, "/nonexistent.txt", nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Errorf("Expected 404 for missing file, got %d", w.Code)
+		}
+	})
+}
+
+func TestStatusCapture(t *testing.T) {
+	t.Run("captures status code", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		statusCap := &statusCapture{ResponseWriter: rec, status: http.StatusOK}
+
+		statusCap.WriteHeader(http.StatusNotFound)
+
+		if statusCap.status != http.StatusNotFound {
+			t.Errorf("Expected captured status %d, got %d", http.StatusNotFound, statusCap.status)
+		}
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("Expected recorder status %d, got %d", http.StatusNotFound, rec.Code)
+		}
+	})
+
+	t.Run("implements http.Flusher", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		statusCap := &statusCapture{ResponseWriter: rec, status: http.StatusOK}
+
+		// Verify it implements http.Flusher
+		flusher, ok := interface{}(statusCap).(http.Flusher)
+		if !ok {
+			t.Error("statusCapture should implement http.Flusher")
+		}
+
+		// Verify Flush doesn't panic
+		flusher.Flush()
+	})
+
+	t.Run("Flush forwards to underlying Flusher", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		statusCap := &statusCapture{ResponseWriter: rec, status: http.StatusOK}
+
+		// Recorder implements Flusher, Flush should work
+		statusCap.Flush()
+
+		// Should not panic and should complete without error
+	})
 }
 
 func TestRouter_ServeMux(t *testing.T) {


### PR DESCRIPTION
- Detect duplicate route registration with clear panic message
- Add statusCapture wrapper to log actual HTTP status codes (not hardcoded 200)
- Implement http.Flusher on statusCapture for proper chunked transfer