### PR TITLE
refactor: use struct-based context keys to prevent collisions

### DIFF
--- a/config/request_id.go
+++ b/config/request_id.go
@@ -5,8 +5,11 @@ import (
 	"encoding/hex"
 )
 
-// RequestIDContextKey is a custom type for context keys to avoid collisions.
-type RequestIDContextKey string
+// requestIDContextKey is the context key type for request ID.
+type requestIDContextKey struct{}
+
+// RequestIDContextKey is the context key for request ID.
+var RequestIDContextKey = requestIDContextKey{}
 
 // RequestIDConfig allows customization of request ID generation.
 type RequestIDConfig struct {
@@ -17,15 +20,16 @@ type RequestIDConfig struct {
 	// The default generator uses crypto/rand (CSPRNG) for 128 bits of entropy.
 	Generator func() string
 
-	// ContextKey is the key to store the request ID in context (defaults to "request_id").
-	ContextKey RequestIDContextKey
+	// ContextKey is the key to store the request ID in context.
+	// Defaults to the package-provided RequestIDContextKey.
+	ContextKey any
 }
 
 // DefaultRequestIDConfig contains the default configuration for request ID generation.
 var DefaultRequestIDConfig = RequestIDConfig{
 	Header:     "X-Request-Id",
 	Generator:  GenerateRequestID,
-	ContextKey: RequestIDContextKey("request_id"),
+	ContextKey: RequestIDContextKey,
 }
 
 // GenerateRequestID creates a unique request ID using crypto/rand.

--- a/config/request_id_test.go
+++ b/config/request_id_test.go
@@ -14,15 +14,13 @@ func TestRequestIDConfig_DefaultValues(t *testing.T) {
 	if cfg.Generator == nil {
 		t.Error("expected default generator to be set")
 	}
-	if cfg.ContextKey != "request_id" {
-		t.Errorf("expected default context key = 'request_id', got %s", string(cfg.ContextKey))
+	if cfg.ContextKey != RequestIDContextKey {
+		t.Errorf("expected default context key = RequestIDContextKey, got %v", cfg.ContextKey)
 	}
 
 	// Test context key type
-	if key, ok := any(cfg.ContextKey).(RequestIDContextKey); !ok {
-		t.Error("expected ContextKey to be of type RequestIDContextKey")
-	} else if string(key) != "request_id" {
-		t.Errorf("expected context key string value = 'request_id', got %s", string(key))
+	if _, ok := cfg.ContextKey.(requestIDContextKey); !ok {
+		t.Error("expected ContextKey to be of type requestIDContextKey")
 	}
 }
 
@@ -105,7 +103,7 @@ func TestRequestIDConfig_StructAssignment(t *testing.T) {
 		cfg := RequestIDConfig{
 			Header:     "X-Trace-Id",
 			Generator:  GenerateRequestID,
-			ContextKey: RequestIDContextKey("request_id"),
+			ContextKey: RequestIDContextKey,
 		}
 		if cfg.Header != "X-Trace-Id" {
 			t.Errorf("expected header = 'X-Trace-Id', got %s", cfg.Header)
@@ -117,7 +115,7 @@ func TestRequestIDConfig_StructAssignment(t *testing.T) {
 		cfg := RequestIDConfig{
 			Header:     "X-Request-Id",
 			Generator:  customGenerator,
-			ContextKey: RequestIDContextKey("request_id"),
+			ContextKey: RequestIDContextKey,
 		}
 		if cfg.Generator == nil {
 			t.Error("expected generator to be set")
@@ -129,27 +127,25 @@ func TestRequestIDConfig_StructAssignment(t *testing.T) {
 	})
 
 	t.Run("context key assignment", func(t *testing.T) {
-		customKey := RequestIDContextKey("trace_id")
+		// Custom context key using a different struct type
+		type customKey struct{}
+		customKeyInstance := customKey{}
 		cfg := RequestIDConfig{
 			Header:     "X-Request-Id",
 			Generator:  GenerateRequestID,
-			ContextKey: customKey,
+			ContextKey: customKeyInstance,
 		}
-		if cfg.ContextKey != customKey {
-			t.Errorf("expected context key = 'trace_id', got %s", string(cfg.ContextKey))
-		}
-		if string(cfg.ContextKey) != "trace_id" {
-			t.Errorf("expected context key string = 'trace_id', got %s", string(cfg.ContextKey))
+		if cfg.ContextKey != customKeyInstance {
+			t.Errorf("expected context key to be customKeyInstance, got %v", cfg.ContextKey)
 		}
 	})
 
 	t.Run("multiple fields assignment", func(t *testing.T) {
 		customGenerator := func() string { return "multi-option-id" }
-		customKey := RequestIDContextKey("custom_request_id")
 		cfg := RequestIDConfig{
 			Header:     "X-Custom-Request-Id",
 			Generator:  customGenerator,
-			ContextKey: customKey,
+			ContextKey: RequestIDContextKey,
 		}
 
 		if cfg.Header != "X-Custom-Request-Id" {
@@ -161,8 +157,8 @@ func TestRequestIDConfig_StructAssignment(t *testing.T) {
 		if cfg.Generator() != "multi-option-id" {
 			t.Error("expected custom generator to work")
 		}
-		if cfg.ContextKey != customKey {
-			t.Errorf("expected context key = 'custom_request_id', got %s", string(cfg.ContextKey))
+		if cfg.ContextKey != RequestIDContextKey {
+			t.Errorf("expected context key = RequestIDContextKey, got %v", cfg.ContextKey)
 		}
 	})
 }
@@ -175,7 +171,7 @@ func TestRequestIDConfig_CommonScenarios(t *testing.T) {
 				cfg := RequestIDConfig{
 					Header:     header,
 					Generator:  GenerateRequestID,
-					ContextKey: RequestIDContextKey("request_id"),
+					ContextKey: RequestIDContextKey,
 				}
 				if cfg.Header != header {
 					t.Errorf("expected header = %s, got %s", header, cfg.Header)
@@ -201,7 +197,7 @@ func TestRequestIDConfig_CommonScenarios(t *testing.T) {
 				cfg := RequestIDConfig{
 					Header:     "X-Request-Id",
 					Generator:  tt.generator,
-					ContextKey: RequestIDContextKey("request_id"),
+					ContextKey: RequestIDContextKey,
 				}
 				result := cfg.Generator()
 				if result != tt.expected {
@@ -211,29 +207,25 @@ func TestRequestIDConfig_CommonScenarios(t *testing.T) {
 		}
 	})
 
-	t.Run("context keys", func(t *testing.T) {
+	t.Run("custom context keys", func(t *testing.T) {
 		tests := []struct {
-			key      RequestIDContextKey
-			expected string
+			name string
+			key  any
 		}{
-			{RequestIDContextKey("request_id"), "request_id"},
-			{RequestIDContextKey("trace_id"), "trace_id"},
-			{RequestIDContextKey("correlation_id"), "correlation_id"},
-			{RequestIDContextKey("session_id"), "session_id"},
-			{RequestIDContextKey("req-id"), "req-id"},
-			{RequestIDContextKey("x-request-id"), "x-request-id"},
-			{RequestIDContextKey(""), ""},
+			{"default struct key", RequestIDContextKey},
+			{"custom string key", "my_request_id"},
+			{"custom int key", 42},
 		}
 
 		for _, tt := range tests {
-			t.Run(string(tt.key), func(t *testing.T) {
+			t.Run(tt.name, func(t *testing.T) {
 				cfg := RequestIDConfig{
 					Header:     "X-Request-Id",
 					Generator:  GenerateRequestID,
 					ContextKey: tt.key,
 				}
-				if string(cfg.ContextKey) != tt.expected {
-					t.Errorf("expected context key = %s, got %s", tt.expected, string(cfg.ContextKey))
+				if cfg.ContextKey != tt.key {
+					t.Errorf("expected context key = %v, got %v", tt.key, cfg.ContextKey)
 				}
 			})
 		}
@@ -251,7 +243,7 @@ func TestRequestIDConfig_CommonScenarios(t *testing.T) {
 				cfg := RequestIDConfig{
 					Header:     header,
 					Generator:  GenerateRequestID,
-					ContextKey: RequestIDContextKey("request_id"),
+					ContextKey: RequestIDContextKey,
 				}
 				if cfg.Header != header {
 					t.Errorf("expected header = %s, got %s", header, cfg.Header)
@@ -266,24 +258,24 @@ func TestRequestIDConfig_EdgeCases(t *testing.T) {
 		cfg := RequestIDConfig{
 			Header:     "X-Request-Id",
 			Generator:  nil,
-			ContextKey: RequestIDContextKey("request_id"),
+			ContextKey: RequestIDContextKey,
 		}
 		if cfg.Generator != nil {
 			t.Error("expected generator to be nil")
 		}
 	})
 
-	t.Run("empty string values", func(t *testing.T) {
+	t.Run("empty string context key", func(t *testing.T) {
 		cfg := RequestIDConfig{
 			Header:     "",
 			Generator:  GenerateRequestID,
-			ContextKey: RequestIDContextKey(""),
+			ContextKey: "",
 		}
 		if cfg.Header != "" {
 			t.Errorf("expected empty header, got %s", cfg.Header)
 		}
-		if string(cfg.ContextKey) != "" {
-			t.Errorf("expected empty context key, got %s", string(cfg.ContextKey))
+		if cfg.ContextKey != "" {
+			t.Errorf("expected empty context key, got %v", cfg.ContextKey)
 		}
 	})
 
@@ -295,8 +287,8 @@ func TestRequestIDConfig_EdgeCases(t *testing.T) {
 		if cfg.Generator != nil {
 			t.Error("expected zero generator = nil, got non-nil function")
 		}
-		if string(cfg.ContextKey) != "" {
-			t.Errorf("expected zero context key = '', got %s", string(cfg.ContextKey))
+		if cfg.ContextKey != nil {
+			t.Errorf("expected zero context key = nil, got %v", cfg.ContextKey)
 		}
 	})
 }

--- a/config/security_headers.go
+++ b/config/security_headers.go
@@ -47,12 +47,13 @@ var DefaultStrictTransportSecurity = StrictTransportSecurity{
 	PreloadEnabled:    false,
 }
 
-// CSPNonceContextKey is the context key for CSP nonce values
-type CSPNonceContextKey string
+// cspNonceContextKey is the context key type for CSP nonce values.
+type cspNonceContextKey struct{}
+
+// CSPNonceContextKey is the context key for CSP nonces.
+var CSPNonceContextKey = cspNonceContextKey{}
 
 const (
-	// DefaultCSPNonceContextKey is the default context key for CSP nonces
-	DefaultCSPNonceContextKey CSPNonceContextKey = "csp_nonce"
 	// CSPNoncePlaceholder is the placeholder string replaced with the actual nonce
 	CSPNoncePlaceholder = "{{nonce}}"
 )
@@ -71,7 +72,7 @@ type SecurityHeadersConfig struct {
 	ContentSecurityPolicyNonceEnabled bool
 
 	// ContentSecurityPolicyNonceContextKey overrides the default context key for storing the nonce
-	ContentSecurityPolicyNonceContextKey CSPNonceContextKey
+	ContentSecurityPolicyNonceContextKey any
 
 	// CrossOriginEmbedderPolicy sets the `Cross-Origin-Embedder-Policy` header
 	CrossOriginEmbedderPolicy string

--- a/middleware/csrf.go
+++ b/middleware/csrf.go
@@ -18,12 +18,13 @@ import (
 	"github.com/alexferl/zerohttp/metrics"
 )
 
-// CSRFContextKey is the key type for CSRF token in context
-type CSRFContextKey string
+// csrfContextKey is the key type for CSRF token in context.
+type csrfContextKey struct{}
+
+// CSRFTokenContextKey is the context key for the CSRF token.
+var CSRFTokenContextKey = csrfContextKey{}
 
 const (
-	// csrfTokenContextKey is the context key for the CSRF token
-	csrfTokenContextKey CSRFContextKey = "csrf_token"
 	// defaultTokenLength is the length of the random token in bytes
 	defaultTokenLength = 32
 	// defaultMaxMultipartMemory is the maximum memory allocated for parsing multipart forms (32 MB)
@@ -91,7 +92,7 @@ func CSRF(cfg ...config.CSRFConfig) func(http.Handler) http.Handler {
 				}
 
 				ctx := r.Context()
-				ctx = context.WithValue(ctx, csrfTokenContextKey, token)
+				ctx = context.WithValue(ctx, CSRFTokenContextKey, token)
 				next.ServeHTTP(w, r.WithContext(ctx))
 				return
 			}
@@ -128,7 +129,7 @@ func CSRF(cfg ...config.CSRFConfig) func(http.Handler) http.Handler {
 			setCSRFCookie(w, c, newToken)
 
 			ctx := r.Context()
-			ctx = context.WithValue(ctx, csrfTokenContextKey, newToken)
+			ctx = context.WithValue(ctx, CSRFTokenContextKey, newToken)
 
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
@@ -138,7 +139,7 @@ func CSRF(cfg ...config.CSRFConfig) func(http.Handler) http.Handler {
 // GetCSRFToken retrieves the CSRF token from the request context
 // Returns empty string if no token is present
 func GetCSRFToken(r *http.Request) string {
-	token, ok := r.Context().Value(csrfTokenContextKey).(string)
+	token, ok := r.Context().Value(CSRFTokenContextKey).(string)
 	if !ok {
 		return ""
 	}

--- a/middleware/hmac_auth.go
+++ b/middleware/hmac_auth.go
@@ -65,14 +65,18 @@ var (
 	}
 )
 
-// HMACAuthContextKey is the context key type for HMAC auth info
-type HMACAuthContextKey string
+type (
+	// hmacAuthContextKey is the context key type for HMAC access key ID.
+	hmacAuthContextKey struct{}
+	// hmacErrorContextKey is the context key type for HMAC auth errors.
+	hmacErrorContextKey struct{}
+)
 
-const (
+var (
 	// HMACAccessKeyIDContextKey holds the verified access key ID in the request context
-	HMACAccessKeyIDContextKey HMACAuthContextKey = "hmac_access_key_id"
+	HMACAccessKeyIDContextKey = hmacAuthContextKey{}
 	// HMACErrorContextKey holds the HMACAuthError in the request context (only set on auth failures)
-	HMACErrorContextKey HMACAuthContextKey = "hmac_error"
+	HMACErrorContextKey = hmacErrorContextKey{}
 )
 
 // GetHMACAccessKeyID retrieves the verified access key ID from the request context.

--- a/middleware/jwt_auth.go
+++ b/middleware/jwt_auth.go
@@ -46,16 +46,19 @@ import (
 	"github.com/alexferl/zerohttp/metrics"
 )
 
-// JWTAuthContextKey is the context key type for JWT auth
-type JWTAuthContextKey string
+type (
+	jwtClaimsContextKey struct{}
+	jwtErrorContextKey  struct{}
+	jwtTokenContextKey  struct{}
+)
 
-const (
+var (
 	// JWTClaimsContextKey holds the validated JWT claims
-	JWTClaimsContextKey JWTAuthContextKey = "jwt_claims"
+	JWTClaimsContextKey = jwtClaimsContextKey{}
 	// JWTErrorContextKey holds the JWT validation error
-	JWTErrorContextKey JWTAuthContextKey = "jwt_error"
+	JWTErrorContextKey = jwtErrorContextKey{}
 	// JWTTokenContextKey holds the raw token string
-	JWTTokenContextKey JWTAuthContextKey = "jwt_token"
+	JWTTokenContextKey = jwtTokenContextKey{}
 )
 
 // JWTAuthError represents a JWT authentication error with RFC 9457 Problem Details

--- a/middleware/request_id.go
+++ b/middleware/request_id.go
@@ -36,8 +36,8 @@ func RequestID(cfg ...config.RequestIDConfig) func(http.Handler) http.Handler {
 
 // GetRequestID retrieves the request ID from context using the specified key
 // If no key is provided, uses the default key
-func GetRequestID(ctx context.Context, key ...config.RequestIDContextKey) string {
-	var contextKey config.RequestIDContextKey
+func GetRequestID(ctx context.Context, key ...any) string {
+	var contextKey any
 	if len(key) > 0 {
 		contextKey = key[0]
 	} else {

--- a/middleware/request_id_test.go
+++ b/middleware/request_id_test.go
@@ -83,7 +83,9 @@ func TestRequestID_CustomGenerator(t *testing.T) {
 
 func TestRequestID_CustomContextKey(t *testing.T) {
 	handler := &testHandler{}
-	customKey := config.RequestIDContextKey("trace_id")
+	// Custom context key using a struct type
+	type traceKey struct{}
+	customKey := traceKey{}
 	req := zhtest.NewRequest(http.MethodGet, "/").Build()
 	w := zhtest.TestMiddlewareWithHandler(RequestID(config.RequestIDConfig{
 		ContextKey: customKey,
@@ -129,7 +131,9 @@ func TestRequestID_MultipleOptions(t *testing.T) {
 }
 
 func TestGetRequestID_WithCustomKey(t *testing.T) {
-	customKey := config.RequestIDContextKey("my_request_id")
+	// Custom context key using a struct type
+	type myRequestKey struct{}
+	customKey := myRequestKey{}
 	testRequestID := "test-123"
 	ctx := context.WithValue(context.Background(), customKey, testRequestID)
 	retrievedID := GetRequestID(ctx, customKey)
@@ -165,8 +169,8 @@ func TestDefaultRequestIDConfig(t *testing.T) {
 	if cfg.Generator == nil {
 		t.Error("Expected default generator to be set")
 	}
-	if cfg.ContextKey != config.RequestIDContextKey("request_id") {
-		t.Errorf("Expected default context key 'request_id', got %s", cfg.ContextKey)
+	if cfg.ContextKey != config.RequestIDContextKey {
+		t.Errorf("Expected default context key to be RequestIDContextKey, got %v", cfg.ContextKey)
 	}
 	id := cfg.Generator()
 	if len(id) != 32 {

--- a/middleware/security_headers.go
+++ b/middleware/security_headers.go
@@ -38,8 +38,8 @@ func SecurityHeaders(cfg ...config.SecurityHeadersConfig) func(http.Handler) htt
 
 				// Store nonce in context for handlers to use
 				ctxKey := c.ContentSecurityPolicyNonceContextKey
-				if ctxKey == "" {
-					ctxKey = config.DefaultCSPNonceContextKey
+				if ctxKey == nil {
+					ctxKey = config.CSPNonceContextKey
 				}
 				r = r.WithContext(context.WithValue(r.Context(), ctxKey, nonce))
 			}
@@ -115,12 +115,12 @@ func generateNonce() string {
 
 // GetCSPNonce retrieves the CSP nonce from the request context.
 // Returns empty string if nonce is not present.
-func GetCSPNonce(r *http.Request, key ...config.CSPNonceContextKey) string {
+func GetCSPNonce(r *http.Request, key ...any) string {
 	var ctxKey any
 	if len(key) > 0 {
 		ctxKey = key[0]
 	} else {
-		ctxKey = config.DefaultCSPNonceContextKey
+		ctxKey = config.CSPNonceContextKey
 	}
 	if nonce, ok := r.Context().Value(ctxKey).(string); ok {
 		return nonce

--- a/middleware/security_headers_test.go
+++ b/middleware/security_headers_test.go
@@ -354,7 +354,8 @@ func TestSecurityHeaders_CSPNonceReportOnly(t *testing.T) {
 }
 
 func TestSecurityHeaders_CSPNonceCustomContextKey(t *testing.T) {
-	customKey := config.CSPNonceContextKey("my_custom_nonce_key")
+	type myNonceKey struct{}
+	customKey := myNonceKey{}
 	var capturedNonce string
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Replace string-based context key types with struct-based types:
- RequestIDContextKey, CSPNonceContextKey
- CSRFTokenContextKey
- HMACAccessKeyIDContextKey, HMACErrorContextKey
- JWTClaimsContextKey, JWTErrorContextKey, JWTTokenContextKey

This prevents key collisions between packages as recommended by Go best practices.