### PR TITLE
feat: CSP nonce generation for SecurityHeaders middleware

### DIFF
--- a/config/security_headers.go
+++ b/config/security_headers.go
@@ -47,13 +47,31 @@ var DefaultStrictTransportSecurity = StrictTransportSecurity{
 	PreloadEnabled:    false,
 }
 
+// CSPNonceContextKey is the context key for CSP nonce values
+type CSPNonceContextKey string
+
+const (
+	// DefaultCSPNonceContextKey is the default context key for CSP nonces
+	DefaultCSPNonceContextKey CSPNonceContextKey = "csp_nonce"
+	// CSPNoncePlaceholder is the placeholder string replaced with the actual nonce
+	CSPNoncePlaceholder = "{{nonce}}"
+)
+
 // SecurityHeadersConfig allows customization of security headers
 type SecurityHeadersConfig struct {
-	// ContentSecurityPolicy sets the `Content-Security-Policy` header
+	// ContentSecurityPolicy sets the `Content-Security-Policy` header.
+	// Use "{{nonce}}" placeholder to enable nonce generation (e.g., script-src 'nonce-{{nonce}}')
 	ContentSecurityPolicy string
 
 	// ContentSecurityPolicyReportOnly sets the policy in report-only mode
 	ContentSecurityPolicyReportOnly bool
+
+	// ContentSecurityPolicyNonceEnabled generates a unique nonce per request when true.
+	// The nonce replaces "{{nonce}}" in the CSP header and is stored in context.
+	ContentSecurityPolicyNonceEnabled bool
+
+	// ContentSecurityPolicyNonceContextKey overrides the default context key for storing the nonce
+	ContentSecurityPolicyNonceContextKey CSPNonceContextKey
 
 	// CrossOriginEmbedderPolicy sets the `Cross-Origin-Embedder-Policy` header
 	CrossOriginEmbedderPolicy string

--- a/examples/csp_nonce/README.md
+++ b/examples/csp_nonce/README.md
@@ -1,0 +1,95 @@
+# CSP Nonce Example
+
+This example demonstrates Content Security Policy (CSP) nonce generation with zerohttp.
+
+## What is a CSP Nonce?
+
+A CSP nonce is a cryptographically random value that allows specific inline scripts and styles to execute while blocking all others. The nonce is:
+
+1. Generated uniquely for each request
+2. Added to the CSP header (`script-src 'nonce-abc123'`)
+3. Added to inline script tags (`<script nonce="abc123">`)
+4. Validated by the browser - only scripts with matching nonces execute
+
+## Why Use CSP Nonces?
+
+- **XSS Protection**: Blocks unauthorized inline scripts
+- **Flexibility**: Allows trusted inline scripts without using `'unsafe-inline'`
+- **Per-Request Unique**: Makes exploitation harder as nonces change every request
+
+## Running the Example
+
+```bash
+go run main.go
+```
+
+Visit http://localhost:8080 to see the demo.
+
+## How It Works
+
+### 1. Enable CSP Nonce Generation
+
+```go
+app.Use(middleware.SecurityHeaders(config.SecurityHeadersConfig{
+    CSPNonceEnabled: true,
+    ContentSecurityPolicy: "script-src 'nonce-{{nonce}}'; style-src 'nonce-{{nonce}}'",
+}))
+```
+
+### 2. Get the Nonce in Your Handler
+
+```go
+nonce := middleware.GetCSPNonce(r)
+```
+
+### 3. Inject into Your HTML
+
+```html
+<script nonce="{{.Nonce}}">
+    // This script is allowed
+</script>
+```
+
+## Configuration Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `CSPNonceEnabled` | Enable nonce generation | `false` |
+| `CSPNonceContextKey` | Custom context key | `"csp_nonce"` |
+| `ContentSecurityPolicy` | CSP header with `{{nonce}}` placeholder | - |
+
+## Using with Templates
+
+For template rendering, pass the nonce to your template data:
+
+```go
+type PageData struct {
+    Title string
+    Nonce string
+}
+
+data := PageData{
+    Title: "My Page",
+    Nonce: middleware.GetCSPNonce(r),
+}
+return tmpl.Execute(w, data)
+```
+
+Then in your template:
+```html
+<script nonce="{{.Nonce}}">
+    console.log("Script with nonce executes");
+</script>
+```
+
+## Report-Only Mode
+
+Test your CSP without blocking:
+
+```go
+SecurityHeaders(config.SecurityHeadersConfig{
+    CSPNonceEnabled: true,
+    ContentSecurityPolicy: "script-src 'nonce-{{nonce}}'",
+    ContentSecurityPolicyReportOnly: true,
+})
+```

--- a/examples/csp_nonce/main.go
+++ b/examples/csp_nonce/main.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/middleware"
+)
+
+func main() {
+	app := zh.New()
+
+	// Configure security headers with CSP nonce generation
+	// The {{nonce}} placeholder will be replaced with a unique nonce per request
+	app.Use(middleware.SecurityHeaders(config.SecurityHeadersConfig{
+		ContentSecurityPolicyNonceEnabled: true,
+		ContentSecurityPolicy: "default-src 'self'; " +
+			"script-src 'nonce-{{nonce}}' 'strict-dynamic'; " +
+			"style-src 'nonce-{{nonce}}' 'self'; " +
+			"img-src 'self' data:; " +
+			"font-src 'self'; " +
+			"connect-src 'self'; " +
+			"frame-ancestors 'none'; " +
+			"base-uri 'self';",
+	}))
+
+	// Route that serves HTML with inline scripts using the CSP nonce
+	app.GET("/", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		// Get the nonce from the request context
+		nonce := middleware.GetCSPNonce(r)
+
+		html := fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<head>
+    <title>CSP Nonce Demo</title>
+    <!-- This inline style is allowed because it has the correct nonce -->
+    <style nonce="%[1]s">
+        body { font-family: sans-serif; max-width: 800px; margin: 50px auto; padding: 20px; }
+        .success { color: green; }
+        .nonce { background: #f0f0f0; padding: 10px; border-radius: 4px; word-break: break-all; }
+    </style>
+</head>
+<body>
+    <h1>Content Security Policy Nonce Demo</h1>
+
+    <h2>Current CSP Nonce:</h2>
+    <div class="nonce">%[1]s</div>
+
+    <h2>Status:</h2>
+    <p id="status">Checking if inline scripts work...</p>
+
+    <!-- This inline script is allowed because it has the correct nonce -->
+    <script nonce="%[1]s">
+        document.getElementById('status').innerHTML =
+            '<span class="success">✓ Inline scripts are working! The CSP nonce is valid.</span>';
+        console.log('CSP nonce used:', '%[1]s');
+    </script>
+
+    <!-- This script block also works with the same nonce -->
+    <script nonce="%[1]s">
+        console.log('Multiple script blocks work with the same nonce');
+    </script>
+</body>
+</html>`, nonce)
+
+		return zh.Render.HTML(w, http.StatusOK, html)
+	}))
+
+	// API route that returns the current nonce (for debugging)
+	app.GET("/api/nonce", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nonce := middleware.GetCSPNonce(r)
+		return zh.Render.JSON(w, http.StatusOK, zh.M{
+			"nonce":   nonce,
+			"message": "This nonce is unique per request and valid for the current page load",
+		})
+	}))
+
+	log.Println("Server starting on http://localhost:8080")
+	log.Println("Visit http://localhost:8080 to see CSP nonces in action")
+	log.Fatal(app.Start())
+}

--- a/middleware/security_headers.go
+++ b/middleware/security_headers.go
@@ -1,8 +1,12 @@
 package middleware
 
 import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/alexferl/zerohttp/config"
 )
@@ -47,11 +51,26 @@ func SecurityHeaders(cfg ...config.SecurityHeadersConfig) func(http.Handler) htt
 				}
 			}
 
-			if c.ContentSecurityPolicy != "" {
+			csp := c.ContentSecurityPolicy
+
+			// Generate CSP nonce if enabled and placeholder is present
+			if c.ContentSecurityPolicyNonceEnabled && strings.Contains(csp, config.CSPNoncePlaceholder) {
+				nonce := generateNonce()
+				csp = strings.ReplaceAll(csp, config.CSPNoncePlaceholder, nonce)
+
+				// Store nonce in context for handlers to use
+				ctxKey := c.ContentSecurityPolicyNonceContextKey
+				if ctxKey == "" {
+					ctxKey = config.DefaultCSPNonceContextKey
+				}
+				r = r.WithContext(context.WithValue(r.Context(), ctxKey, nonce))
+			}
+
+			if csp != "" {
 				if c.ContentSecurityPolicyReportOnly {
-					w.Header().Set("Content-Security-Policy-Report-Only", c.ContentSecurityPolicy)
+					w.Header().Set("Content-Security-Policy-Report-Only", csp)
 				} else {
-					w.Header().Set("Content-Security-Policy", c.ContentSecurityPolicy)
+					w.Header().Set("Content-Security-Policy", csp)
 				}
 			}
 
@@ -107,4 +126,26 @@ func isHTTPS(r *http.Request) bool {
 	return r.TLS != nil ||
 		r.Header.Get("X-Forwarded-Proto") == "https" ||
 		r.Header.Get("X-Forwarded-Protocol") == "https"
+}
+
+// generateNonce creates a random base64-encoded nonce for CSP
+func generateNonce() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+// GetCSPNonce retrieves the CSP nonce from the request context.
+// Returns empty string if nonce is not present.
+func GetCSPNonce(r *http.Request, key ...config.CSPNonceContextKey) string {
+	var ctxKey any
+	if len(key) > 0 {
+		ctxKey = key[0]
+	} else {
+		ctxKey = config.DefaultCSPNonceContextKey
+	}
+	if nonce, ok := r.Context().Value(ctxKey).(string); ok {
+		return nonce
+	}
+	return ""
 }

--- a/middleware/security_headers_test.go
+++ b/middleware/security_headers_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"crypto/tls"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/alexferl/zerohttp/config"
@@ -251,5 +252,135 @@ func TestSecurityHeaders_DefaultValueFill_All(t *testing.T) {
 			zhtest.AssertWith(t, w).Status(http.StatusOK)
 			zhtest.AssertWith(t, w).Header(tt.header, tt.expected)
 		})
+	}
+}
+
+func TestSecurityHeaders_CSPNonce(t *testing.T) {
+	tests := []struct {
+		name            string
+		csp             string
+		nonceEnabled    bool
+		wantNonce       bool
+		wantCSPContains string
+	}{
+		{
+			name:            "Nonce generated and replaced",
+			csp:             "script-src 'nonce-{{nonce}}'",
+			nonceEnabled:    true,
+			wantNonce:       true,
+			wantCSPContains: "script-src 'nonce-",
+		},
+		{
+			name:            "No nonce when disabled",
+			csp:             "script-src 'nonce-{{nonce}}'",
+			nonceEnabled:    false,
+			wantNonce:       false,
+			wantCSPContains: "script-src 'nonce-{{nonce}}'",
+		},
+		{
+			name:            "No placeholder no nonce",
+			csp:             "default-src 'self'",
+			nonceEnabled:    true,
+			wantNonce:       false,
+			wantCSPContains: "default-src 'self'",
+		},
+		{
+			name:            "Multiple placeholders replaced",
+			csp:             "script-src 'nonce-{{nonce}}'; style-src 'nonce-{{nonce}}'",
+			nonceEnabled:    true,
+			wantNonce:       true,
+			wantCSPContains: "'nonce-",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedNonce string
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedNonce = GetCSPNonce(r)
+				w.WriteHeader(http.StatusOK)
+			})
+
+			req := zhtest.NewRequest(http.MethodGet, "/").Build()
+			mw := SecurityHeaders(config.SecurityHeadersConfig{
+				ContentSecurityPolicy:             tt.csp,
+				ContentSecurityPolicyNonceEnabled: tt.nonceEnabled,
+			})
+			w := zhtest.TestMiddlewareWithHandler(mw, handler, req)
+
+			zhtest.AssertWith(t, w).Status(http.StatusOK)
+
+			csp := w.Header().Get("Content-Security-Policy")
+			if !strings.Contains(csp, tt.wantCSPContains) {
+				t.Errorf("CSP header = %q, want containing %q", csp, tt.wantCSPContains)
+			}
+
+			if tt.wantNonce {
+				if capturedNonce == "" {
+					t.Error("Expected nonce in context, got empty string")
+				}
+				if !strings.Contains(csp, capturedNonce) {
+					t.Errorf("CSP header %q does not contain nonce %q", csp, capturedNonce)
+				}
+			} else {
+				if capturedNonce != "" {
+					t.Errorf("Expected no nonce, got %q", capturedNonce)
+				}
+			}
+		})
+	}
+}
+
+func TestSecurityHeaders_CSPNonceReportOnly(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := zhtest.NewRequest(http.MethodGet, "/").Build()
+	mw := SecurityHeaders(config.SecurityHeadersConfig{
+		ContentSecurityPolicy:             "script-src 'nonce-{{nonce}}'",
+		ContentSecurityPolicyReportOnly:   true,
+		ContentSecurityPolicyNonceEnabled: true,
+	})
+	w := zhtest.TestMiddlewareWithHandler(mw, handler, req)
+
+	zhtest.AssertWith(t, w).Status(http.StatusOK)
+	zhtest.AssertWith(t, w).HeaderNotExists("Content-Security-Policy")
+
+	csp := w.Header().Get("Content-Security-Policy-Report-Only")
+	if !strings.Contains(csp, "'nonce-") {
+		t.Errorf("CSP-Report-Only header should contain nonce, got: %s", csp)
+	}
+}
+
+func TestSecurityHeaders_CSPNonceCustomContextKey(t *testing.T) {
+	customKey := config.CSPNonceContextKey("my_custom_nonce_key")
+	var capturedNonce string
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedNonce = GetCSPNonce(r, customKey)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := zhtest.NewRequest(http.MethodGet, "/").Build()
+	mw := SecurityHeaders(config.SecurityHeadersConfig{
+		ContentSecurityPolicy:                "script-src 'nonce-{{nonce}}'",
+		ContentSecurityPolicyNonceEnabled:    true,
+		ContentSecurityPolicyNonceContextKey: customKey,
+	})
+	w := zhtest.TestMiddlewareWithHandler(mw, handler, req)
+
+	zhtest.AssertWith(t, w).Status(http.StatusOK)
+
+	if capturedNonce == "" {
+		t.Error("Expected nonce with custom context key, got empty string")
+	}
+}
+
+func TestGetCSPNonce_NotFound(t *testing.T) {
+	req := zhtest.NewRequest(http.MethodGet, "/").Build()
+	nonce := GetCSPNonce(req)
+	if nonce != "" {
+		t.Errorf("Expected empty string for missing nonce, got %q", nonce)
 	}
 }


### PR DESCRIPTION
Add {{nonce}} placeholder support that generates unique per-request nonces for Content-Security-Policy headers. Includes GetCSPNonce() helper and example demonstrating inline script nonce injection.