### PR TITLE
feat: add AcceptsJSON and RenderAuto for content negotiation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -85,12 +85,6 @@ type Config struct {
 	// RequestLogger holds the configuration for the HTTP request logging middleware.
 	RequestLogger RequestLoggerConfig
 
-	// ErrorResponseType controls the format of 404/405 error responses.
-	// ErrorResponseJSON returns RFC 9457 Problem Detail responses (application/problem+json).
-	// ErrorResponsePlain returns simple text/plain responses.
-	// Default: ErrorResponsePlain
-	ErrorResponseType ErrorResponseType
-
 	// SecurityHeaders holds the configuration for the security headers middleware.
 	SecurityHeaders SecurityHeadersConfig
 
@@ -148,14 +142,6 @@ type Config struct {
 	TracerConfig TracerConfig
 }
 
-// ErrorResponseType defines the format of error responses.
-type ErrorResponseType string
-
-const (
-	ErrorResponseJSON  ErrorResponseType = "json"
-	ErrorResponsePlain ErrorResponseType = "plain"
-)
-
 // DefaultConfig contains all default values used by Config.
 // Update this file if you want to change system-wide defaults.
 var DefaultConfig = Config{
@@ -169,7 +155,6 @@ var DefaultConfig = Config{
 	RequestLogger:             DefaultRequestLoggerConfig,
 	SecurityHeaders:           DefaultSecurityHeadersConfig,
 	Metrics:                   DefaultMetricsConfig,
-	ErrorResponseType:         ErrorResponsePlain,
 	Logger:                    nil, // means use DefaultLogger
 	Server:                    nil,
 	TLSServer:                 nil,

--- a/constants.go
+++ b/constants.go
@@ -8,7 +8,7 @@ const (
 	MIMETextEventStream           = "text/event-stream"
 	MIMEApplicationJSON           = "application/json"
 	MIMEApplicationJSONCharset    = "application/json; charset=utf-8"
-	MIMEApplicationProblem        = "application/problem+json"
+	MIMEApplicationProblemJSON    = "application/problem+json"
 	MIMEApplicationFormURLEncoded = "application/x-www-form-urlencoded"
 	MIMEMultipartFormData         = "multipart/form-data"
 )

--- a/internal/problem/detail.go
+++ b/internal/problem/detail.go
@@ -3,6 +3,7 @@ package problem
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 )
 
 // Detail represents an RFC 9457 Problem Details response.
@@ -80,6 +81,25 @@ func (p *Detail) Render(w http.ResponseWriter) error {
 	return json.NewEncoder(w).Encode(p)
 }
 
+// RenderAuto writes the Detail as an HTTP response, automatically selecting the
+// content type based on the Accept header. Returns JSON if the client accepts
+// application/json or application/problem+json; otherwise returns plain text.
+func (p *Detail) RenderAuto(w http.ResponseWriter, r *http.Request) error {
+	if !AcceptsJSON(r) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(p.Status)
+		text := p.Detail
+		if text == "" {
+			text = p.Title
+		}
+		if text != "" {
+			_, _ = w.Write([]byte(text + "\n"))
+		}
+		return nil
+	}
+	return p.Render(w)
+}
+
 // ValidationError represents a single validation error with optional field location information
 type ValidationError struct {
 	// Detail describes what went wrong with the validation
@@ -99,4 +119,18 @@ func NewValidationDetail[T any](detail string, errors []T) *Detail {
 	problem := NewDetail(http.StatusUnprocessableEntity, detail)
 	problem.Set("errors", errors)
 	return problem
+}
+
+// AcceptsJSON checks if the client accepts JSON responses based on the Accept header.
+// Returns true if the Accept header includes application/json or application/problem+json.
+func AcceptsJSON(r *http.Request) bool {
+	accept := r.Header.Get("Accept")
+	if accept == "" {
+		return false
+	}
+	if strings.Contains(accept, "application/json") ||
+		strings.Contains(accept, "application/problem+json") {
+		return true
+	}
+	return strings.Contains(accept, "*/*")
 }

--- a/internal/problem/detail_test.go
+++ b/internal/problem/detail_test.go
@@ -245,6 +245,101 @@ func TestDetail_Render_WithExtensions(t *testing.T) {
 	}
 }
 
+func TestDetail_RenderAuto(t *testing.T) {
+	tests := []struct {
+		name         string
+		acceptHeader string
+		wantJSON     bool
+	}{
+		{"accepts JSON", "application/json", true},
+		{"accepts problem+json", "application/problem+json", true},
+		{"accepts wildcard", "*/*", true},
+		{"accepts HTML only", "text/html", false},
+		{"empty accept header", "", false},
+		{"accepts JSON with quality", "application/json;q=0.9", true},
+		{"accepts HTML with wildcard", "text/html,*/*;q=0.8", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detail := NewDetail(http.StatusBadRequest, "Invalid request")
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tt.acceptHeader != "" {
+				r.Header.Set("Accept", tt.acceptHeader)
+			}
+
+			err := detail.RenderAuto(w, r)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			if tt.wantJSON {
+				zhtest.AssertWith(t, w).
+					Status(http.StatusBadRequest).
+					Header("Content-Type", "application/problem+json").
+					JSONPathEqual("title", "Bad Request").
+					JSONPathEqual("detail", "Invalid request")
+			} else {
+				zhtest.AssertWith(t, w).
+					Status(http.StatusBadRequest).
+					Header("Content-Type", "text/plain; charset=utf-8").
+					BodyContains("Invalid request")
+			}
+		})
+	}
+}
+
+func TestDetail_RenderAuto_FallbackToTitle(t *testing.T) {
+	detail := &Detail{Title: "Custom Error Title", Status: http.StatusInternalServerError}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Accept", "text/plain")
+
+	err := detail.RenderAuto(w, r)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	zhtest.AssertWith(t, w).
+		Status(http.StatusInternalServerError).
+		Header("Content-Type", "text/plain; charset=utf-8").
+		BodyContains("Custom Error Title")
+}
+
+func TestAcceptsJSON(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   bool
+	}{
+		{"empty header", "", false},
+		{"application/json", "application/json", true},
+		{"application/problem+json", "application/problem+json", true},
+		{"text/html", "text/html", false},
+		{"text/plain", "text/plain", false},
+		{"*/*", "*/*", true},
+		{"wildcard after json", "application/json, text/plain", true},
+		{"json after wildcard", "text/plain, application/json", true},
+		{"json with quality", "application/json;q=0.9", true},
+		{"problem+json with quality", "application/problem+json;q=0.8", true},
+		{"html only", "text/html,application/xhtml+xml,application/xml;q=0.9", false},
+		{"html with wildcard", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tt.header != "" {
+				req.Header.Set("Accept", tt.header)
+			}
+			if got := AcceptsJSON(req); got != tt.want {
+				t.Errorf("AcceptsJSON() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func equalValues(a, b any) bool {
 	if slice, ok := b.([]string); ok {
 		aSlice, ok := a.([]any)

--- a/middleware/basic_auth.go
+++ b/middleware/basic_auth.go
@@ -31,7 +31,7 @@ func BasicAuth(cfg ...config.BasicAuthConfig) func(http.Handler) http.Handler {
 			user, pass, ok := r.BasicAuth()
 			if !ok {
 				reg.Counter("basic_auth_requests_total", "result").WithLabelValues("missing").Inc()
-				basicAuthFailed(w, c.Realm)
+				basicAuthFailed(w, r, c.Realm)
 				return
 			}
 
@@ -48,7 +48,7 @@ func BasicAuth(cfg ...config.BasicAuthConfig) func(http.Handler) http.Handler {
 
 			if !isValid {
 				reg.Counter("basic_auth_requests_total", "result").WithLabelValues("invalid").Inc()
-				basicAuthFailed(w, c.Realm)
+				basicAuthFailed(w, r, c.Realm)
 				return
 			}
 
@@ -58,8 +58,8 @@ func BasicAuth(cfg ...config.BasicAuthConfig) func(http.Handler) http.Handler {
 	}
 }
 
-func basicAuthFailed(w http.ResponseWriter, realm string) {
+func basicAuthFailed(w http.ResponseWriter, r *http.Request, realm string) {
 	w.Header().Add("WWW-Authenticate", `Basic realm="`+realm+`"`)
 	detail := problem.NewDetail(http.StatusUnauthorized, "Authentication required")
-	_ = detail.Render(w)
+	_ = detail.RenderAuto(w, r)
 }

--- a/middleware/basic_auth_test.go
+++ b/middleware/basic_auth_test.go
@@ -273,8 +273,9 @@ func TestBasicAuthNilExemptPathsFallback(t *testing.T) {
 }
 
 func TestBasicAuthFailedFunction(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	w := httptest.NewRecorder()
-	basicAuthFailed(w, "Test Realm")
+	basicAuthFailed(w, req, "Test Realm")
 
 	zhtest.AssertWith(t, w).
 		Status(http.StatusUnauthorized).

--- a/middleware/circuit_breaker.go
+++ b/middleware/circuit_breaker.go
@@ -63,7 +63,7 @@ func CircuitBreaker(cfg ...config.CircuitBreakerConfig) func(http.Handler) http.
 			if circ.isOpen() {
 				reg.Counter("circuit_breaker_requests_total", "key", "result").WithLabelValues(key, "rejected").Inc()
 				detail := problem.NewDetail(c.OpenStatusCode, c.OpenMessage)
-				_ = detail.Render(w) // Best effort - client may have disconnected
+				_ = detail.RenderAuto(w, r) // Best effort - client may have disconnected
 				return
 			}
 

--- a/middleware/circuit_breaker_test.go
+++ b/middleware/circuit_breaker_test.go
@@ -51,13 +51,23 @@ func TestCircuitBreaker_FailureThreshold(t *testing.T) {
 		zhtest.AssertWith(t, w).Status(http.StatusInternalServerError)
 	}
 
-	req := zhtest.NewRequest(http.MethodGet, "/test").Build()
+	// Test JSON response (with Accept header)
+	req := zhtest.NewRequest(http.MethodGet, "/test").WithHeader("Accept", "application/json").Build()
 	w := zhtest.Serve(middleware, req)
 
 	zhtest.AssertWith(t, w).
 		Status(http.StatusServiceUnavailable).
 		IsProblemDetail().
 		ProblemDetailDetail("Service temporarily unavailable")
+
+	// Test plain text response (without Accept header)
+	req = zhtest.NewRequest(http.MethodGet, "/test").Build()
+	w = zhtest.Serve(middleware, req)
+
+	zhtest.AssertWith(t, w).
+		Status(http.StatusServiceUnavailable).
+		Header("Content-Type", "text/plain; charset=utf-8")
+
 	if handler.getCallCount() != 3 {
 		t.Errorf("Expected handler to be called 3 times, got %d", handler.getCallCount())
 	}
@@ -190,13 +200,22 @@ func TestCircuitBreaker_CustomOpenResponse(t *testing.T) {
 		zhtest.Serve(middleware, req)
 	}
 
-	req := zhtest.NewRequest(http.MethodGet, "/test").Build()
+	// Test JSON response
+	req := zhtest.NewRequest(http.MethodGet, "/test").WithHeader("Accept", "application/json").Build()
 	w := zhtest.Serve(middleware, req)
 
 	zhtest.AssertWith(t, w).
 		Status(http.StatusTooManyRequests).
 		IsProblemDetail().
 		ProblemDetailDetail("Circuit breaker active")
+
+	// Test plain text response
+	req = zhtest.NewRequest(http.MethodGet, "/test").Build()
+	w = zhtest.Serve(middleware, req)
+
+	zhtest.AssertWith(t, w).
+		Status(http.StatusTooManyRequests).
+		Header("Content-Type", "text/plain; charset=utf-8")
 }
 
 func TestCircuitBreaker_ZeroConfigValues(t *testing.T) {

--- a/middleware/content_charset.go
+++ b/middleware/content_charset.go
@@ -30,7 +30,7 @@ func ContentCharset(cfg ...config.ContentCharsetConfig) func(http.Handler) http.
 				if len(c.Charsets) > 0 {
 					w.Header().Set("Accept-Post", "application/json; charset="+c.Charsets[0])
 				}
-				_ = detail.Render(w)
+				_ = detail.RenderAuto(w, r)
 				return
 			}
 			next.ServeHTTP(w, r)

--- a/middleware/content_encoding.go
+++ b/middleware/content_encoding.go
@@ -48,7 +48,7 @@ func ContentEncoding(cfg ...config.ContentEncodingConfig) func(http.Handler) htt
 							if len(c.Encodings) > 0 {
 								w.Header().Set("Accept-Encoding", strings.Join(c.Encodings, ", "))
 							}
-							_ = detail.Render(w)
+							_ = detail.RenderAuto(w, r)
 							return
 						}
 					}

--- a/middleware/content_type.go
+++ b/middleware/content_type.go
@@ -45,7 +45,7 @@ func ContentType(cfg ...config.ContentTypeConfig) func(http.Handler) http.Handle
 				if len(c.ContentTypes) > 0 {
 					w.Header().Set("Accept-Post", c.ContentTypes[0])
 				}
-				_ = detail.Render(w)
+				_ = detail.RenderAuto(w, r)
 				return
 			}
 

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -128,7 +128,7 @@ func CORS(cfg ...config.CORSConfig) func(http.Handler) http.Handler {
 				if requestMethod != "" && !allowedMethodMap[strings.ToUpper(requestMethod)] {
 					detail := problem.NewDetail(http.StatusMethodNotAllowed, "Method not allowed")
 					w.Header().Set("Allow", allowedMethodsHeader)
-					_ = detail.Render(w)
+					_ = detail.RenderAuto(w, r)
 					return
 				}
 
@@ -140,7 +140,7 @@ func CORS(cfg ...config.CORSConfig) func(http.Handler) http.Handler {
 						header = strings.ToLower(strings.TrimSpace(header))
 						if !allowedHeaderMap[header] {
 							detail := problem.NewDetail(http.StatusForbidden, "Request header not allowed")
-							_ = detail.Render(w)
+							_ = detail.RenderAuto(w, r)
 							return
 						}
 					}

--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -83,7 +83,26 @@ func TestCORSPreflightRequest(t *testing.T) {
 			zhtest.AssertWith(t, rr).Status(tt.expectCode)
 
 			if tt.checkProblemDetail {
+				// Test JSON response with Accept header
+				req.Header.Set("Accept", "application/json")
+				rr = httptest.NewRecorder()
+				mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})).ServeHTTP(rr, req)
 				zhtest.AssertWith(t, rr).IsProblemDetail()
+
+				// Test plain text response without Accept header
+				req = httptest.NewRequest(http.MethodOptions, "/test", nil)
+				if tt.origin != "" {
+					req.Header.Set("Origin", tt.origin)
+				}
+				if tt.method != "" {
+					req.Header.Set("Access-Control-Request-Method", tt.method)
+				}
+				if tt.headers != "" {
+					req.Header.Set("Access-Control-Request-Headers", tt.headers)
+				}
+				rr = httptest.NewRecorder()
+				mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})).ServeHTTP(rr, req)
+				zhtest.AssertWith(t, rr).Header("Content-Type", "text/plain; charset=utf-8")
 			}
 			if tt.checkAllowHeader {
 				zhtest.AssertWith(t, rr).HeaderExists("Allow")

--- a/middleware/csrf.go
+++ b/middleware/csrf.go
@@ -264,5 +264,5 @@ func setCSRFCookie(w http.ResponseWriter, cfg config.CSRFConfig, token string) {
 // defaultCSRFErrorHandler is the default handler for CSRF validation failures
 func defaultCSRFErrorHandler(w http.ResponseWriter, r *http.Request) {
 	detail := problem.NewDetail(http.StatusForbidden, "CSRF token is missing or invalid")
-	_ = detail.Render(w)
+	_ = detail.RenderAuto(w, r)
 }

--- a/middleware/csrf_test.go
+++ b/middleware/csrf_test.go
@@ -218,9 +218,10 @@ func TestCSRF_InvalidToken(t *testing.T) {
 
 	csrf := CSRF(config.CSRFConfig{HMACKey: testHMACKey})(handler)
 
-	// Make POST request with invalid token
+	// Make POST request with invalid token - test JSON response
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
 	req.Header.Set("X-CSRF-Token", "invalid-token")
+	req.Header.Set("Accept", "application/json")
 	req.AddCookie(&http.Cookie{Name: "csrf_token", Value: "invalid-token"})
 
 	rr := httptest.NewRecorder()
@@ -230,6 +231,18 @@ func TestCSRF_InvalidToken(t *testing.T) {
 		Status(http.StatusForbidden).
 		IsProblemDetail().
 		ProblemDetailTitle("Forbidden")
+
+	// Test plain text response without Accept header
+	req = httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set("X-CSRF-Token", "invalid-token")
+	req.AddCookie(&http.Cookie{Name: "csrf_token", Value: "invalid-token"})
+
+	rr = httptest.NewRecorder()
+	csrf.ServeHTTP(rr, req)
+
+	zhtest.AssertWith(t, rr).
+		Status(http.StatusForbidden).
+		Header("Content-Type", "text/plain; charset=utf-8")
 }
 
 func TestCSRF_MissingToken(t *testing.T) {

--- a/middleware/hmac_auth.go
+++ b/middleware/hmac_auth.go
@@ -665,5 +665,5 @@ func defaultHMACErrorHandler(w http.ResponseWriter, r *http.Request) {
 	detail := problem.NewDetail(hmacErr.Status, hmacErr.Detail)
 	detail.Type = hmacErr.Type
 	detail.Title = hmacErr.Title
-	_ = detail.Render(w)
+	_ = detail.RenderAuto(w, r)
 }

--- a/middleware/host_validation.go
+++ b/middleware/host_validation.go
@@ -64,7 +64,7 @@ func HostValidation(cfg ...config.HostValidationConfig) func(http.Handler) http.
 
 			if r.Host == "" {
 				detail := problem.NewDetail(c.StatusCode, c.Message)
-				_ = detail.Render(w)
+				_ = detail.RenderAuto(w, r)
 				return
 			}
 
@@ -82,14 +82,14 @@ func HostValidation(cfg ...config.HostValidationConfig) func(http.Handler) http.
 				expectedPort := strconv.Itoa(c.Port)
 				if port != expectedPort {
 					detail := problem.NewDetail(c.StatusCode, c.Message)
-					_ = detail.Render(w)
+					_ = detail.RenderAuto(w, r)
 					return
 				}
 			}
 
 			if !isValidHost(hostWithoutPort, allowedHosts, c.AllowSubdomains) {
 				detail := problem.NewDetail(c.StatusCode, c.Message)
-				_ = detail.Render(w)
+				_ = detail.RenderAuto(w, r)
 				return
 			}
 

--- a/middleware/host_validation_test.go
+++ b/middleware/host_validation_test.go
@@ -190,11 +190,17 @@ func TestHostValidation_CustomStatusCodeAndMessage(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	req := zhtest.NewRequest(http.MethodGet, "/test").Build()
+	// Test JSON response
+	req := zhtest.NewRequest(http.MethodGet, "/test").WithHeader("Accept", "application/json").Build()
 	req.Host = "evil.com"
 	w := zhtest.Serve(handler, req)
-
 	zhtest.AssertWith(t, w).Status(http.StatusForbidden).IsProblemDetail().ProblemDetailDetail("Forbidden host")
+
+	// Test plain text response
+	req = zhtest.NewRequest(http.MethodGet, "/test").Build()
+	req.Host = "evil.com"
+	w = zhtest.Serve(handler, req)
+	zhtest.AssertWith(t, w).Status(http.StatusForbidden).Header("Content-Type", "text/plain; charset=utf-8")
 }
 
 func TestHostValidation_DefaultsFallback(t *testing.T) {
@@ -207,12 +213,17 @@ func TestHostValidation_DefaultsFallback(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	req := zhtest.NewRequest(http.MethodGet, "/test").Build()
+	// Test JSON response
+	req := zhtest.NewRequest(http.MethodGet, "/test").WithHeader("Accept", "application/json").Build()
 	req.Host = "evil.com"
 	w := zhtest.Serve(handler, req)
-
-	// Should use default 400 status code
 	zhtest.AssertWith(t, w).Status(http.StatusBadRequest).IsProblemDetail().ProblemDetailDetail("Invalid Host header")
+
+	// Test plain text response
+	req = zhtest.NewRequest(http.MethodGet, "/test").Build()
+	req.Host = "evil.com"
+	w = zhtest.Serve(handler, req)
+	zhtest.AssertWith(t, w).Status(http.StatusBadRequest).Header("Content-Type", "text/plain; charset=utf-8")
 }
 
 func TestHostValidation_StrictPort(t *testing.T) {

--- a/middleware/idempotency.go
+++ b/middleware/idempotency.go
@@ -57,7 +57,7 @@ func Idempotency(cfg ...config.IdempotencyConfig) func(http.Handler) http.Handle
 
 			if c.Required && idempotencyKey == "" {
 				detail := problem.NewDetail(http.StatusBadRequest, "Idempotency-Key header is required")
-				_ = detail.Render(w)
+				_ = detail.RenderAuto(w, r)
 				return
 			}
 
@@ -70,7 +70,7 @@ func Idempotency(cfg ...config.IdempotencyConfig) func(http.Handler) http.Handle
 			if err != nil {
 				log.GetGlobalLogger().Error("Failed to read request body for idempotency", log.E(err))
 				detail := problem.NewDetail(http.StatusInternalServerError, "Failed to read request body")
-				_ = detail.Render(w)
+				_ = detail.RenderAuto(w, r)
 				return
 			}
 			_ = r.Body.Close()
@@ -115,7 +115,7 @@ func Idempotency(cfg ...config.IdempotencyConfig) func(http.Handler) http.Handle
 					case <-time.After(jitteredInterval):
 					case <-r.Context().Done():
 						detail := problem.NewDetail(http.StatusServiceUnavailable, "Request cancelled")
-						_ = detail.Render(w)
+						_ = detail.RenderAuto(w, r)
 						return
 					}
 
@@ -141,7 +141,7 @@ func Idempotency(cfg ...config.IdempotencyConfig) func(http.Handler) http.Handle
 				}
 				// Max retries exhausted, another request is still in-flight
 				detail := problem.NewDetail(http.StatusConflict, "Idempotent request is still being processed")
-				_ = detail.Render(w)
+				_ = detail.RenderAuto(w, r)
 				return
 			}
 

--- a/middleware/idempotency_test.go
+++ b/middleware/idempotency_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -758,6 +759,260 @@ func TestIdempotency_HandlerWritesNothing(t *testing.T) {
 		}
 		if w2.Header().Get("X-Idempotency-Replay") != "true" {
 			t.Error("Expected X-Idempotency-Replay header on replay")
+		}
+	})
+}
+
+// errorStore is a mock store that returns errors for testing error handling
+type errorStore struct {
+	failGet    bool
+	failLock   bool
+	failUnlock bool
+	failSet    bool
+}
+
+func (e *errorStore) Get(ctx context.Context, key string) (config.IdempotencyRecord, bool, error) {
+	if e.failGet {
+		return config.IdempotencyRecord{}, false, errors.New("store get error")
+	}
+	return config.IdempotencyRecord{}, false, nil
+}
+
+func (e *errorStore) Set(ctx context.Context, key string, record config.IdempotencyRecord, ttl time.Duration) error {
+	if e.failSet {
+		return errors.New("store set error")
+	}
+	return nil
+}
+
+func (e *errorStore) Lock(ctx context.Context, key string) (bool, error) {
+	if e.failLock {
+		return false, errors.New("store lock error")
+	}
+	return true, nil
+}
+
+func (e *errorStore) Unlock(ctx context.Context, key string) error {
+	if e.failUnlock {
+		return errors.New("store unlock error")
+	}
+	return nil
+}
+
+func TestIdempotency_StoreErrors(t *testing.T) {
+	t.Run("continues to handler when store Get fails", func(t *testing.T) {
+		callCount := 0
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"123"}`))
+		})
+
+		store := &errorStore{failGet: true}
+		idempotencyMiddleware := Idempotency(config.IdempotencyConfig{
+			TTL:   time.Hour,
+			Store: store,
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/api/payments", bytes.NewReader([]byte(`{"amount":100}`)))
+		req.Header.Set("Idempotency-Key", "key-error")
+		w := httptest.NewRecorder()
+		idempotencyMiddleware(handler).ServeHTTP(w, req)
+
+		// Should fail open and call handler
+		if callCount != 1 {
+			t.Errorf("Expected 1 handler call (fail open), got %d", callCount)
+		}
+		if w.Code != http.StatusCreated {
+			t.Errorf("Expected 201, got %d", w.Code)
+		}
+	})
+
+	t.Run("continues to handler when store Lock fails", func(t *testing.T) {
+		callCount := 0
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"123"}`))
+		})
+
+		store := &errorStore{failLock: true}
+		idempotencyMiddleware := Idempotency(config.IdempotencyConfig{
+			TTL:   time.Hour,
+			Store: store,
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/api/payments", bytes.NewReader([]byte(`{"amount":100}`)))
+		req.Header.Set("Idempotency-Key", "key-lock-error")
+		w := httptest.NewRecorder()
+		idempotencyMiddleware(handler).ServeHTTP(w, req)
+
+		// Should fail open and call handler
+		if callCount != 1 {
+			t.Errorf("Expected 1 handler call (fail open on lock error), got %d", callCount)
+		}
+		if w.Code != http.StatusCreated {
+			t.Errorf("Expected 201, got %d", w.Code)
+		}
+	})
+
+	t.Run("logs error but does not fail when store Unlock fails", func(t *testing.T) {
+		callCount := 0
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"123"}`))
+		})
+
+		store := &errorStore{failUnlock: true}
+		idempotencyMiddleware := Idempotency(config.IdempotencyConfig{
+			TTL:   time.Hour,
+			Store: store,
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/api/payments", bytes.NewReader([]byte(`{"amount":100}`)))
+		req.Header.Set("Idempotency-Key", "key-unlock-error")
+		w := httptest.NewRecorder()
+		idempotencyMiddleware(handler).ServeHTTP(w, req)
+
+		// Should complete successfully even if unlock fails
+		if callCount != 1 {
+			t.Errorf("Expected 1 handler call, got %d", callCount)
+		}
+		if w.Code != http.StatusCreated {
+			t.Errorf("Expected 201, got %d", w.Code)
+		}
+	})
+
+	t.Run("logs error but does not fail when store Set fails", func(t *testing.T) {
+		callCount := 0
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"123"}`))
+		})
+
+		store := &errorStore{failSet: true}
+		idempotencyMiddleware := Idempotency(config.IdempotencyConfig{
+			TTL:   time.Hour,
+			Store: store,
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/api/payments", bytes.NewReader([]byte(`{"amount":100}`)))
+		req.Header.Set("Idempotency-Key", "key-set-error")
+		w := httptest.NewRecorder()
+		idempotencyMiddleware(handler).ServeHTTP(w, req)
+
+		// Should complete successfully even if set fails
+		if callCount != 1 {
+			t.Errorf("Expected 1 handler call, got %d", callCount)
+		}
+		if w.Code != http.StatusCreated {
+			t.Errorf("Expected 201, got %d", w.Code)
+		}
+	})
+}
+
+func TestIdempotency_PanicRecovery(t *testing.T) {
+	t.Run("unlocks store when handler panics", func(t *testing.T) {
+		store := NewIdempotencyMemoryStore(100)
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			panic("handler panic")
+		})
+
+		idempotencyMiddleware := Idempotency(config.IdempotencyConfig{
+			TTL:   time.Hour,
+			Store: store,
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/api/payments", bytes.NewReader([]byte(`{"amount":100}`)))
+		req.Header.Set("Idempotency-Key", "key-panic")
+		w := httptest.NewRecorder()
+
+		// Use defer/recover to catch the panic
+		func() {
+			defer func() {
+				_ = recover() // Expected panic, ignore it
+			}()
+			idempotencyMiddleware(handler).ServeHTTP(w, req)
+		}()
+
+		// Verify lock was released by trying to lock again
+		ctx := context.Background()
+		locked, err := store.Lock(ctx, "key-panic:POST:/api/payments:fef5c3c40c3c0f3887720d0d0bc7e26d61ebd42d82697109469727e790f35837")
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if !locked {
+			t.Error("Lock should succeed after panic recovery (unlock was called)")
+		}
+	})
+}
+
+func TestIdempotency_WriteHeaderHopByHop(t *testing.T) {
+	t.Run("skips hop-by-hop headers in cache", func(t *testing.T) {
+		callCount := 0
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Connection", "keep-alive")
+			w.Header().Set("Keep-Alive", "timeout=5")
+			w.Header().Set("X-Custom", "value")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"123"}`))
+		})
+
+		idempotencyMiddleware := Idempotency(config.IdempotencyConfig{
+			TTL: time.Hour,
+		})
+
+		// First request
+		req1 := httptest.NewRequest(http.MethodPost, "/api/payments", bytes.NewReader([]byte(`{"amount":100}`)))
+		req1.Header.Set("Idempotency-Key", "key-hop")
+		w1 := httptest.NewRecorder()
+		idempotencyMiddleware(handler).ServeHTTP(w1, req1)
+
+		// Second request - replay
+		req2 := httptest.NewRequest(http.MethodPost, "/api/payments", bytes.NewReader([]byte(`{"amount":100}`)))
+		req2.Header.Set("Idempotency-Key", "key-hop")
+		w2 := httptest.NewRecorder()
+		idempotencyMiddleware(handler).ServeHTTP(w2, req2)
+
+		// Hop-by-hop headers should not be replayed
+		if w2.Header().Get("Connection") != "" {
+			t.Error("Connection header should not be replayed (hop-by-hop)")
+		}
+		if w2.Header().Get("Keep-Alive") != "" {
+			t.Error("Keep-Alive header should not be replayed (hop-by-hop)")
+		}
+		// Custom header should be replayed
+		if w2.Header().Get("X-Custom") != "value" {
+			t.Error("X-Custom header should be replayed")
+		}
+	})
+}
+
+func TestIdempotency_WriteHeaderIdempotent(t *testing.T) {
+	t.Run("WriteHeader is idempotent", func(t *testing.T) {
+		callCount := 0
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.WriteHeader(http.StatusCreated)
+			w.WriteHeader(http.StatusOK) // Second call should be ignored
+			_, _ = w.Write([]byte(`{"id":"123"}`))
+		})
+
+		idempotencyMiddleware := Idempotency(config.IdempotencyConfig{
+			TTL: time.Hour,
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/api/payments", bytes.NewReader([]byte(`{"amount":100}`)))
+		req.Header.Set("Idempotency-Key", "key-idempotent")
+		w := httptest.NewRecorder()
+		idempotencyMiddleware(handler).ServeHTTP(w, req)
+
+		if w.Code != http.StatusCreated {
+			t.Errorf("Expected 201 (first WriteHeader), got %d", w.Code)
 		}
 	})
 }

--- a/middleware/idempotency_test.go
+++ b/middleware/idempotency_test.go
@@ -197,7 +197,18 @@ func TestIdempotency_Required(t *testing.T) {
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("Expected 400 when key is required, got %d", w.Code)
 		}
+
+		// Test JSON response
+		req.Header.Set("Accept", "application/json")
+		w = httptest.NewRecorder()
+		idempotencyMiddleware(handler).ServeHTTP(w, req)
 		zhtest.AssertWith(t, w).IsProblemDetail().ProblemDetailDetail("Idempotency-Key header is required")
+
+		// Test plain text response
+		req = httptest.NewRequest(http.MethodPost, "/api/payments", bytes.NewReader([]byte(`{}`)))
+		w = httptest.NewRecorder()
+		idempotencyMiddleware(handler).ServeHTTP(w, req)
+		zhtest.AssertWith(t, w).Header("Content-Type", "text/plain; charset=utf-8")
 	})
 
 	t.Run("allows request when key is provided and required", func(t *testing.T) {
@@ -430,7 +441,23 @@ func TestIdempotency_ConcurrentLock(t *testing.T) {
 		if w2.Code != http.StatusConflict {
 			t.Errorf("Expected 409 Conflict, got %d", w2.Code)
 		}
+
+		// Test JSON response
+		req2.Header.Set("Accept", "application/json")
+		w2 = httptest.NewRecorder()
+		idempotencyMiddleware(handler).ServeHTTP(w2, req2)
 		zhtest.AssertWith(t, w2).IsProblemDetail().ProblemDetailDetail("Idempotent request is still being processed")
+
+		// Test plain text response
+		req2 = httptest.NewRequest(http.MethodPost, "/api/payments", bytes.NewReader([]byte(`{"amount":100}`)))
+		req2.Header.Set("Idempotency-Key", "slow-key")
+		w2 = httptest.NewRecorder()
+		idempotencyMiddleware(handler).ServeHTTP(w2, req2)
+		// Note: This may return 409 (still processing) or 201 (completed) depending on timing
+		// The important thing is that when it returns 409, the content type is plain text
+		if w2.Code == http.StatusConflict {
+			zhtest.AssertWith(t, w2).Header("Content-Type", "text/plain; charset=utf-8")
+		}
 	})
 }
 

--- a/middleware/jwt_auth.go
+++ b/middleware/jwt_auth.go
@@ -414,11 +414,11 @@ func GenerateRefreshToken(r *http.Request, claims config.JWTClaims, cfg config.J
 }
 
 // writeJWTError writes a JWTAuthError response
-func writeJWTError(w http.ResponseWriter, jwtErr *JWTAuthError) {
+func writeJWTError(w http.ResponseWriter, r *http.Request, jwtErr *JWTAuthError) {
 	detail := problem.NewDetail(jwtErr.Status, jwtErr.Detail)
 	detail.Type = jwtErr.Type
 	detail.Title = jwtErr.Title
-	_ = detail.Render(w)
+	_ = detail.RenderAuto(w, r)
 }
 
 // tokenHandlerRequest parses and validates the refresh token from the request body.
@@ -426,12 +426,12 @@ func writeJWTError(w http.ResponseWriter, jwtErr *JWTAuthError) {
 func tokenHandlerRequest(w http.ResponseWriter, r *http.Request, cfg config.JWTAuthConfig) (config.JWTClaims, bool) {
 	if r.Method != http.MethodPost {
 		detail := problem.NewDetail(http.StatusMethodNotAllowed, "Method not allowed")
-		_ = detail.Render(w)
+		_ = detail.RenderAuto(w, r)
 		return nil, false
 	}
 
 	if cfg.TokenStore == nil {
-		writeJWTError(w, errTokenStoreNotConfigured)
+		writeJWTError(w, r, errTokenStoreNotConfigured)
 		return nil, false
 	}
 
@@ -440,7 +440,7 @@ func tokenHandlerRequest(w http.ResponseWriter, r *http.Request, cfg config.JWTA
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJWTError(w, &JWTAuthError{
+		writeJWTError(w, r, &JWTAuthError{
 			Title:  "Invalid Request",
 			Status: http.StatusBadRequest,
 			Detail: "Request body must contain refresh_token",
@@ -449,7 +449,7 @@ func tokenHandlerRequest(w http.ResponseWriter, r *http.Request, cfg config.JWTA
 	}
 
 	if req.RefreshToken == "" {
-		writeJWTError(w, &JWTAuthError{
+		writeJWTError(w, r, &JWTAuthError{
 			Title:  "Missing Refresh Token",
 			Status: http.StatusUnprocessableEntity,
 			Detail: "refresh_token is required",
@@ -459,12 +459,12 @@ func tokenHandlerRequest(w http.ResponseWriter, r *http.Request, cfg config.JWTA
 
 	claims, err := cfg.TokenStore.Validate(r.Context(), req.RefreshToken)
 	if err != nil {
-		writeJWTError(w, errInvalidToken)
+		writeJWTError(w, r, errInvalidToken)
 		return nil, false
 	}
 
 	if tokenType := getStringClaim(claims, config.JWTClaimType); tokenType != config.TokenTypeRefresh {
-		writeJWTError(w, &JWTAuthError{
+		writeJWTError(w, r, &JWTAuthError{
 			Title:  "Invalid Token Type",
 			Status: http.StatusUnprocessableEntity,
 			Detail: "Provided token is not a refresh token",
@@ -474,7 +474,7 @@ func tokenHandlerRequest(w http.ResponseWriter, r *http.Request, cfg config.JWTA
 
 	revoked, err := cfg.TokenStore.IsRevoked(r.Context(), claims)
 	if err != nil {
-		writeJWTError(w, &JWTAuthError{
+		writeJWTError(w, r, &JWTAuthError{
 			Title:  "Token Revocation Check Failed",
 			Status: http.StatusInternalServerError,
 			Detail: err.Error(),
@@ -482,7 +482,7 @@ func tokenHandlerRequest(w http.ResponseWriter, r *http.Request, cfg config.JWTA
 		return nil, false
 	}
 	if revoked {
-		writeJWTError(w, &JWTAuthError{
+		writeJWTError(w, r, &JWTAuthError{
 			Title:  "Token Revoked",
 			Status: http.StatusUnauthorized,
 			Detail: "token has been revoked",
@@ -491,7 +491,7 @@ func tokenHandlerRequest(w http.ResponseWriter, r *http.Request, cfg config.JWTA
 	}
 
 	if err := cfg.TokenStore.Revoke(r.Context(), claims); err != nil {
-		writeJWTError(w, &JWTAuthError{
+		writeJWTError(w, r, &JWTAuthError{
 			Title:  "Token Revocation Failed",
 			Status: http.StatusInternalServerError,
 			Detail: err.Error(),
@@ -515,13 +515,13 @@ func RefreshTokenHandler(cfg config.JWTAuthConfig) http.HandlerFunc {
 
 		accessToken, err := GenerateAccessToken(r, claims, cfg)
 		if err != nil {
-			writeJWTError(w, errTokenGeneratorNotConfigured)
+			writeJWTError(w, r, errTokenGeneratorNotConfigured)
 			return
 		}
 
 		refreshToken, err := GenerateRefreshToken(r, claims, cfg)
 		if err != nil {
-			writeJWTError(w, errTokenGeneratorNotConfigured)
+			writeJWTError(w, r, errTokenGeneratorNotConfigured)
 			return
 		}
 
@@ -599,7 +599,7 @@ func defaultJWTErrorHandler(w http.ResponseWriter, r *http.Request) {
 	detail := problem.NewDetail(jwtErr.Status, jwtErr.Detail)
 	detail.Type = jwtErr.Type
 	detail.Title = jwtErr.Title
-	_ = detail.Render(w)
+	_ = detail.RenderAuto(w, r)
 }
 
 // hasClaim checks if a claim exists in the claims

--- a/middleware/jwt_auth_test.go
+++ b/middleware/jwt_auth_test.go
@@ -76,9 +76,10 @@ func TestJWTAuth_MissingToken(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
+	// Test JSON response
 	req := httptest.NewRequest(http.MethodGet, "/api/protected", nil)
+	req.Header.Set("Accept", "application/json")
 	rr := httptest.NewRecorder()
-
 	handler.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusUnauthorized {
@@ -88,6 +89,14 @@ func TestJWTAuth_MissingToken(t *testing.T) {
 	var errResp JWTAuthError
 	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
 		t.Fatalf("failed to unmarshal error response: %v", err)
+	}
+
+	// Test plain text response
+	req = httptest.NewRequest(http.MethodGet, "/api/protected", nil)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if !strings.Contains(rr.Header().Get("Content-Type"), "text/plain") {
+		t.Errorf("expected text/plain, got %s", rr.Header().Get("Content-Type"))
 	}
 }
 
@@ -106,9 +115,11 @@ func TestJWTAuth_InvalidToken(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
+	// Test JSON response
 	reg := metrics.NewRegistry()
 	req := httptest.NewRequest(http.MethodGet, "/api/protected", nil)
 	req.Header.Set("Authorization", "Bearer invalid-token")
+	req.Header.Set("Accept", "application/json")
 	req = req.WithContext(metrics.WithRegistry(req.Context(), reg))
 	rr := httptest.NewRecorder()
 
@@ -137,6 +148,15 @@ func TestJWTAuth_InvalidToken(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected jwt_auth_requests_total metric with result='invalid' to be 1")
+	}
+
+	// Test plain text response
+	req = httptest.NewRequest(http.MethodGet, "/api/protected", nil)
+	req.Header.Set("Authorization", "Bearer invalid-token")
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if !strings.Contains(rr.Header().Get("Content-Type"), "text/plain") {
+		t.Errorf("expected text/plain, got %s", rr.Header().Get("Content-Type"))
 	}
 }
 
@@ -262,10 +282,11 @@ func TestJWTAuth_RequiredClaims(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
+	// Test JSON response
 	req := httptest.NewRequest(http.MethodGet, "/api/protected", nil)
 	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("Accept", "application/json")
 	rr := httptest.NewRecorder()
-
 	handler.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusForbidden {
@@ -275,6 +296,15 @@ func TestJWTAuth_RequiredClaims(t *testing.T) {
 	var errResp JWTAuthError
 	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
 		t.Fatalf("failed to unmarshal error response: %v", err)
+	}
+
+	// Test plain text response
+	req = httptest.NewRequest(http.MethodGet, "/api/protected", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if !strings.Contains(rr.Header().Get("Content-Type"), "text/plain") {
+		t.Errorf("expected text/plain, got %s", rr.Header().Get("Content-Type"))
 	}
 }
 
@@ -830,7 +860,18 @@ func TestRefreshTokenHandler_InvalidMethod(t *testing.T) {
 	if rr.Code != http.StatusMethodNotAllowed {
 		t.Errorf("expected status %d, got %d", http.StatusMethodNotAllowed, rr.Code)
 	}
+
+	// Test JSON response
+	req.Header.Set("Accept", "application/json")
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
 	zhtest.AssertWith(t, rr).IsProblemDetail().ProblemDetailDetail("Method not allowed")
+
+	// Test plain text response
+	req = httptest.NewRequest(http.MethodGet, "/auth/refresh", nil)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	zhtest.AssertWith(t, rr).Header("Content-Type", "text/plain; charset=utf-8")
 }
 
 func TestRefreshTokenHandler_MissingToken(t *testing.T) {
@@ -939,11 +980,12 @@ func TestRefreshTokenHandler_TokenRevoked(t *testing.T) {
 
 	handler := RefreshTokenHandler(cfg)
 
+	// Test JSON response
 	body := `{"refresh_token":"revoked-refresh-token"}`
 	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
 	rr := httptest.NewRecorder()
-
 	handler.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusUnauthorized {
@@ -953,6 +995,15 @@ func TestRefreshTokenHandler_TokenRevoked(t *testing.T) {
 	var errResp JWTAuthError
 	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
 		t.Fatalf("failed to unmarshal error response: %v", err)
+	}
+
+	// Test plain text response
+	req = httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if !strings.Contains(rr.Header().Get("Content-Type"), "text/plain") {
+		t.Errorf("expected text/plain, got %s", rr.Header().Get("Content-Type"))
 	}
 }
 
@@ -1052,7 +1103,18 @@ func TestLogoutTokenHandler_InvalidMethod(t *testing.T) {
 	if rr.Code != http.StatusMethodNotAllowed {
 		t.Errorf("expected status %d, got %d", http.StatusMethodNotAllowed, rr.Code)
 	}
+
+	// Test JSON response
+	req.Header.Set("Accept", "application/json")
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
 	zhtest.AssertWith(t, rr).IsProblemDetail().ProblemDetailDetail("Method not allowed")
+
+	// Test plain text response
+	req = httptest.NewRequest(http.MethodGet, "/auth/logout", nil)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	zhtest.AssertWith(t, rr).Header("Content-Type", "text/plain; charset=utf-8")
 }
 
 func TestLogoutTokenHandler_NoTokenStore(t *testing.T) {
@@ -1168,11 +1230,12 @@ func TestLogoutTokenHandler_RevokeError(t *testing.T) {
 
 	handler := LogoutTokenHandler(cfg)
 
+	// Test JSON response
 	body := `{"refresh_token":"valid-refresh-token"}`
 	req := httptest.NewRequest(http.MethodPost, "/auth/logout", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
 	rr := httptest.NewRecorder()
-
 	handler.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusInternalServerError {
@@ -1182,6 +1245,15 @@ func TestLogoutTokenHandler_RevokeError(t *testing.T) {
 	var errResp JWTAuthError
 	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
 		t.Fatalf("failed to unmarshal error response: %v", err)
+	}
+
+	// Test plain text response
+	req = httptest.NewRequest(http.MethodPost, "/auth/logout", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if !strings.Contains(rr.Header().Get("Content-Type"), "text/plain") {
+		t.Errorf("expected text/plain, got %s", rr.Header().Get("Content-Type"))
 	}
 }
 
@@ -1912,10 +1984,11 @@ func TestJWTAuth_RevokedToken(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
+	// Test JSON response
 	req := httptest.NewRequest(http.MethodGet, "/api/protected", nil)
 	req.Header.Set("Authorization", "Bearer revoked-token")
+	req.Header.Set("Accept", "application/json")
 	rr := httptest.NewRecorder()
-
 	handler.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusUnauthorized {
@@ -1925,6 +1998,15 @@ func TestJWTAuth_RevokedToken(t *testing.T) {
 	var errResp JWTAuthError
 	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
 		t.Fatalf("failed to unmarshal error response: %v", err)
+	}
+
+	// Test plain text response
+	req = httptest.NewRequest(http.MethodGet, "/api/protected", nil)
+	req.Header.Set("Authorization", "Bearer revoked-token")
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if !strings.Contains(rr.Header().Get("Content-Type"), "text/plain") {
+		t.Errorf("expected text/plain, got %s", rr.Header().Get("Content-Type"))
 	}
 }
 
@@ -1946,10 +2028,11 @@ func TestJWTAuth_RefreshTokenAsAccessToken(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
+	// Test JSON response
 	req := httptest.NewRequest(http.MethodGet, "/api/protected", nil)
 	req.Header.Set("Authorization", "Bearer refresh-token")
+	req.Header.Set("Accept", "application/json")
 	rr := httptest.NewRecorder()
-
 	handler.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusUnauthorized {
@@ -1959,6 +2042,15 @@ func TestJWTAuth_RefreshTokenAsAccessToken(t *testing.T) {
 	var errResp JWTAuthError
 	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
 		t.Fatalf("failed to unmarshal error response: %v", err)
+	}
+
+	// Test plain text response
+	req = httptest.NewRequest(http.MethodGet, "/api/protected", nil)
+	req.Header.Set("Authorization", "Bearer refresh-token")
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if !strings.Contains(rr.Header().Get("Content-Type"), "text/plain") {
+		t.Errorf("expected text/plain, got %s", rr.Header().Get("Content-Type"))
 	}
 }
 

--- a/middleware/jwt_auth_test.go
+++ b/middleware/jwt_auth_test.go
@@ -30,10 +30,11 @@ func slicesEqual(a, b []string) bool {
 
 // mockTokenStore is a test implementation of config.TokenStore
 type mockTokenStore struct {
-	validateFunc func(ctx context.Context, token string) (config.JWTClaims, error)
-	generateFunc func(ctx context.Context, claims config.JWTClaims, tokenType config.TokenType) (string, error)
-	revokeFunc   func(ctx context.Context, claims config.JWTClaims) error
-	isRevoked    bool
+	validateFunc  func(ctx context.Context, token string) (config.JWTClaims, error)
+	generateFunc  func(ctx context.Context, claims config.JWTClaims, tokenType config.TokenType) (string, error)
+	revokeFunc    func(ctx context.Context, claims config.JWTClaims) error
+	isRevoked     bool
+	isRevokedFunc func(ctx context.Context, claims config.JWTClaims) (bool, error)
 }
 
 func (m *mockTokenStore) Validate(ctx context.Context, token string) (config.JWTClaims, error) {
@@ -58,6 +59,9 @@ func (m *mockTokenStore) Revoke(ctx context.Context, claims config.JWTClaims) er
 }
 
 func (m *mockTokenStore) IsRevoked(ctx context.Context, claims config.JWTClaims) (bool, error) {
+	if m.isRevokedFunc != nil {
+		return m.isRevokedFunc(ctx, claims)
+	}
 	return m.isRevoked, nil
 }
 
@@ -2117,5 +2121,239 @@ func TestJWTAuth_Metrics(t *testing.T) {
 	}
 	if results["valid"] != 1 {
 		t.Errorf("expected 1 valid, got %d", results["valid"])
+	}
+}
+
+// Test for IsRevoked error path in JWTAuth middleware
+func TestJWTAuth_IsRevokedCheckError(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
+			return map[string]any{"sub": "user123"}, nil
+		},
+		isRevokedFunc: func(ctx context.Context, claims config.JWTClaims) (bool, error) {
+			return false, errors.New("database connection failed")
+		},
+	}
+
+	middleware := JWTAuth(config.JWTAuthConfig{
+		TokenStore: store,
+	})
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Test JSON response
+	req := httptest.NewRequest(http.MethodGet, "/api/protected", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("Accept", "application/json")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("expected status %d, got %d", http.StatusInternalServerError, rr.Code)
+	}
+
+	var errResp JWTAuthError
+	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("failed to unmarshal error response: %v", err)
+	}
+	if !strings.Contains(errResp.Title, "Token Revocation Check Failed") {
+		t.Errorf("expected 'Token Revocation Check Failed', got %q", errResp.Title)
+	}
+
+	// Test plain text response
+	req = httptest.NewRequest(http.MethodGet, "/api/protected", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if !strings.Contains(rr.Header().Get("Content-Type"), "text/plain") {
+		t.Errorf("expected text/plain, got %s", rr.Header().Get("Content-Type"))
+	}
+}
+
+// Test for IsRevoked error path in RefreshTokenHandler
+func TestRefreshTokenHandler_IsRevokedCheckError(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
+			return map[string]any{
+				"sub":  "user123",
+				"type": config.TokenTypeRefresh,
+			}, nil
+		},
+		isRevokedFunc: func(ctx context.Context, claims config.JWTClaims) (bool, error) {
+			return false, errors.New("database connection failed")
+		},
+	}
+	cfg := config.JWTAuthConfig{
+		TokenStore: store,
+	}
+	handler := RefreshTokenHandler(cfg)
+
+	body := `{"refresh_token":"valid-refresh-token"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("expected status %d, got %d", http.StatusInternalServerError, rr.Code)
+	}
+}
+
+// Test for getStringClaim with []any slice containing non-string elements
+func TestGetStringClaim_AnySliceWithNonString(t *testing.T) {
+	claims := map[string]any{
+		"aud": []any{123, "aud2"}, // First element is not a string
+	}
+
+	result := getStringClaim(claims, "aud")
+	if result != "" {
+		t.Errorf("expected empty string for non-string first element, got %q", result)
+	}
+
+	// Test with empty []any slice
+	claims2 := map[string]any{
+		"aud": []any{},
+	}
+
+	result2 := getStringClaim(claims2, "aud")
+	if result2 != "" {
+		t.Errorf("expected empty string for empty slice, got %q", result2)
+	}
+}
+
+// Test for getStringClaim with reflection path for non-map claims
+func TestGetStringClaim_ReflectionPath(t *testing.T) {
+	// Use a custom map type that requires reflection
+	claims := customMapClaims{
+		"sub": "user123",
+	}
+
+	result := getStringClaim(claims, "sub")
+	if result != "user123" {
+		t.Errorf("expected 'user123', got %q", result)
+	}
+
+	// Test missing key via reflection
+	result2 := getStringClaim(claims, "missing")
+	if result2 != "" {
+		t.Errorf("expected empty string for missing key, got %q", result2)
+	}
+}
+
+// Test for deepCopySlice with nested []any
+func TestDeepCopySlice_NestedSlice(t *testing.T) {
+	original := []any{
+		"simple",
+		[]any{"nested1", "nested2"},
+		map[string]any{"key": "value"},
+	}
+
+	copied := deepCopySlice(original)
+
+	// Modify original
+	original[0] = "modified"
+	original[1].([]any)[0] = "modified-nested"
+	original[2].(map[string]any)["key"] = "modified-value"
+
+	// Check copy wasn't affected
+	if copied[0] != "simple" {
+		t.Error("deep copy failed - simple element was modified")
+	}
+	nested := copied[1].([]any)
+	if nested[0] != "nested1" {
+		t.Error("deep copy failed - nested slice element was modified")
+	}
+	m := copied[2].(map[string]any)
+	if m["key"] != "value" {
+		t.Error("deep copy failed - nested map element was modified")
+	}
+}
+
+// Test for addExpirationToClaims with HS256Claims
+func TestAddExpirationToClaims_HS256Claims(t *testing.T) {
+	ttl := 15 * time.Minute
+	claims := HS256Claims{"sub": "user123"}
+
+	result := addExpirationToClaims(claims, ttl)
+
+	resultMap, ok := result.(HS256Claims)
+	if !ok {
+		t.Fatal("result should be HS256Claims")
+	}
+
+	if resultMap["sub"] != "user123" {
+		t.Errorf("expected sub = 'user123', got %v", resultMap["sub"])
+	}
+
+	if _, exists := resultMap["exp"]; !exists {
+		t.Error("exp claim should be added")
+	}
+
+	// Original should not be modified
+	if _, exists := claims["exp"]; exists {
+		t.Error("original claims should not be modified")
+	}
+}
+
+// Test for addTypeToClaims with HS256Claims
+func TestAddTypeToClaims_HS256Claims(t *testing.T) {
+	claims := HS256Claims{"sub": "user123"}
+
+	result := addTypeToClaims(claims, "refresh")
+
+	resultMap, ok := result.(HS256Claims)
+	if !ok {
+		t.Fatal("result should be HS256Claims")
+	}
+
+	if resultMap["type"] != "refresh" {
+		t.Errorf("expected type = 'refresh', got %v", resultMap["type"])
+	}
+
+	// Original should not be modified
+	if _, exists := claims["type"]; exists {
+		t.Error("original claims should not be modified")
+	}
+}
+
+// Test for RefreshTokenHandler GenerateRefreshToken error
+func TestRefreshTokenHandler_GenerateRefreshTokenError(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
+			return map[string]any{
+				"sub":  "user123",
+				"type": config.TokenTypeRefresh,
+			}, nil
+		},
+		generateFunc: func(ctx context.Context, claims config.JWTClaims, tokenType config.TokenType) (string, error) {
+			if tokenType == config.RefreshToken {
+				return "", errors.New("refresh token generation failed")
+			}
+			return "access-token", nil
+		},
+		isRevokedFunc: func(ctx context.Context, claims config.JWTClaims) (bool, error) {
+			return false, nil
+		},
+		revokeFunc: func(ctx context.Context, claims config.JWTClaims) error {
+			return nil
+		},
+	}
+	cfg := config.JWTAuthConfig{
+		TokenStore: store,
+	}
+	handler := RefreshTokenHandler(cfg)
+
+	body := `{"refresh_token":"valid-refresh-token"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("expected status %d, got %d", http.StatusInternalServerError, rr.Code)
 	}
 }

--- a/middleware/rate_limit.go
+++ b/middleware/rate_limit.go
@@ -66,7 +66,7 @@ func RateLimit(cfg ...config.RateLimitConfig) func(http.Handler) http.Handler {
 				reg.Counter("ratelimit_rejected_total", "key").WithLabelValues(key).Inc()
 				w.Header().Set("Retry-After", strconv.Itoa(int(time.Until(resetTime).Seconds())))
 				detail := problem.NewDetail(c.StatusCode, c.Message)
-				_ = detail.Render(w)
+				_ = detail.RenderAuto(w, r)
 				return
 			}
 

--- a/middleware/rate_limit_test.go
+++ b/middleware/rate_limit_test.go
@@ -38,10 +38,15 @@ func TestRateLimitStatusCodeAndMessageDefaults(t *testing.T) {
 	handler := m(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }))
 	req := zhtest.NewRequest(http.MethodGet, "/test").Build()
 	zhtest.Serve(handler, req)
-	req = zhtest.NewRequest(http.MethodGet, "/test").Build()
+	// Test JSON response
+	req = zhtest.NewRequest(http.MethodGet, "/test").WithHeader("Accept", "application/json").Build()
 	w := zhtest.Serve(handler, req)
-
 	zhtest.AssertWith(t, w).Status(http.StatusTooManyRequests).IsProblemDetail().ProblemDetailDetail("Rate limit exceeded")
+
+	// Test plain text response
+	req = zhtest.NewRequest(http.MethodGet, "/test").Build()
+	w = zhtest.Serve(handler, req)
+	zhtest.AssertWith(t, w).Status(http.StatusTooManyRequests).Header("Content-Type", "text/plain; charset=utf-8")
 }
 
 func TestRateLimitMessageDefaults(t *testing.T) {
@@ -50,10 +55,16 @@ func TestRateLimitMessageDefaults(t *testing.T) {
 	handler := m(next)
 	req := zhtest.NewRequest(http.MethodGet, "/test").Build()
 	zhtest.Serve(handler, req) // 1st OK
-	req = zhtest.NewRequest(http.MethodGet, "/test").Build()
-	w := zhtest.Serve(handler, req) // 2nd rate limited
 
+	// Test JSON response
+	req = zhtest.NewRequest(http.MethodGet, "/test").WithHeader("Accept", "application/json").Build()
+	w := zhtest.Serve(handler, req)
 	zhtest.AssertWith(t, w).IsProblemDetail().ProblemDetailDetail("Rate limit exceeded")
+
+	// Test plain text response
+	req = zhtest.NewRequest(http.MethodGet, "/test").Build()
+	w = zhtest.Serve(handler, req)
+	zhtest.AssertWith(t, w).Header("Content-Type", "text/plain; charset=utf-8")
 }
 
 func TestRateLimitTokenBucket(t *testing.T) {
@@ -76,11 +87,18 @@ func TestRateLimitTokenBucket(t *testing.T) {
 			t.Errorf("request %d: expected status 200, got %d", i+1, w.Code)
 		}
 	}
-	req := zhtest.NewRequest(http.MethodGet, "/test").Build()
+	// Test JSON response
+	req := zhtest.NewRequest(http.MethodGet, "/test").WithHeader("Accept", "application/json").Build()
 	req.RemoteAddr = "127.0.0.1:12345"
 	w := zhtest.Serve(handler, req)
-
 	zhtest.AssertWith(t, w).Status(http.StatusTooManyRequests).IsProblemDetail().ProblemDetailDetail("Rate limit exceeded")
+
+	// Test plain text response
+	req = zhtest.NewRequest(http.MethodGet, "/test").Build()
+	req.RemoteAddr = "127.0.0.1:12345"
+	w = zhtest.Serve(handler, req)
+	zhtest.AssertWith(t, w).Status(http.StatusTooManyRequests).Header("Content-Type", "text/plain; charset=utf-8")
+
 	if count != 2 {
 		t.Errorf("expected 2 successful requests, got %d", count)
 	}
@@ -263,15 +281,23 @@ func TestRateLimitCustomMessage(t *testing.T) {
 	req.RemoteAddr = "127.0.0.1:12345"
 	zhtest.Serve(handler, req)
 
-	req = zhtest.NewRequest(http.MethodGet, "/test").Build()
+	// Test JSON response
+	req = zhtest.NewRequest(http.MethodGet, "/test").WithHeader("Accept", "application/json").Build()
 	req.RemoteAddr = "127.0.0.1:12345"
 	w := zhtest.Serve(handler, req)
-
 	zhtest.AssertWith(t, w).
 		Status(http.StatusServiceUnavailable).
 		IsProblemDetail().
 		ProblemDetailDetail("Too many requests, please slow down").
 		HeaderExists("Retry-After")
+
+	// Test plain text response
+	req = zhtest.NewRequest(http.MethodGet, "/test").Build()
+	req.RemoteAddr = "127.0.0.1:12345"
+	w = zhtest.Serve(handler, req)
+	zhtest.AssertWith(t, w).
+		Status(http.StatusServiceUnavailable).
+		Header("Content-Type", "text/plain; charset=utf-8")
 }
 
 func TestIPKeyExtractor(t *testing.T) {

--- a/middleware/recover.go
+++ b/middleware/recover.go
@@ -55,7 +55,7 @@ func Recover(logger log.Logger, cfg ...config.RecoverConfig) func(http.Handler) 
 
 					if r.Header.Get("Connection") != "Upgrade" {
 						detail := problem.NewDetail(http.StatusInternalServerError, "Internal server error")
-						_ = detail.Render(w)
+						_ = detail.RenderAuto(w, r)
 					}
 				}
 			}()

--- a/middleware/recover_test.go
+++ b/middleware/recover_test.go
@@ -306,7 +306,9 @@ func TestRecover_NonHandlerError(t *testing.T) {
 	logger := &mockLogger{}
 	// Regular panic (not a handler error wrapper)
 	handler := Recover(logger)(panicHandler("random panic"))
-	req := zhtest.NewRequest(http.MethodGet, "/").Build()
+
+	// Test JSON response with Accept header
+	req := zhtest.NewRequest(http.MethodGet, "/").WithHeader("Accept", "application/json").Build()
 	w := zhtest.Serve(handler, req)
 
 	// Should return 500
@@ -330,6 +332,17 @@ func TestRecover_NonHandlerError(t *testing.T) {
 	}
 	if !strings.Contains(body, `"title":"Internal Server Error"`) {
 		t.Errorf("Expected body to contain title 'Internal Server Error', got %s", body)
+	}
+
+	// Test plain text response without Accept header
+	logger = &mockLogger{} // Reset logger
+	handler = Recover(logger)(panicHandler("random panic"))
+	req = zhtest.NewRequest(http.MethodGet, "/").Build()
+	w = zhtest.Serve(handler, req)
+
+	contentType = w.Header().Get("Content-Type")
+	if !strings.Contains(contentType, "text/plain") {
+		t.Errorf("Expected Content-Type to contain text/plain, got %s", contentType)
 	}
 }
 

--- a/middleware/timeout.go
+++ b/middleware/timeout.go
@@ -86,7 +86,7 @@ func Timeout(cfg ...config.TimeoutConfig) func(http.Handler) http.Handler {
 					metrics.SafeRegistry(metrics.GetRegistry(r.Context())).Counter("timeout_requests_total").Inc()
 
 					detail := problem.NewDetail(c.StatusCode, c.Message)
-					_ = detail.Render(w) // Best effort - client may have disconnected
+					_ = detail.RenderAuto(w, r) // Best effort - client may have disconnected
 					tw.err = ErrTimeoutWrite
 				}
 			}

--- a/middleware/timeout_test.go
+++ b/middleware/timeout_test.go
@@ -55,7 +55,15 @@ func TestTimeout_Scenarios(t *testing.T) {
 				zhtest.AssertWith(t, w).Status(tt.wantStatus).Body(tt.wantBody)
 			} else {
 				// Timeout cases return ProblemDetail
+				// Test JSON response
+				req = zhtest.NewRequest(http.MethodGet, "/").WithHeader("Accept", "application/json").Build()
+				w = zhtest.Serve(middleware, req)
 				zhtest.AssertWith(t, w).Status(tt.wantStatus).IsProblemDetail()
+
+				// Test plain text response
+				req = zhtest.NewRequest(http.MethodGet, "/").Build()
+				w = zhtest.Serve(middleware, req)
+				zhtest.AssertWith(t, w).Status(tt.wantStatus).Header("Content-Type", "text/plain; charset=utf-8")
 			}
 		})
 	}

--- a/render.go
+++ b/render.go
@@ -181,7 +181,7 @@ func (r *defaultRenderer) Redirect(w http.ResponseWriter, req *http.Request, url
 
 // ProblemDetail writes an RFC 9457 Problem Details response
 func (r *defaultRenderer) ProblemDetail(w http.ResponseWriter, problem *ProblemDetail) error {
-	w.Header().Set(HeaderContentType, MIMEApplicationProblem)
+	w.Header().Set(HeaderContentType, MIMEApplicationProblemJSON)
 	w.WriteHeader(problem.Status)
 	return json.NewEncoder(w).Encode(problem)
 }

--- a/render_test.go
+++ b/render_test.go
@@ -351,7 +351,7 @@ func TestRenderer_ProblemDetail(t *testing.T) {
 
 		zhtest.AssertWith(t, w).
 			Status(http.StatusNotFound).
-			Header(HeaderContentType, MIMEApplicationProblem).
+			Header(HeaderContentType, MIMEApplicationProblemJSON).
 			IsProblemDetail().
 			ProblemDetailTitle("Not Found").
 			ProblemDetailDetail("Resource not found")

--- a/router.go
+++ b/router.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/internal/problem"
 	"github.com/alexferl/zerohttp/log"
 	"github.com/alexferl/zerohttp/middleware"
 )
@@ -69,7 +70,7 @@ func handleHandlerError(w http.ResponseWriter, err error) {
 	// Check for validation errors (422)
 	var verr ValidationErrorer
 	if errors.As(err, &verr) {
-		w.Header().Set(HeaderContentType, MIMEApplicationProblem)
+		w.Header().Set(HeaderContentType, MIMEApplicationProblemJSON)
 		w.WriteHeader(http.StatusUnprocessableEntity)
 		response := map[string]any{
 			"title":  "Unprocessable Entity",
@@ -85,7 +86,7 @@ func handleHandlerError(w http.ResponseWriter, err error) {
 
 	// Check for binding errors (400)
 	if IsBindError(err) {
-		w.Header().Set(HeaderContentType, MIMEApplicationProblem)
+		w.Header().Set(HeaderContentType, MIMEApplicationProblemJSON)
 		w.WriteHeader(http.StatusBadRequest)
 		response := map[string]any{
 			"title":  "Bad Request",
@@ -99,7 +100,7 @@ func handleHandlerError(w http.ResponseWriter, err error) {
 	}
 
 	// For all other errors, return 500 Internal Server Error
-	w.Header().Set(HeaderContentType, MIMEApplicationProblem)
+	w.Header().Set(HeaderContentType, MIMEApplicationProblemJSON)
 	w.WriteHeader(http.StatusInternalServerError)
 	response := map[string]any{
 		"title":  "Internal Server Error",
@@ -691,7 +692,6 @@ func (r *defaultRouter) shouldLogRequest() bool {
 func (r *defaultRouter) catchAllHandler() http.HandlerFunc {
 	// Capture config values at handler creation time to avoid data races.
 	// Handler fields are protected by handlerMu and accessed with locking.
-	useJSON := r.config.ErrorResponseType == config.ErrorResponseJSON
 	shouldLog := r.shouldLogRequest()
 	requestIDHeader := r.config.RequestID.Header
 	requestIDGenerator := r.config.RequestID.Generator
@@ -740,7 +740,7 @@ func (r *defaultRouter) catchAllHandler() http.HandlerFunc {
 			if !methodAllowed {
 				w.Header().Set(HeaderAllow, allowHeader)
 
-				if useJSON {
+				if problem.AcceptsJSON(req) {
 					jsonMethodNotAllowedHandler(w, req)
 				} else {
 					r.handlerMu.RLock()
@@ -765,7 +765,7 @@ func (r *defaultRouter) catchAllHandler() http.HandlerFunc {
 			r.routesMu.RUnlock()
 		}
 
-		if useJSON {
+		if problem.AcceptsJSON(req) {
 			jsonNotFoundHandler(w, req)
 		} else {
 			r.handlerMu.RLock()
@@ -799,7 +799,7 @@ var defaultMethodNotAllowedHandler http.Handler = http.HandlerFunc(func(w http.R
 
 // jsonNotFoundHandler returns a JSON problem detail 404 response.
 func jsonNotFoundHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set(HeaderContentType, MIMEApplicationProblem)
+	w.Header().Set(HeaderContentType, MIMEApplicationProblemJSON)
 	w.WriteHeader(http.StatusNotFound)
 	_, _ = w.Write(preEncodedNotFoundJSON)
 }
@@ -807,7 +807,7 @@ func jsonNotFoundHandler(w http.ResponseWriter, _ *http.Request) {
 // jsonMethodNotAllowedHandler returns a JSON problem detail 405 response.
 // The "Allow" header should be set by the caller to indicate which methods are allowed.
 func jsonMethodNotAllowedHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set(HeaderContentType, MIMEApplicationProblem)
+	w.Header().Set(HeaderContentType, MIMEApplicationProblemJSON)
 	w.WriteHeader(http.StatusMethodNotAllowed)
 	_, _ = w.Write(preEncodedMethodNotAllowedJSON)
 }

--- a/router_test.go
+++ b/router_test.go
@@ -1353,7 +1353,7 @@ func TestJSONNotFoundHandler(t *testing.T) {
 
 	zhtest.AssertWith(t, w).
 		Status(http.StatusNotFound).
-		Header(HeaderContentType, MIMEApplicationProblem).
+		Header(HeaderContentType, MIMEApplicationProblemJSON).
 		BodyContains(`"title":"Not Found"`).
 		BodyContains(`"status":404`)
 }
@@ -1369,7 +1369,7 @@ func TestJSONMethodNotAllowedHandler(t *testing.T) {
 
 	zhtest.AssertWith(t, w).
 		Status(http.StatusMethodNotAllowed).
-		Header(HeaderContentType, MIMEApplicationProblem).
+		Header(HeaderContentType, MIMEApplicationProblemJSON).
 		Header(HeaderAllow, "GET, HEAD").
 		BodyContains(`"title":"Method Not Allowed"`).
 		BodyContains(`"status":405`)


### PR DESCRIPTION
- Add AcceptsJSON function to detect JSON-capable clients
- Add RenderAuto method that returns JSON or plain text based on Accept header
- Add tests for both AcceptsJSON and RenderAuto
- Update middleware to use RenderAuto instead of Render