### PR TITLE
feat: add startup hooks and reorganize config structure

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,10 +18,6 @@ type Config struct {
 	// Default: "localhost:8080"
 	Addr string
 
-	// TLSAddr is the address for the HTTPS server to listen on.
-	// Default: "localhost:8443"
-	TLSAddr string
-
 	// Server is the HTTP server instance for plain (non-TLS) traffic.
 	// Default: preconfigured server listening on "localhost:8080"
 	Server *http.Server
@@ -30,40 +26,15 @@ type Config struct {
 	// Default: nil (system default listener will be created)
 	Listener net.Listener
 
-	// TLSServer is the HTTPS server instance for encrypted traffic.
-	// Default: preconfigured server listening on "localhost:8443"
-	TLSServer *http.Server
+	// TLS holds the configuration for the HTTPS server.
+	TLS TLSConfig
 
-	// TLSListener allows specifying a custom net.Listener for HTTPS traffic (optional).
-	// Default: nil (system default listener will be created)
-	TLSListener net.Listener
-
-	// CertFile is the file path to the TLS certificate (PEM) when serving HTTPS.
-	// Default: "" (no certificate loaded unless specified)
-	CertFile string
-
-	// KeyFile is the file path to the TLS private key (PEM) when serving HTTPS.
-	// Default: "" (no key loaded unless specified)
-	KeyFile string
+	// Lifecycle holds the server startup and shutdown hook configuration.
+	Lifecycle LifecycleConfig
 
 	// Logger is the logger instance used by the server and middlewares.
 	// Default: nil (a default logger will be created if nil)
 	Logger log.Logger
-
-	// PreShutdownHooks are hooks that execute sequentially before server shutdown begins.
-	// These run before any servers start shutting down.
-	// Default: nil
-	PreShutdownHooks []ShutdownHookConfig
-
-	// ShutdownHooks are hooks that execute concurrently with server shutdown.
-	// These run alongside the HTTP/HTTPS/HTTP3 server shutdown.
-	// Default: nil
-	ShutdownHooks []ShutdownHookConfig
-
-	// PostShutdownHooks are hooks that execute sequentially after all servers are shut down.
-	// These run after all servers have completed shutdown.
-	// Default: nil
-	PostShutdownHooks []ShutdownHookConfig
 
 	// DisableDefaultMiddlewares disables all built-in default middlewares when true.
 	// Default: false (default middlewares are enabled)
@@ -91,6 +62,10 @@ type Config struct {
 	// Metrics holds the configuration for the metrics middleware.
 	Metrics MetricsConfig
 
+	// Tracer holds the configuration for the tracing middleware.
+	// Default: DefaultTracerConfig
+	Tracer TracerConfig
+
 	// Validator is an optional struct validator for validating request data.
 	// Users can inject their own implementation (e.g., github.com/go-playground/validator/v10).
 	// The validator must implement the Validator interface.
@@ -98,6 +73,55 @@ type Config struct {
 	// Default: nil
 	Validator Validator
 
+	// Extensions holds optional protocol and feature extensions.
+	Extensions ExtensionsConfig
+}
+
+type TLSConfig struct {
+	// Addr is the address for the HTTPS server to listen on.
+	// Default: "localhost:8443"
+	Addr string
+	// Server is the HTTPS server instance for encrypted traffic.
+	// Default: preconfigured server listening on "localhost:8443"
+	Server *http.Server
+
+	// Listener allows specifying a custom net.Listener for HTTPS traffic (optional).
+	// Default: nil (system default listener will be created)
+	Listener net.Listener
+
+	// CertFile is the file path to the TLS certificate (PEM) when serving HTTPS.
+	// Default: "" (no certificate loaded unless specified)
+	CertFile string
+
+	// KeyFile is the file path to the TLS private key (PEM) when serving HTTPS.
+	// Default: "" (no key loaded unless specified)
+	KeyFile string
+}
+
+type LifecycleConfig struct {
+	// StartupHooks are hooks that execute sequentially before the server starts
+	// accepting connections. If any startup hook returns an error, the server
+	// will not start.
+	// Default: nil
+	StartupHooks []StartupHookConfig
+
+	// PreShutdownHooks are hooks that execute sequentially before server shutdown begins.
+	// These run before any servers start shutting down.
+	// Default: nil
+	PreShutdownHooks []ShutdownHookConfig
+
+	// ShutdownHooks are hooks that execute concurrently with server shutdown.
+	// These run alongside the HTTP/HTTPS/HTTP3 server shutdown.
+	// Default: nil
+	ShutdownHooks []ShutdownHookConfig
+
+	// PostShutdownHooks are hooks that execute sequentially after all servers are shut down.
+	// These run after all servers have completed shutdown.
+	// Default: nil
+	PostShutdownHooks []ShutdownHookConfig
+}
+
+type ExtensionsConfig struct {
 	// AutocertManager is an optional autocert manager for automatic certificate management (AutoTLS).
 	// Users can inject their own implementation (e.g., golang.org/x/crypto/acme/autocert.Manager)
 	// by implementing the AutocertManager interface.
@@ -129,24 +153,16 @@ type Config struct {
 	// The server will be started automatically when ListenAndServeTLS or Start is called.
 	// Default: nil
 	WebTransportServer WebTransportServer
-
-	// Tracer is an optional tracer for distributed tracing.
-	// Users can inject their own implementation (e.g., wrapping go.opentelemetry.io/otel).
-	// The tracer must implement the trace.Tracer interface.
-	// If nil, tracing is disabled.
-	// Default: nil
-	Tracer TracerField
-
-	// TracerConfig holds the configuration for the tracing middleware.
-	// Default: DefaultTracerConfig
-	TracerConfig TracerConfig
 }
 
 // DefaultConfig contains all default values used by Config.
 // Update this file if you want to change system-wide defaults.
 var DefaultConfig = Config{
-	Addr:                      "localhost:8080",
-	TLSAddr:                   "localhost:8443",
+	Addr: "localhost:8080",
+	TLS: TLSConfig{
+		Addr:   "localhost:8443",
+		Server: nil,
+	},
 	DisableDefaultMiddlewares: false,
 	DefaultMiddlewares:        nil, // means use DefaultMiddlewares
 	Recover:                   DefaultRecoverConfig,
@@ -157,7 +173,32 @@ var DefaultConfig = Config{
 	Metrics:                   DefaultMetricsConfig,
 	Logger:                    nil, // means use DefaultLogger
 	Server:                    nil,
-	TLSServer:                 nil,
+}
+
+// ============================================================================
+// Startup Hook Types
+// ============================================================================
+
+// StartupHook is a function called before the server starts accepting connections.
+// The context passed to the hook has a deadline based on any configured timeout.
+//
+// Startup hooks execute sequentially in registration order.
+// If any startup hook returns an error, the server will not start.
+//
+// Hooks must respect context cancellation by checking ctx.Done().
+// If a hook blocks without respecting the context, startup will hang.
+//
+// Example:
+//
+//	app.RegisterStartupHook("migrations", func(ctx context.Context) error {
+//	    return goose.Up(db.DB, "migrations")
+//	})
+type StartupHook func(ctx context.Context) error
+
+// StartupHookConfig configures a startup hook.
+type StartupHookConfig struct {
+	Name string
+	Hook StartupHook
 }
 
 // ============================================================================

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,8 +15,8 @@ func TestDefaultConfigValues(t *testing.T) {
 	if cfg.Addr != "localhost:8080" {
 		t.Errorf("expected Addr = localhost:8080, got %s", cfg.Addr)
 	}
-	if cfg.TLSAddr != "localhost:8443" {
-		t.Errorf("expected TLSAddr = localhost:8443, got %s", cfg.TLSAddr)
+	if cfg.TLS.Addr != "localhost:8443" {
+		t.Errorf("expected Addr = localhost:8443, got %s", cfg.TLS.Addr)
 	}
 	if cfg.DisableDefaultMiddlewares {
 		t.Error("expected DisableDefaultMiddlewares to be false")
@@ -27,26 +27,26 @@ func TestDefaultConfigValues(t *testing.T) {
 	if cfg.Logger != nil {
 		t.Error("expected Logger to be nil")
 	}
-	if cfg.CertFile != "" {
-		t.Errorf("expected CertFile to be empty, got %s", cfg.CertFile)
+	if cfg.TLS.CertFile != "" {
+		t.Errorf("expected CertFile to be empty, got %s", cfg.TLS.CertFile)
 	}
-	if cfg.KeyFile != "" {
-		t.Errorf("expected KeyFile to be empty, got %s", cfg.KeyFile)
+	if cfg.TLS.KeyFile != "" {
+		t.Errorf("expected KeyFile to be empty, got %s", cfg.TLS.KeyFile)
 	}
-	if cfg.AutocertManager != nil {
+	if cfg.Extensions.AutocertManager != nil {
 		t.Error("expected AutocertManager to be nil")
 	}
 	if cfg.Server != nil {
 		t.Error("expected Server to be nil in default config")
 	}
-	if cfg.TLSServer != nil {
-		t.Error("expected TLSServer to be nil in default config")
+	if cfg.TLS.Server != nil {
+		t.Error("expected Server to be nil in default config")
 	}
 	if cfg.Listener != nil {
 		t.Error("expected Listener to be nil")
 	}
-	if cfg.TLSListener != nil {
-		t.Error("expected TLSListener to be nil")
+	if cfg.TLS.Listener != nil {
+		t.Error("expected Listener to be nil")
 	}
 
 	// Test middleware configs are initialized with defaults
@@ -66,8 +66,8 @@ func TestConfigZeroValues(t *testing.T) {
 	if cfg.Addr != "" {
 		t.Error("expected zero value for Addr to be empty string")
 	}
-	if cfg.TLSAddr != "" {
-		t.Error("expected zero value for TLSAddr to be empty string")
+	if cfg.TLS.Addr != "" {
+		t.Error("expected zero value for Addr to be empty string")
 	}
 	if cfg.DisableDefaultMiddlewares != false {
 		t.Error("expected zero value for DisableDefaultMiddlewares to be false")
@@ -81,22 +81,22 @@ func TestConfigZeroValues(t *testing.T) {
 	if cfg.Server != nil {
 		t.Error("expected zero value for Server to be nil")
 	}
-	if cfg.TLSServer != nil {
-		t.Error("expected zero value for TLSServer to be nil")
+	if cfg.TLS.Server != nil {
+		t.Error("expected zero value for Server to be nil")
 	}
 	if cfg.Listener != nil {
 		t.Error("expected zero value for Listener to be nil")
 	}
-	if cfg.TLSListener != nil {
-		t.Error("expected zero value for TLSListener to be nil")
+	if cfg.TLS.Listener != nil {
+		t.Error("expected zero value for Listener to be nil")
 	}
-	if cfg.CertFile != "" {
+	if cfg.TLS.CertFile != "" {
 		t.Error("expected zero value for CertFile to be empty string")
 	}
-	if cfg.KeyFile != "" {
+	if cfg.TLS.KeyFile != "" {
 		t.Error("expected zero value for KeyFile to be empty string")
 	}
-	if cfg.AutocertManager != nil {
+	if cfg.Extensions.AutocertManager != nil {
 		t.Error("expected zero value for AutocertManager to be nil")
 	}
 }
@@ -111,9 +111,9 @@ func (m *mockHTTP3Server) Close() error                                     { re
 func TestWithHTTP3Server(t *testing.T) {
 	cfg := DefaultConfig
 	mockServer := &mockHTTP3Server{}
-	cfg.HTTP3Server = mockServer
+	cfg.Extensions.HTTP3Server = mockServer
 
-	if cfg.HTTP3Server == nil {
+	if cfg.Extensions.HTTP3Server == nil {
 		t.Error("expected HTTP3Server to be set")
 	}
 }
@@ -127,9 +127,9 @@ func (m *mockWebTransportServer) Close() error                                  
 func TestWithWebTransportServer(t *testing.T) {
 	cfg := DefaultConfig
 	mockServer := &mockWebTransportServer{}
-	cfg.WebTransportServer = mockServer
+	cfg.Extensions.WebTransportServer = mockServer
 
-	if cfg.WebTransportServer == nil {
+	if cfg.Extensions.WebTransportServer == nil {
 		t.Error("expected WebTransportServer to be set")
 	}
 }
@@ -141,9 +141,9 @@ func TestShutdownHookWithError(t *testing.T) {
 	}
 
 	cfg := DefaultConfig
-	cfg.ShutdownHooks = []ShutdownHookConfig{{Name: "error-hook", Hook: hook}}
+	cfg.Lifecycle.ShutdownHooks = []ShutdownHookConfig{{Name: "error-hook", Hook: hook}}
 
-	err := cfg.ShutdownHooks[0].Hook(context.Background())
+	err := cfg.Lifecycle.ShutdownHooks[0].Hook(context.Background())
 	if !errors.Is(err, expectedErr) {
 		t.Errorf("Expected error '%v', got '%v'", expectedErr, err)
 	}
@@ -160,13 +160,13 @@ func TestShutdownHookContextCancellation(t *testing.T) {
 	}
 
 	cfg := DefaultConfig
-	cfg.ShutdownHooks = []ShutdownHookConfig{{Name: "ctx-hook", Hook: hook}}
+	cfg.Lifecycle.ShutdownHooks = []ShutdownHookConfig{{Name: "ctx-hook", Hook: hook}}
 
 	// Test with cancelled context
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := cfg.ShutdownHooks[0].Hook(ctx)
+	err := cfg.Lifecycle.ShutdownHooks[0].Hook(ctx)
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("Expected context.Canceled error, got %v", err)
 	}
@@ -240,9 +240,9 @@ func (m *mockWebSocketUpgrader) Upgrade(w http.ResponseWriter, r *http.Request) 
 func TestWebSocketUpgrader(t *testing.T) {
 	cfg := DefaultConfig
 	mockUpgrader := &mockWebSocketUpgrader{}
-	cfg.WebSocketUpgrader = mockUpgrader
+	cfg.Extensions.WebSocketUpgrader = mockUpgrader
 
-	if cfg.WebSocketUpgrader == nil {
+	if cfg.Extensions.WebSocketUpgrader == nil {
 		t.Error("expected WebSocketUpgrader to be set")
 	}
 }
@@ -265,9 +265,9 @@ func (m *mockSSEProvider) NewSSE(w http.ResponseWriter, r *http.Request) (SSECon
 func TestSSEProvider(t *testing.T) {
 	cfg := DefaultConfig
 	mockProvider := &mockSSEProvider{}
-	cfg.SSEProvider = mockProvider
+	cfg.Extensions.SSEProvider = mockProvider
 
-	if cfg.SSEProvider == nil {
+	if cfg.Extensions.SSEProvider == nil {
 		t.Error("expected SSEProvider to be set")
 	}
 }

--- a/config/tracing.go
+++ b/config/tracing.go
@@ -9,6 +9,8 @@ import (
 
 // TracerConfig holds configuration for the tracing middleware.
 type TracerConfig struct {
+	TracerField trace.Tracer
+
 	// ExemptPaths is a list of paths that should not be traced.
 	// Requests to these paths will not create spans.
 	// Default: nil (all paths are traced)
@@ -54,7 +56,3 @@ func (w *TracerConfigWrapper) GetSpanName(r *http.Request) string {
 	}
 	return DefaultSpanNameFormatter(r)
 }
-
-// TracerField is a type alias for trace.Tracer to avoid import cycles
-// when embedding in Config. The actual field in Config is of type trace.Tracer.
-type TracerField = trace.Tracer

--- a/examples/autotls/main.go
+++ b/examples/autotls/main.go
@@ -37,9 +37,13 @@ func main() {
 
 	app := zh.New(
 		config.Config{
-			Addr:            ":80",   // HTTP port for ACME challenges
-			TLSAddr:         ":443",  // HTTPS port
-			AutocertManager: manager, // Enable auto TLS
+			Addr: ":80", // HTTP port for ACME challenges
+			TLS: config.TLSConfig{
+				Addr: ":443", // HTTPS port
+			},
+			Extensions: config.ExtensionsConfig{
+				AutocertManager: manager, // Enable auto TLS
+			},
 		},
 	)
 

--- a/examples/graceful/main.go
+++ b/examples/graceful/main.go
@@ -17,42 +17,44 @@ import (
 func main() {
 	app := zh.New(
 		config.Config{
-			// Pre-shutdown: mark service as unhealthy first
-			PreShutdownHooks: []config.ShutdownHookConfig{
-				{
-					Name: "health",
-					Hook: func(ctx context.Context) error {
-						// In a real app, this would update a health check endpoint
-						return nil
+			Lifecycle: config.LifecycleConfig{
+				// Pre-shutdown: mark service as unhealthy first
+				PreShutdownHooks: []config.ShutdownHookConfig{
+					{
+						Name: "health",
+						Hook: func(ctx context.Context) error {
+							// In a real app, this would update a health check endpoint
+							return nil
+						},
 					},
 				},
-			},
-			// During shutdown: close resources concurrently with server shutdown
-			ShutdownHooks: []config.ShutdownHookConfig{
-				{
-					Name: "flush-logs",
-					Hook: func(ctx context.Context) error {
-						// Simulate log flush
-						time.Sleep(100 * time.Millisecond)
-						return nil
+				// During shutdown: close resources concurrently with server shutdown
+				ShutdownHooks: []config.ShutdownHookConfig{
+					{
+						Name: "flush-logs",
+						Hook: func(ctx context.Context) error {
+							// Simulate log flush
+							time.Sleep(100 * time.Millisecond)
+							return nil
+						},
+					},
+					{
+						Name: "close-connections",
+						Hook: func(ctx context.Context) error {
+							// Simulate DB connection close
+							time.Sleep(100 * time.Millisecond)
+							return nil
+						},
 					},
 				},
-				{
-					Name: "close-connections",
-					Hook: func(ctx context.Context) error {
-						// Simulate DB connection close
-						time.Sleep(100 * time.Millisecond)
-						return nil
-					},
-				},
-			},
-			// Post-shutdown: final cleanup after servers are stopped
-			PostShutdownHooks: []config.ShutdownHookConfig{
-				{
-					Name: "cleanup",
-					Hook: func(ctx context.Context) error {
-						// Cleanup temporary files
-						return nil
+				// Post-shutdown: final cleanup after servers are stopped
+				PostShutdownHooks: []config.ShutdownHookConfig{
+					{
+						Name: "cleanup",
+						Hook: func(ctx context.Context) error {
+							// Cleanup temporary files
+							return nil
+						},
 					},
 				},
 			},

--- a/examples/hsts/main.go
+++ b/examples/hsts/main.go
@@ -11,10 +11,12 @@ import (
 func main() {
 	app := zh.New(
 		config.Config{
-			Addr:     "localhost:8080",
-			TLSAddr:  "localhost:8443",
-			CertFile: "cert.pem",
-			KeyFile:  "key.pem",
+			Addr: "localhost:8080",
+			TLS: config.TLSConfig{
+				Addr:     "localhost:8443",
+				CertFile: "cert.pem",
+				KeyFile:  "key.pem",
+			},
 			// Enable HSTS with custom configuration
 			SecurityHeaders: config.SecurityHeadersConfig{
 				StrictTransportSecurity: config.StrictTransportSecurity{

--- a/examples/http3/autotls.go
+++ b/examples/http3/autotls.go
@@ -87,9 +87,13 @@ func main() {
 	// Create zerohttp server with autocert manager
 	app := zh.New(
 		config.Config{
-			Addr:            ":80",
-			TLSAddr:         ":443",
-			AutocertManager: wrappedManager,
+			Addr: ":80",
+			TLS: config.TLSConfig{
+				Addr: ":443",
+			},
+			Extensions: config.ExtensionsConfig{
+				AutocertManager: wrappedManager,
+			},
 		},
 	)
 

--- a/examples/http3/main.go
+++ b/examples/http3/main.go
@@ -17,7 +17,9 @@ func main() {
 	// Create zerohttp server with TLS
 	app := zh.New(
 		config.Config{
-			TLSAddr: ":8443",
+			TLS: config.TLSConfig{
+				Addr: ":8443",
+			},
 		},
 	)
 

--- a/examples/sse/main.go
+++ b/examples/sse/main.go
@@ -43,7 +43,9 @@ func main() {
 		config.Config{
 			Server:                    customServer,
 			DisableDefaultMiddlewares: true,
-			SSEProvider:               zh.NewDefaultProvider(),
+			Extensions: config.ExtensionsConfig{
+				SSEProvider: zh.NewDefaultProvider(),
+			},
 		},
 	)
 

--- a/examples/tls/main.go
+++ b/examples/tls/main.go
@@ -31,10 +31,12 @@ func httpsRedirectMiddleware(httpsPort string) func(http.Handler) http.Handler {
 func main() {
 	app := zh.New(
 		config.Config{
-			Addr:     "localhost:8080",
-			TLSAddr:  "localhost:8443",
-			CertFile: "cert.pem",
-			KeyFile:  "key.pem",
+			Addr: "localhost:8080",
+			TLS: config.TLSConfig{
+				Addr:     "localhost:8443",
+				CertFile: "cert.pem",
+				KeyFile:  "key.pem",
+			},
 		},
 	)
 

--- a/examples/tracing/jaeger.go
+++ b/examples/tracing/jaeger.go
@@ -155,7 +155,9 @@ func main() {
 
 	// Configure the server
 	app := zh.New(config.Config{
-		Tracer: tracer,
+		Tracer: config.TracerConfig{
+			TracerField: tracer,
+		},
 	})
 
 	// Add the tracing middleware

--- a/examples/tracing/main.go
+++ b/examples/tracing/main.go
@@ -66,7 +66,9 @@ func main() {
 
 	// Configure the server with our custom tracer
 	app := zh.New(config.Config{
-		Tracer: tracer,
+		Tracer: config.TracerConfig{
+			TracerField: tracer,
+		},
 	})
 
 	// Add the tracing middleware

--- a/examples/tracing/otel.go
+++ b/examples/tracing/otel.go
@@ -113,7 +113,9 @@ func main() {
 
 	// Configure the server
 	app := zh.New(config.Config{
-		Tracer: tracer,
+		Tracer: config.TracerConfig{
+			TracerField: tracer,
+		},
 	})
 
 	// Add the tracing middleware

--- a/examples/websocket/main.go
+++ b/examples/websocket/main.go
@@ -69,7 +69,9 @@ func main() {
 	app := zh.New(
 		config.Config{
 			DisableDefaultMiddlewares: true,
-			WebSocketUpgrader:         &myUpgrader{upgrader: gupgrader},
+			Extensions: config.ExtensionsConfig{
+				WebSocketUpgrader: &myUpgrader{upgrader: gupgrader},
+			},
 		},
 	)
 

--- a/examples/webtransport/autotls.go
+++ b/examples/webtransport/autotls.go
@@ -88,9 +88,13 @@ func main() {
 	app := zh.New(
 		config.Config{
 			DisableDefaultMiddlewares: true,
-			Addr:                      ":80",  // HTTP port for ACME challenges
-			TLSAddr:                   ":443", // HTTPS port
-			AutocertManager:           wrappedMgr,
+			Addr:                      ":80", // HTTP port for ACME challenges
+			TLS: config.TLSConfig{
+				Addr: ":443", // HTTPS port
+			},
+			Extensions: config.ExtensionsConfig{
+				AutocertManager: wrappedMgr,
+			},
 		},
 	)
 

--- a/server.go
+++ b/server.go
@@ -67,6 +67,10 @@ type Server struct {
 	// for recording HTTP requests, errors, and server lifecycle events.
 	logger log.Logger
 
+	// startupHooks execute sequentially before the server starts accepting connections.
+	// If any startup hook returns an error, the server will not start.
+	startupHooks []config.StartupHookConfig
+
 	// preShutdownHooks execute sequentially before server shutdown begins.
 	preShutdownHooks []config.ShutdownHookConfig
 
@@ -169,10 +173,10 @@ func New(cfg ...config.Config) *Server {
 		}
 	}
 
-	tlsServer := c.TLSServer
+	tlsServer := c.TLS.Server
 	if tlsServer == nil {
 		tlsServer = &http.Server{
-			Addr:           c.TLSAddr,
+			Addr:           c.TLS.Addr,
 			ReadTimeout:    10 * time.Second,
 			WriteTimeout:   10 * time.Second,
 			IdleTimeout:    60 * time.Second,
@@ -197,21 +201,22 @@ func New(cfg ...config.Config) *Server {
 		server:             server,
 		listener:           c.Listener,
 		tlsServer:          tlsServer,
-		tlsListener:        c.TLSListener,
-		certFile:           c.CertFile,
-		keyFile:            c.KeyFile,
-		autocertManager:    c.AutocertManager,
-		http3Server:        c.HTTP3Server,
-		webTransportServer: c.WebTransportServer,
-		webSocketUpgrader:  c.WebSocketUpgrader,
-		sseProvider:        c.SSEProvider,
+		tlsListener:        c.TLS.Listener,
+		certFile:           c.TLS.CertFile,
+		keyFile:            c.TLS.KeyFile,
+		autocertManager:    c.Extensions.AutocertManager,
+		http3Server:        c.Extensions.HTTP3Server,
+		webTransportServer: c.Extensions.WebTransportServer,
+		webSocketUpgrader:  c.Extensions.WebSocketUpgrader,
+		sseProvider:        c.Extensions.SSEProvider,
 		metricsRegistry:    registry,
 		metricsServerAddr:  c.Metrics.ServerAddr,
 		validator:          c.Validator,
 		logger:             logger,
-		preShutdownHooks:   c.PreShutdownHooks,
-		shutdownHooks:      c.ShutdownHooks,
-		postShutdownHooks:  c.PostShutdownHooks,
+		startupHooks:       c.Lifecycle.StartupHooks,
+		preShutdownHooks:   c.Lifecycle.PreShutdownHooks,
+		shutdownHooks:      c.Lifecycle.ShutdownHooks,
+		postShutdownHooks:  c.Lifecycle.PostShutdownHooks,
 		baseCtx:            baseCtx,
 		cancelBaseCtx:      cancelBaseCtx,
 	}
@@ -323,6 +328,13 @@ func (s *Server) ListenAndServe() error {
 // Returns nil when all servers shut down cleanly (e.g. via Shutdown()).
 func (s *Server) Start() error {
 	s.logger.Info("Starting server...")
+
+	// Run startup hooks before starting any servers
+	// If any hook fails, the server will not start
+	if err := s.runStartupHooks(s.baseCtx); err != nil {
+		s.logger.Error("Startup hook failed, server not starting", log.E(err))
+		return err
+	}
 
 	handler := s.Router
 

--- a/server_http3_test.go
+++ b/server_http3_test.go
@@ -301,8 +301,8 @@ func TestServer_StartAutoTLS_WithHTTP3Autocert(t *testing.T) {
 
 	// Use unique port to avoid conflicts with other tests
 	server := New(config.Config{
-		AutocertManager: mgr,
-		TLSAddr:         "localhost:18443",
+		TLS:        config.TLSConfig{Addr: "localhost:18443"},
+		Extensions: config.ExtensionsConfig{AutocertManager: mgr},
 	})
 	server.SetHTTP3Server(h3Server)
 
@@ -342,7 +342,7 @@ func TestServer_StartAutoTLS_WithHTTP3NoAutocert(t *testing.T) {
 	mgr := &mockAutocertManager{}
 	h3Server := &mockHTTP3Server{} // This doesn't implement HTTP3ServerWithAutocert
 
-	server := New(config.Config{AutocertManager: mgr})
+	server := New(config.Config{Extensions: config.ExtensionsConfig{AutocertManager: mgr}})
 	server.SetHTTP3Server(h3Server)
 
 	// Run StartAutoTLS in a goroutine since it blocks

--- a/server_lifecycle.go
+++ b/server_lifecycle.go
@@ -2,11 +2,62 @@ package zerohttp
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/alexferl/zerohttp/config"
 	"github.com/alexferl/zerohttp/log"
 )
+
+// RegisterStartupHook registers a hook to run before the server starts accepting connections.
+// Startup hooks execute sequentially in registration order.
+// If any startup hook returns an error, the server will not start.
+//
+// Hooks must respect context cancellation by checking ctx.Done().
+// If a hook blocks without respecting the context, startup will hang.
+//
+// Example:
+//
+//	app.RegisterStartupHook("migrations", func(ctx context.Context) error {
+//	    return goose.Up(db.DB, "migrations")
+//	})
+func (s *Server) RegisterStartupHook(name string, hook config.StartupHook) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.startupHooks = append(s.startupHooks, config.StartupHookConfig{Name: name, Hook: hook})
+}
+
+// runStartupHooks executes startup hooks sequentially in registration order.
+// If any hook returns an error, execution stops and the error is returned.
+func (s *Server) runStartupHooks(ctx context.Context) error {
+	s.mu.RLock()
+	hooks := s.startupHooks
+	s.mu.RUnlock()
+
+	if len(hooks) == 0 {
+		return nil
+	}
+
+	s.logger.Debug("Running startup hooks", log.F("count", len(hooks)))
+
+	for _, hook := range hooks {
+		select {
+		case <-ctx.Done():
+			s.logger.Warn("Startup hook aborted due to context cancellation", log.F("hook", hook.Name))
+			return ctx.Err()
+		default:
+		}
+
+		s.logger.Debug("Running startup hook", log.F("hook", hook.Name))
+		if err := hook.Hook(ctx); err != nil {
+			s.logger.Error("Startup hook failed", log.F("hook", hook.Name), log.E(err))
+			return fmt.Errorf("startup hook %q failed: %w", hook.Name, err)
+		}
+	}
+
+	s.logger.Debug("All startup hooks completed successfully")
+	return nil
+}
 
 // RegisterPreShutdownHook registers a hook to run before server shutdown begins.
 // Pre-shutdown hooks execute sequentially in registration order.

--- a/server_lifecycle_test.go
+++ b/server_lifecycle_test.go
@@ -262,23 +262,25 @@ func TestServer_ConfigWithShutdownHooks(t *testing.T) {
 	var preCalled, shutdownCalled, postCalled bool
 
 	server := New(config.Config{
-		PreShutdownHooks: []config.ShutdownHookConfig{
-			{Name: "pre", Hook: func(ctx context.Context) error {
-				preCalled = true
-				return nil
-			}},
-		},
-		ShutdownHooks: []config.ShutdownHookConfig{
-			{Name: "shutdown", Hook: func(ctx context.Context) error {
-				shutdownCalled = true
-				return nil
-			}},
-		},
-		PostShutdownHooks: []config.ShutdownHookConfig{
-			{Name: "post", Hook: func(ctx context.Context) error {
-				postCalled = true
-				return nil
-			}},
+		Lifecycle: config.LifecycleConfig{
+			PreShutdownHooks: []config.ShutdownHookConfig{
+				{Name: "pre", Hook: func(ctx context.Context) error {
+					preCalled = true
+					return nil
+				}},
+			},
+			ShutdownHooks: []config.ShutdownHookConfig{
+				{Name: "shutdown", Hook: func(ctx context.Context) error {
+					shutdownCalled = true
+					return nil
+				}},
+			},
+			PostShutdownHooks: []config.ShutdownHookConfig{
+				{Name: "post", Hook: func(ctx context.Context) error {
+					postCalled = true
+					return nil
+				}},
+			},
 		},
 	})
 
@@ -302,5 +304,217 @@ func TestServer_ConfigWithShutdownHooks(t *testing.T) {
 	}
 	if !postCalled {
 		t.Error("Expected post-shutdown hook to be called")
+	}
+}
+
+// ============================================================================
+// Startup Hook Tests
+// ============================================================================
+
+func TestServer_RegisterStartupHook(t *testing.T) {
+	server := New()
+
+	called := false
+	server.RegisterStartupHook("test-hook", func(ctx context.Context) error {
+		called = true
+		return nil
+	})
+
+	if len(server.startupHooks) != 1 {
+		t.Errorf("Expected 1 startup hook, got %d", len(server.startupHooks))
+	}
+
+	if server.startupHooks[0].Name != "test-hook" {
+		t.Errorf("Expected hook name 'test-hook', got '%s'", server.startupHooks[0].Name)
+	}
+
+	err := server.startupHooks[0].Hook(context.Background())
+	if err != nil {
+		t.Errorf("Expected no error from hook, got %v", err)
+	}
+
+	if !called {
+		t.Error("Expected hook to be called")
+	}
+}
+
+func TestServer_StartupHooks_RunInOrder(t *testing.T) {
+	var order []string
+	server := New(config.Config{
+		Lifecycle: config.LifecycleConfig{
+			StartupHooks: []config.StartupHookConfig{
+				{Name: "hook-1", Hook: func(ctx context.Context) error {
+					order = append(order, "hook-1")
+					return nil
+				}},
+				{Name: "hook-2", Hook: func(ctx context.Context) error {
+					order = append(order, "hook-2")
+					return nil
+				}},
+			},
+		},
+	})
+
+	listener, _ := net.Listen("tcp", "127.0.0.1:0")
+	server.listener = listener
+	server.server = &http.Server{Addr: listener.Addr().String()}
+
+	// Start server in goroutine - it will fail because we don't actually run it
+	// but startup hooks will run
+	go func() {
+		_ = server.Start()
+	}()
+
+	// Give time for startup hooks to run
+	time.Sleep(100 * time.Millisecond)
+
+	// Shutdown to clean up
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_ = server.Shutdown(ctx)
+
+	if len(order) != 2 {
+		t.Errorf("Expected 2 hooks to run, got %d", len(order))
+	}
+
+	if len(order) >= 2 && (order[0] != "hook-1" || order[1] != "hook-2") {
+		t.Errorf("Expected hooks to run in registration order, got %v", order)
+	}
+}
+
+func TestServer_StartupHook_FailsServerStart(t *testing.T) {
+	server := New(config.Config{
+		Lifecycle: config.LifecycleConfig{
+			StartupHooks: []config.StartupHookConfig{
+				{Name: "failing-hook", Hook: func(ctx context.Context) error {
+					return errors.New("startup failed")
+				}},
+			},
+		},
+	})
+
+	listener, _ := net.Listen("tcp", "127.0.0.1:0")
+	server.listener = listener
+	server.server = &http.Server{Addr: listener.Addr().String()}
+
+	err := server.Start()
+	if err == nil {
+		t.Error("Expected server start to fail due to startup hook error")
+	}
+
+	if !errors.Is(err, context.Canceled) && err.Error() != `startup hook "failing-hook" failed: startup failed` {
+		t.Errorf("Expected startup hook error, got: %v", err)
+	}
+}
+
+func TestServer_StartupHook_StopsOnFirstError(t *testing.T) {
+	var calls []string
+	server := New(config.Config{
+		Lifecycle: config.LifecycleConfig{
+			StartupHooks: []config.StartupHookConfig{
+				{Name: "first", Hook: func(ctx context.Context) error {
+					calls = append(calls, "first")
+					return errors.New("first failed")
+				}},
+				{Name: "second", Hook: func(ctx context.Context) error {
+					calls = append(calls, "second")
+					return nil
+				}},
+			},
+		},
+	})
+
+	listener, _ := net.Listen("tcp", "127.0.0.1:0")
+	server.listener = listener
+	server.server = &http.Server{Addr: listener.Addr().String()}
+
+	_ = server.Start()
+
+	// Only first hook should have run
+	if len(calls) != 1 {
+		t.Errorf("Expected only 1 hook to run, got %d: %v", len(calls), calls)
+	}
+
+	if len(calls) > 0 && calls[0] != "first" {
+		t.Errorf("Expected first hook to run, got %v", calls)
+	}
+}
+
+func TestServer_StartupHook_RespectsContextCancellation(t *testing.T) {
+	// Create a server with a startup hook that checks context
+	var hookCalled bool
+	server := New(config.Config{
+		Lifecycle: config.LifecycleConfig{
+			StartupHooks: []config.StartupHookConfig{
+				{Name: "context-check", Hook: func(ctx context.Context) error {
+					hookCalled = true
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					default:
+						return nil
+					}
+				}},
+			},
+		},
+	})
+
+	listener, _ := net.Listen("tcp", "127.0.0.1:0")
+	server.listener = listener
+	server.server = &http.Server{Addr: listener.Addr().String()}
+
+	// Cancel the base context before starting
+	server.cancelBaseCtx()
+
+	err := server.Start()
+	if err == nil {
+		t.Error("Expected server start to fail due to cancelled context")
+	}
+
+	// When context is cancelled before hooks run, hooks should not be called
+	if hookCalled {
+		t.Error("Expected hook not to be called when context is already cancelled")
+	}
+}
+
+func TestServer_StartupHook_ViaRegisterMethod(t *testing.T) {
+	var order []string
+	server := New()
+
+	server.RegisterStartupHook("hook-a", func(ctx context.Context) error {
+		order = append(order, "hook-a")
+		return nil
+	})
+	server.RegisterStartupHook("hook-b", func(ctx context.Context) error {
+		order = append(order, "hook-b")
+		return nil
+	})
+
+	// Also add some via config (simulating what New() does with c.StartupHooks)
+	server.startupHooks = append(server.startupHooks, config.StartupHookConfig{
+		Name: "hook-config",
+		Hook: func(ctx context.Context) error {
+			order = append(order, "hook-config")
+			return nil
+		},
+	})
+
+	listener, _ := net.Listen("tcp", "127.0.0.1:0")
+	server.listener = listener
+	server.server = &http.Server{Addr: listener.Addr().String()}
+
+	go func() {
+		_ = server.Start()
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_ = server.Shutdown(ctx)
+
+	// Should have 3 hooks: hook-a, hook-b, hook-config
+	if len(order) != 3 {
+		t.Errorf("Expected 3 hooks to run, got %d: %v", len(order), order)
 	}
 }

--- a/server_sse_test.go
+++ b/server_sse_test.go
@@ -26,7 +26,7 @@ func TestServer_SSEProvider(t *testing.T) {
 
 	t.Run("SSEProvider works with config option", func(t *testing.T) {
 		provider := NewDefaultProvider()
-		s := New(config.Config{SSEProvider: provider})
+		s := New(config.Config{Extensions: config.ExtensionsConfig{SSEProvider: provider}})
 
 		if s.SSEProvider() != provider {
 			t.Error("expected SSEProvider from config option")

--- a/server_tls_test.go
+++ b/server_tls_test.go
@@ -92,7 +92,7 @@ func (m *mockAutocertManager) Hostnames() []string {
 
 func TestServer_StartAutoTLS_WithManager(t *testing.T) {
 	mgr := &mockAutocertManager{}
-	server := New(config.Config{AutocertManager: mgr})
+	server := New(config.Config{Extensions: config.ExtensionsConfig{AutocertManager: mgr}})
 
 	// Verify manager was set (compare using concrete type assertion)
 	if server.autocertManager == nil {
@@ -126,9 +126,11 @@ func TestStartAutoTLS_HTTPReadyGatesWarmUp(t *testing.T) {
 	h3Server := &mockHTTP3ServerWithAutocert{}
 
 	server := New(config.Config{
-		AutocertManager: mgr,
-		TLSAddr:         "localhost:0",
-		Addr:            "localhost:0",
+		Addr: "localhost:0",
+		TLS: config.TLSConfig{
+			Addr: "localhost:0",
+		},
+		Extensions: config.ExtensionsConfig{AutocertManager: mgr},
 	})
 	server.SetHTTP3Server(h3Server)
 
@@ -173,9 +175,11 @@ func TestStartAutoTLS_SyncOnceSignalsOnce(t *testing.T) {
 	wtServer := &mockWebTransportServerWithAutocert{}
 
 	server := New(config.Config{
-		AutocertManager: mgr,
-		TLSAddr:         "localhost:0",
-		Addr:            "localhost:0",
+		Addr: "localhost:0",
+		TLS: config.TLSConfig{
+			Addr: "localhost:0",
+		},
+		Extensions: config.ExtensionsConfig{AutocertManager: mgr},
 	})
 	server.SetHTTP3Server(h3Server)
 	server.SetWebTransportServer(wtServer)
@@ -205,9 +209,11 @@ func TestStartAutoTLS_MultipleConsumersUnblock(t *testing.T) {
 	mgr := &mockAutocertManager{}
 
 	server := New(config.Config{
-		AutocertManager: mgr,
-		TLSAddr:         "localhost:0",
-		Addr:            "localhost:0",
+		Addr: "localhost:0",
+		TLS: config.TLSConfig{
+			Addr: "localhost:0",
+		},
+		Extensions: config.ExtensionsConfig{AutocertManager: mgr},
 	})
 
 	h3Server := &mockHTTP3ServerWithAutocert{}
@@ -250,14 +256,16 @@ func TestStartAutoTLS_WarmUpTimeout(t *testing.T) {
 	// The actual timeout behavior is verified by code inspection
 
 	// Create a manager that never returns a cert
-	neverReadyMgr := &neverReadyAutocertManager{}
+	mgr := &neverReadyAutocertManager{}
 
 	h3Server := &mockHTTP3ServerWithAutocert{}
 
 	server := New(config.Config{
-		AutocertManager: neverReadyMgr,
-		TLSAddr:         "localhost:0",
-		Addr:            "localhost:0",
+		Addr: "localhost:0",
+		TLS: config.TLSConfig{
+			Addr: "localhost:0",
+		},
+		Extensions: config.ExtensionsConfig{AutocertManager: mgr},
 	})
 	server.SetHTTP3Server(h3Server)
 
@@ -298,9 +306,11 @@ func TestStartAutoTLS_EmptyHostnames(t *testing.T) {
 	h3Server := &mockHTTP3ServerWithAutocert{}
 
 	server := New(config.Config{
-		AutocertManager: mgr,
-		TLSAddr:         "localhost:0",
-		Addr:            "localhost:0",
+		Addr: "localhost:0",
+		TLS: config.TLSConfig{
+			Addr: "localhost:0",
+		},
+		Extensions: config.ExtensionsConfig{AutocertManager: mgr},
 	})
 	server.SetHTTP3Server(h3Server)
 
@@ -324,9 +334,11 @@ func TestStartAutoTLS_NoHTTPServer(t *testing.T) {
 	h3Server := &mockHTTP3ServerWithAutocert{}
 
 	server := New(config.Config{
-		AutocertManager: mgr,
-		TLSAddr:         "localhost:0",
 		// No Addr - no HTTP server
+		TLS: config.TLSConfig{
+			Addr: "localhost:0",
+		},
+		Extensions: config.ExtensionsConfig{AutocertManager: mgr},
 	})
 	server.SetHTTP3Server(h3Server)
 

--- a/server_webtransport_test.go
+++ b/server_webtransport_test.go
@@ -61,8 +61,10 @@ func TestServer_StartAutoTLS_WithWebTransportAutocert(t *testing.T) {
 
 	// Use unique port to avoid conflicts with other tests
 	server := New(config.Config{
-		AutocertManager: mgr,
-		TLSAddr:         "localhost:28443",
+		TLS: config.TLSConfig{
+			Addr: "localhost:28443",
+		},
+		Extensions: config.ExtensionsConfig{AutocertManager: mgr},
 	})
 	server.SetWebTransportServer(wtServer)
 
@@ -102,7 +104,7 @@ func TestServer_StartAutoTLS_WithWebTransportNoAutocert(t *testing.T) {
 	mgr := &mockAutocertManager{}
 	wtServer := &mockWebTransportServer{} // This doesn't implement WebTransportServerWithAutocert
 
-	server := New(config.Config{AutocertManager: mgr})
+	server := New(config.Config{Extensions: config.ExtensionsConfig{AutocertManager: mgr}})
 	server.SetWebTransportServer(wtServer)
 
 	// Run StartAutoTLS in a goroutine since it blocks
@@ -262,7 +264,7 @@ func TestServer_SetWebTransportServer(t *testing.T) {
 
 func TestServer_SetWebTransportServer_WithConfig(t *testing.T) {
 	mockWT := &mockWebTransportServer{}
-	server := New(config.Config{WebTransportServer: mockWT})
+	server := New(config.Config{Extensions: config.ExtensionsConfig{WebTransportServer: mockWT}})
 
 	if server.webTransportServer != mockWT {
 		t.Error("Expected WebTransport server to be set via config")

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -265,7 +265,7 @@ func TestServerWebSocketUpgrader(t *testing.T) {
 func TestServerWithWebSocketUpgrader(t *testing.T) {
 	// Test that WebSocket upgrader can be set via config option
 	mockUpgrader := &mockWebSocketUpgrader{}
-	app := New(config.Config{WebSocketUpgrader: mockUpgrader})
+	app := New(config.Config{Extensions: config.ExtensionsConfig{WebSocketUpgrader: mockUpgrader}})
 
 	if app.WebSocketUpgrader() != mockUpgrader {
 		t.Error("WebSocketUpgrader should be set via config option")
@@ -288,7 +288,7 @@ func TestWebSocketHandler(t *testing.T) {
 
 	mockUpgrader := &mockWebSocketUpgrader{conn: mockConn}
 
-	app := New(config.Config{WebSocketUpgrader: mockUpgrader})
+	app := New(config.Config{Extensions: config.ExtensionsConfig{WebSocketUpgrader: mockUpgrader}})
 
 	app.GET("/ws", HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 		ws, err := app.WebSocketUpgrader().Upgrade(w, r)


### PR DESCRIPTION
- Add StartupHook type and LifecycleConfig to hold startup/shutdown hooks
- Startup hooks run sequentially before server starts; failure prevents startup
- Reorganize Config into logical groups: TLSConfig, LifecycleConfig, ExtensionsConfig
- Update all examples and tests for new config structure