### PR TITLE
refactor: variadic config patterns and *bool fields for optional configs

### DIFF
--- a/config/metrics.go
+++ b/config/metrics.go
@@ -4,9 +4,10 @@ import "net/http"
 
 // MetricsConfig allows customization of metrics behavior.
 type MetricsConfig struct {
-	// Enabled determines if metrics middleware is active.
-	// Default: true
-	Enabled bool
+	// Enabled determines if metrics are collected.
+	// nil = use default (enabled), true = enabled, false = disabled
+	// Default: nil (enabled)
+	Enabled *bool
 
 	// Endpoint is the path where metrics are exposed.
 	// Default: "/metrics"
@@ -15,9 +16,9 @@ type MetricsConfig struct {
 	// ServerAddr is the address for a dedicated metrics server.
 	// Metrics are served on a separate port bound to localhost for security,
 	// preventing exposure of internal metrics to the public internet.
-	// Set to empty string to serve metrics on the main application server (not recommended).
+	// Set to empty string (via config.String("")) to serve metrics on the main application server (not recommended).
 	// Default: "localhost:9090"
-	ServerAddr string
+	ServerAddr *string
 
 	// DurationBuckets defines histogram buckets for request duration (seconds).
 	// Default: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
@@ -43,9 +44,8 @@ type MetricsConfig struct {
 
 // DefaultMetricsConfig contains default values for metrics configuration.
 var DefaultMetricsConfig = MetricsConfig{
-	Enabled:         false,
 	Endpoint:        "/metrics",
-	ServerAddr:      "localhost:9090",
+	ServerAddr:      String("localhost:9090"),
 	DurationBuckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 	SizeBuckets:     []float64{100, 1000, 10000, 100000, 1000000, 10000000},
 	ExcludePaths:    []string{"/metrics"},

--- a/config/metrics_test.go
+++ b/config/metrics_test.go
@@ -9,16 +9,12 @@ import (
 func TestDefaultMetricsConfig(t *testing.T) {
 	defaults := DefaultMetricsConfig
 
-	if defaults.Enabled != false {
-		t.Errorf("expected Enabled to be false, got %v", defaults.Enabled)
-	}
-
 	if defaults.Endpoint != "/metrics" {
 		t.Errorf("expected Endpoint to be /metrics, got %s", defaults.Endpoint)
 	}
 
-	if defaults.ServerAddr != "localhost:9090" {
-		t.Errorf("expected ServerAddr to be localhost:9090, got %s", defaults.ServerAddr)
+	if defaults.ServerAddr == nil || *defaults.ServerAddr != "localhost:9090" {
+		t.Errorf("expected ServerAddr to be localhost:9090, got %v", defaults.ServerAddr)
 	}
 
 	expectedDurationBuckets := []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
@@ -59,9 +55,8 @@ func TestMetricsConfig_CustomLabels(t *testing.T) {
 	}
 
 	cfg := MetricsConfig{
-		Enabled:         true,
 		Endpoint:        "/custom-metrics",
-		ServerAddr:      "localhost:9091",
+		ServerAddr:      String("localhost:9091"),
 		DurationBuckets: []float64{0.1, 0.5, 1.0},
 		SizeBuckets:     []float64{1000, 10000},
 		ExcludePaths:    []string{"/health", "/readyz"},
@@ -69,16 +64,12 @@ func TestMetricsConfig_CustomLabels(t *testing.T) {
 		CustomLabels:    customLabels,
 	}
 
-	if !cfg.Enabled {
-		t.Error("expected Enabled to be true")
-	}
-
 	if cfg.Endpoint != "/custom-metrics" {
 		t.Errorf("expected Endpoint to be /custom-metrics, got %s", cfg.Endpoint)
 	}
 
-	if cfg.ServerAddr != "localhost:9091" {
-		t.Errorf("expected ServerAddr to be localhost:9091, got %s", cfg.ServerAddr)
+	if cfg.ServerAddr == nil || *cfg.ServerAddr != "localhost:9091" {
+		t.Errorf("expected ServerAddr to be localhost:9091, got %v", cfg.ServerAddr)
 	}
 
 	if len(cfg.DurationBuckets) != 3 {
@@ -111,12 +102,11 @@ func TestMetricsConfig_CustomLabels(t *testing.T) {
 func TestMetricsConfig_EmptyServerAddr(t *testing.T) {
 	// Empty ServerAddr means metrics are served on the main server
 	cfg := MetricsConfig{
-		Enabled:    true,
-		ServerAddr: "",
+		ServerAddr: String(""),
 		Endpoint:   "/metrics",
 	}
 
-	if cfg.ServerAddr != "" {
-		t.Errorf("expected ServerAddr to be empty, got %s", cfg.ServerAddr)
+	if cfg.ServerAddr == nil || *cfg.ServerAddr != "" {
+		t.Errorf("expected ServerAddr to be empty, got %v", cfg.ServerAddr)
 	}
 }

--- a/config/util.go
+++ b/config/util.go
@@ -6,3 +6,28 @@ package config
 func Bool(b bool) *bool {
 	return &b
 }
+
+// String returns a pointer to a string value.
+// Used for *string config fields that distinguish "not set" (nil) from
+// "explicitly set to empty string".
+func String(s string) *string {
+	return &s
+}
+
+// BoolOrDefault dereferences a *bool, returning defaultVal if nil.
+// Used for *bool config fields to get the value or a default.
+func BoolOrDefault(b *bool, defaultVal bool) bool {
+	if b == nil {
+		return defaultVal
+	}
+	return *b
+}
+
+// StringOrDefault dereferences a *string, returning defaultVal if nil.
+// Used for *string config fields to get the value or a default.
+func StringOrDefault(s *string, defaultVal string) string {
+	if s == nil {
+		return defaultVal
+	}
+	return *s
+}

--- a/config/util_test.go
+++ b/config/util_test.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestBool(t *testing.T) {
+	t.Run("returns pointer to true", func(t *testing.T) {
+		b := Bool(true)
+		if b == nil {
+			t.Fatal("expected non-nil pointer")
+		}
+		if !*b {
+			t.Error("expected true")
+		}
+	})
+
+	t.Run("returns pointer to false", func(t *testing.T) {
+		b := Bool(false)
+		if b == nil {
+			t.Fatal("expected non-nil pointer")
+		}
+		if *b {
+			t.Error("expected false")
+		}
+	})
+}
+
+func TestBoolOrDefault(t *testing.T) {
+	t.Run("returns value when not nil", func(t *testing.T) {
+		b := true
+		result := BoolOrDefault(&b, false)
+		if !result {
+			t.Error("expected true, got false")
+		}
+	})
+
+	t.Run("returns default when nil", func(t *testing.T) {
+		result := BoolOrDefault(nil, true)
+		if !result {
+			t.Error("expected default true, got false")
+		}
+	})
+
+	t.Run("returns default false when nil", func(t *testing.T) {
+		result := BoolOrDefault(nil, false)
+		if result {
+			t.Error("expected default false, got true")
+		}
+	})
+}
+
+func TestString(t *testing.T) {
+	t.Run("returns pointer to string", func(t *testing.T) {
+		s := String("test")
+		if s == nil {
+			t.Fatal("expected non-nil pointer")
+		}
+		if *s != "test" {
+			t.Errorf("expected 'test', got '%s'", *s)
+		}
+	})
+}
+
+func TestStringOrDefault(t *testing.T) {
+	t.Run("returns value when not nil", func(t *testing.T) {
+		s := "hello"
+		result := StringOrDefault(&s, "default")
+		if result != "hello" {
+			t.Errorf("expected 'hello', got '%s'", result)
+		}
+	})
+
+	t.Run("returns default when nil", func(t *testing.T) {
+		result := StringOrDefault(nil, "default")
+		if result != "default" {
+			t.Errorf("expected 'default', got '%s'", result)
+		}
+	})
+
+	t.Run("returns empty string when nil and default is empty", func(t *testing.T) {
+		result := StringOrDefault(nil, "")
+		if result != "" {
+			t.Errorf("expected empty string, got '%s'", result)
+		}
+	})
+}

--- a/examples/core/metrics/main.go
+++ b/examples/core/metrics/main.go
@@ -23,9 +23,8 @@ func main() {
 	// for security. This prevents exposing metrics to the public internet.
 	app := zh.New(config.Config{
 		Metrics: config.MetricsConfig{
-			Enabled:      true,
+			Enabled:      config.Bool(true),
 			Endpoint:     "/metrics",
-			ServerAddr:   "localhost:9090", // Separate metrics server on localhost
 			ExcludePaths: []string{"/health", "/metrics"},
 			PathLabelFunc: func(p string) string {
 				// Normalize dynamic paths - replace numeric IDs with placeholders

--- a/examples/core/pprof/README.md
+++ b/examples/core/pprof/README.md
@@ -67,28 +67,28 @@ go tool pprof -http=:8081 heap.prof
 
 ### Custom prefix and credentials
 ```go
-cfg := pprof.DefaultConfig
-cfg.Prefix = "/admin/pprof"
-cfg.Auth = &pprof.AuthConfig{
-    Username: "admin",
-    Password: "secret",
-}
-pp := pprof.New(app, cfg)
+pp := pprof.New(app, pprof.Config{
+    Prefix: "/admin/pprof",
+    Auth: &pprof.AuthConfig{
+        Username: "admin",
+        Password: "secret",
+    },
+})
 ```
 
 ### Allow specific IP ranges
 ```go
-cfg := pprof.DefaultConfig
-cfg.AllowedIPs = []string{"10.0.0.0/8", "192.168.1.100"}
-pp := pprof.New(app, cfg)
+pp := pprof.New(app, pprof.Config{
+    AllowedIPs: []string{"10.0.0.0/8", "192.168.1.100"},
+})
 ```
 
 ### Disable specific profiles
 ```go
-cfg := pprof.DefaultConfig
-cfg.EnableBlock = false
-cfg.EnableMutex = false
-pp := pprof.New(app, cfg)
+pp := pprof.New(app, pprof.Config{
+    EnableBlock: config.Bool(false),
+    EnableMutex: config.Bool(false),
+})
 ```
 
 ## Security Notes

--- a/examples/core/pprof/main.go
+++ b/examples/core/pprof/main.go
@@ -12,7 +12,7 @@ func main() {
 
 	// Basic usage with defaults - auto-generates secure password
 	// Credentials are available via the returned PProf struct
-	pp := pprof.New(app, pprof.DefaultConfig)
+	pp := pprof.New(app)
 	log.Printf("pprof credentials - username: %s, password: %s", pp.Auth.Username, pp.Auth.Password)
 	log.Printf("pprof endpoints available at http://localhost:8080%s/", pp.Config.Prefix)
 

--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/internal/config"
 )
 
 // Config holds the healthcheck configuration
@@ -52,18 +53,33 @@ var DefaultConfig = Config{
 }
 
 // New creates and registers all healthcheck endpoints with the provided configuration.
-// Use DefaultConfig for default values:
+// Uses DefaultConfig if no config is provided, or merges user config with defaults.
 //
-//	healthcheck.New(app, healthcheck.DefaultConfig)
+// Examples:
 //
-// Or customize specific fields:
+//	// Use defaults
+//	healthcheck.New(app)
 //
-//	cfg := healthcheck.DefaultConfig
-//	cfg.LivenessEndpoint = "/health/live"
-//	cfg.ReadinessHandler = myCustomHandler
-//	healthcheck.New(app, cfg)
-func New(app *zh.Server, cfg Config) {
-	app.GET(cfg.LivenessEndpoint, cfg.LivenessHandler)
-	app.GET(cfg.ReadinessEndpoint, cfg.ReadinessHandler)
-	app.GET(cfg.StartupEndpoint, cfg.StartupHandler)
+//	// Override specific fields
+//	healthcheck.New(app, healthcheck.Config{
+//	    LivenessEndpoint: "/health/live",
+//	})
+//
+//	// Full custom config
+//	healthcheck.New(app, healthcheck.Config{
+//	    LivenessEndpoint:  "/livez",
+//	    LivenessHandler:   myCustomHandler,
+//	    ReadinessEndpoint: "/readyz",
+//	    ReadinessHandler:  myCustomHandler,
+//	    StartupEndpoint:   "/startupz",
+//	    StartupHandler:    myCustomHandler,
+//	})
+func New(app *zh.Server, cfg ...Config) {
+	c := DefaultConfig
+	if len(cfg) > 0 {
+		config.Merge(&c, cfg[0])
+	}
+	app.GET(c.LivenessEndpoint, c.LivenessHandler)
+	app.GET(c.ReadinessEndpoint, c.ReadinessHandler)
+	app.GET(c.StartupEndpoint, c.StartupHandler)
 }

--- a/healthcheck/healthcheck_test.go
+++ b/healthcheck/healthcheck_test.go
@@ -165,3 +165,48 @@ func TestDefaultConfig(t *testing.T) {
 		t.Error("Expected StartupHandler to be set")
 	}
 }
+
+func TestNoConfig(t *testing.T) {
+	// Test calling New without any config (uses defaults)
+	app := zh.New()
+	New(app)
+
+	endpoints := []string{"/livez", "/readyz", "/startupz"}
+	for _, endpoint := range endpoints {
+		t.Run(endpoint, func(t *testing.T) {
+			req := zhtest.NewRequest(http.MethodGet, endpoint).Build()
+			w := zhtest.Serve(app, req)
+			zhtest.AssertWith(t, w).Status(http.StatusOK).Body("ok")
+		})
+	}
+}
+
+func TestPartialConfig(t *testing.T) {
+	// Test partial config merging with defaults
+	app := zh.New()
+
+	// Only override liveness endpoint, rest should use defaults
+	New(app, Config{
+		LivenessEndpoint: "/health/live",
+	})
+
+	// Custom endpoint should work
+	t.Run("custom liveness", func(t *testing.T) {
+		req := zhtest.NewRequest(http.MethodGet, "/health/live").Build()
+		w := zhtest.Serve(app, req)
+		zhtest.AssertWith(t, w).Status(http.StatusOK).Body("ok")
+	})
+
+	// Default endpoints should still work
+	t.Run("default readiness", func(t *testing.T) {
+		req := zhtest.NewRequest(http.MethodGet, "/readyz").Build()
+		w := zhtest.Serve(app, req)
+		zhtest.AssertWith(t, w).Status(http.StatusOK).Body("ok")
+	})
+
+	t.Run("default startup", func(t *testing.T) {
+		req := zhtest.NewRequest(http.MethodGet, "/startupz").Build()
+		w := zhtest.Serve(app, req)
+		zhtest.AssertWith(t, w).Status(http.StatusOK).Body("ok")
+	})
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,7 +6,6 @@ import (
 )
 
 type TestMetricsConfig struct {
-	Enabled    bool
 	Endpoint   string
 	ServerAddr string
 }
@@ -19,7 +18,6 @@ type TestConfig struct {
 var defaultConfig = TestConfig{
 	Addr: "localhost:8080",
 	Metrics: TestMetricsConfig{
-		Enabled:    false,
 		Endpoint:   "/metrics",
 		ServerAddr: "localhost:9090",
 	},
@@ -35,9 +33,6 @@ func TestConfigMerging(t *testing.T) {
 		if c.Addr != "localhost:8080" {
 			t.Errorf("expected Addr localhost:8080, got %s", c.Addr)
 		}
-		if c.Metrics.Enabled != false {
-			t.Errorf("expected Metrics.Enabled false, got %v", c.Metrics.Enabled)
-		}
 		if c.Metrics.Endpoint != "/metrics" {
 			t.Errorf("expected Metrics.Endpoint /metrics, got %s", c.Metrics.Endpoint)
 		}
@@ -48,7 +43,6 @@ func TestConfigMerging(t *testing.T) {
 		userCfg := TestConfig{
 			Addr: ":9090",
 			Metrics: TestMetricsConfig{
-				Enabled:  true,
 				Endpoint: "/custom-metrics",
 			},
 		}
@@ -57,9 +51,6 @@ func TestConfigMerging(t *testing.T) {
 
 		if c.Addr != ":9090" {
 			t.Errorf("expected Addr :9090, got %s", c.Addr)
-		}
-		if c.Metrics.Enabled != true {
-			t.Errorf("expected Metrics.Enabled true, got %v", c.Metrics.Enabled)
 		}
 		if c.Metrics.Endpoint != "/custom-metrics" {
 			t.Errorf("expected Metrics.Endpoint /custom-metrics, got %s", c.Metrics.Endpoint)
@@ -74,14 +65,14 @@ func TestConfigMerging(t *testing.T) {
 		c := defaultConfig
 		userCfg := TestConfig{
 			Metrics: TestMetricsConfig{
-				Enabled: true,
+				ServerAddr: "custom:9090",
 			},
 		}
 
 		Merge(&c, userCfg)
 
-		if !c.Metrics.Enabled {
-			t.Error("expected Metrics.Enabled to be true")
+		if c.Metrics.ServerAddr != "custom:9090" {
+			t.Errorf("expected ServerAddr to be custom:9090, got %s", c.Metrics.ServerAddr)
 		}
 		if c.Metrics.Endpoint != "/metrics" {
 			t.Errorf("expected Endpoint to keep default, got %s", c.Metrics.Endpoint)

--- a/metrics/middleware.go
+++ b/metrics/middleware.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/alexferl/zerohttp/config"
+	zconfig "github.com/alexferl/zerohttp/internal/config"
 )
 
 // responseWriter wraps http.ResponseWriter to capture status and size.
@@ -60,30 +61,36 @@ type Middleware struct {
 }
 
 // NewMiddleware creates a new metrics middleware.
-func NewMiddleware(reg Registry, cfg config.MetricsConfig) func(http.Handler) http.Handler {
-	if !cfg.Enabled || reg == nil {
+// Uses default config if none provided, or merges user config with defaults.
+func NewMiddleware(reg Registry, cfg ...config.MetricsConfig) func(http.Handler) http.Handler {
+	if reg == nil {
 		return func(next http.Handler) http.Handler {
 			return next
 		}
 	}
 
+	c := config.DefaultMetricsConfig
+	if len(cfg) > 0 {
+		zconfig.Merge(&c, cfg[0])
+	}
+
 	excludePaths := make(map[string]struct{})
-	for _, p := range cfg.ExcludePaths {
+	for _, p := range c.ExcludePaths {
 		excludePaths[p] = struct{}{}
 	}
 
 	mm := &Middleware{
 		reg:             reg,
-		DurationBuckets: cfg.DurationBuckets,
-		SizeBuckets:     cfg.SizeBuckets,
+		DurationBuckets: c.DurationBuckets,
+		SizeBuckets:     c.SizeBuckets,
 		ExcludePaths:    excludePaths,
-		PathLabelFunc:   cfg.PathLabelFunc,
-		CustomLabels:    cfg.CustomLabels,
+		PathLabelFunc:   c.PathLabelFunc,
+		CustomLabels:    c.CustomLabels,
 	}
 
 	// Only initialize metrics immediately if CustomLabels is not set
 	// If CustomLabels is set, we'll initialize on first request when we know the label keys
-	if cfg.CustomLabels == nil {
+	if c.CustomLabels == nil {
 		mm.initMetrics(reg, nil)
 		mm.initialized = true
 	}

--- a/metrics/middleware_test.go
+++ b/metrics/middleware_test.go
@@ -10,13 +10,44 @@ import (
 	"github.com/alexferl/zerohttp/config"
 )
 
-func TestNewMiddleware_Disabled(t *testing.T) {
+func TestNewMiddleware_NoConfig(t *testing.T) {
+	// Test calling NewMiddleware with no config (uses defaults)
+	// When a registry is passed, metrics should be recorded
 	reg := NewRegistry()
-	cfg := config.MetricsConfig{Enabled: false}
+	middleware := NewMiddleware(reg)
 
-	middleware := NewMiddleware(reg, cfg)
+	called := false
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
 
-	// Middleware should return the handler as-is when disabled
+	wrapped := middleware(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+
+	wrapped.ServeHTTP(rec, req)
+
+	if !called {
+		t.Error("handler should have been called")
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	// Metrics should be recorded since we passed a registry
+	families := reg.Gather()
+	if len(families) == 0 {
+		t.Error("expected metrics to be recorded when a registry is provided")
+	}
+}
+
+func TestNewMiddleware_NilRegistry(t *testing.T) {
+	// Nil registry means metrics disabled - middleware should pass through
+	middleware := NewMiddleware(nil)
+
 	called := false
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
@@ -39,33 +70,9 @@ func TestNewMiddleware_Disabled(t *testing.T) {
 	}
 }
 
-func TestNewMiddleware_NilRegistry(t *testing.T) {
-	cfg := config.MetricsConfig{Enabled: true}
-
-	middleware := NewMiddleware(nil, cfg)
-
-	called := false
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		called = true
-		w.WriteHeader(http.StatusOK)
-	})
-
-	wrapped := middleware(handler)
-
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	rec := httptest.NewRecorder()
-
-	wrapped.ServeHTTP(rec, req)
-
-	if !called {
-		t.Error("handler should have been called")
-	}
-}
-
 func TestMiddleware_BasicRequest(t *testing.T) {
 	reg := NewRegistry()
 	cfg := config.MetricsConfig{
-		Enabled:         true,
 		Endpoint:        "/metrics",
 		DurationBuckets: []float64{0.001, 0.01, 0.1, 1},
 		SizeBuckets:     []float64{100, 1000, 10000},
@@ -115,7 +122,6 @@ func TestMiddleware_BasicRequest(t *testing.T) {
 func TestMiddleware_ExcludedPath(t *testing.T) {
 	reg := NewRegistry()
 	cfg := config.MetricsConfig{
-		Enabled:       true,
 		ExcludePaths:  []string{"/health", "/metrics"},
 		PathLabelFunc: func(p string) string { return p },
 	}
@@ -162,7 +168,6 @@ func TestMiddleware_ExcludedPath(t *testing.T) {
 func TestMiddleware_DifferentStatusCodes(t *testing.T) {
 	reg := NewRegistry()
 	cfg := config.MetricsConfig{
-		Enabled:         true,
 		DurationBuckets: []float64{0.001, 0.01, 0.1},
 		SizeBuckets:     []float64{100, 1000},
 		PathLabelFunc:   func(p string) string { return p },
@@ -222,7 +227,6 @@ func TestMiddleware_DifferentStatusCodes(t *testing.T) {
 func TestMiddleware_RequestSize(t *testing.T) {
 	reg := NewRegistry()
 	cfg := config.MetricsConfig{
-		Enabled:         true,
 		DurationBuckets: []float64{0.001, 0.01},
 		SizeBuckets:     []float64{10, 100, 1000},
 		PathLabelFunc:   func(p string) string { return p },
@@ -263,7 +267,6 @@ func TestMiddleware_RequestSize(t *testing.T) {
 func TestMiddleware_ResponseSize(t *testing.T) {
 	reg := NewRegistry()
 	cfg := config.MetricsConfig{
-		Enabled:         true,
 		DurationBuckets: []float64{0.001, 0.01},
 		SizeBuckets:     []float64{10, 100, 1000},
 		PathLabelFunc:   func(p string) string { return p },
@@ -307,7 +310,6 @@ func TestMiddleware_ResponseSize(t *testing.T) {
 func TestMiddleware_InFlightGauge(t *testing.T) {
 	reg := NewRegistry()
 	cfg := config.MetricsConfig{
-		Enabled:         true,
 		DurationBuckets: []float64{0.001},
 		SizeBuckets:     []float64{100},
 		PathLabelFunc:   func(p string) string { return p },
@@ -357,7 +359,6 @@ func TestMiddleware_InFlightGauge(t *testing.T) {
 func TestMiddleware_CustomPathLabelFunc(t *testing.T) {
 	reg := NewRegistry()
 	cfg := config.MetricsConfig{
-		Enabled:         true,
 		DurationBuckets: []float64{0.001},
 		SizeBuckets:     []float64{100},
 		PathLabelFunc: func(p string) string {
@@ -413,7 +414,6 @@ func TestMiddleware_CustomPathLabelFunc(t *testing.T) {
 func TestMiddleware_DefaultStatusCode(t *testing.T) {
 	reg := NewRegistry()
 	cfg := config.MetricsConfig{
-		Enabled:         true,
 		DurationBuckets: []float64{0.001},
 		SizeBuckets:     []float64{100},
 		PathLabelFunc:   func(p string) string { return p },
@@ -513,7 +513,6 @@ func TestResponseWriter_WriteSetsDefaultStatus(t *testing.T) {
 func TestMiddleware_MultipleMethods(t *testing.T) {
 	reg := NewRegistry()
 	cfg := config.MetricsConfig{
-		Enabled:         true,
 		DurationBuckets: []float64{0.001},
 		SizeBuckets:     []float64{100},
 		PathLabelFunc:   func(p string) string { return p },
@@ -568,7 +567,6 @@ func TestMiddleware_Router404And405(t *testing.T) {
 	// Create a real zerohttp router to test 404/405 handling
 	reg := NewRegistry()
 	cfg := config.MetricsConfig{
-		Enabled:         true,
 		DurationBuckets: []float64{0.001, 0.01, 0.1},
 		SizeBuckets:     []float64{100, 1000},
 		PathLabelFunc:   func(p string) string { return p },
@@ -653,7 +651,6 @@ func TestMiddleware_Router404And405(t *testing.T) {
 func TestMiddleware_NotFound(t *testing.T) {
 	reg := NewRegistry()
 	cfg := config.MetricsConfig{
-		Enabled:         true,
 		DurationBuckets: []float64{0.001},
 		SizeBuckets:     []float64{100},
 		PathLabelFunc:   func(p string) string { return p },
@@ -715,7 +712,6 @@ func TestMiddleware_NotFound(t *testing.T) {
 func TestMiddleware_CustomLabels(t *testing.T) {
 	reg := NewRegistry()
 	cfg := config.MetricsConfig{
-		Enabled:         true,
 		DurationBuckets: []float64{0.001},
 		SizeBuckets:     []float64{100},
 		PathLabelFunc:   func(p string) string { return p },
@@ -782,7 +778,6 @@ func TestMiddleware_CustomLabels(t *testing.T) {
 func TestMiddleware_PanicRecords500(t *testing.T) {
 	reg := NewRegistry()
 	cfg := config.MetricsConfig{
-		Enabled:         true,
 		DurationBuckets: []float64{0.001, 0.01, 0.1},
 		SizeBuckets:     []float64{100, 1000},
 		PathLabelFunc:   func(p string) string { return p },
@@ -840,7 +835,6 @@ func TestMiddleware_PanicRecords500(t *testing.T) {
 func TestMiddleware_RegistryInContext(t *testing.T) {
 	reg := NewRegistry()
 	cfg := config.MetricsConfig{
-		Enabled:         true,
 		DurationBuckets: []float64{0.001},
 		SizeBuckets:     []float64{100},
 		PathLabelFunc:   func(p string) string { return p },

--- a/middleware/basic_auth_test.go
+++ b/middleware/basic_auth_test.go
@@ -291,7 +291,7 @@ func TestBasicAuth_Metrics(t *testing.T) {
 
 	// Wrap with metrics middleware to provide registry in context
 	metricsMw := metrics.NewMiddleware(reg, config.MetricsConfig{
-		Enabled:       true,
+		Enabled:       config.Bool(true),
 		PathLabelFunc: func(p string) string { return p },
 	})
 	wrapped := metricsMw(mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -730,7 +730,7 @@ func TestCompress_Metrics(t *testing.T) {
 	})
 
 	metricsMw := metrics.NewMiddleware(reg, config.MetricsConfig{
-		Enabled:       true,
+		Enabled:       config.Bool(true),
 		PathLabelFunc: func(p string) string { return p },
 	})
 

--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -360,7 +360,7 @@ func TestCORS_Metrics(t *testing.T) {
 	})
 
 	metricsMw := metrics.NewMiddleware(reg, config.MetricsConfig{
-		Enabled:       true,
+		Enabled:       config.Bool(true),
 		PathLabelFunc: func(p string) string { return p },
 	})
 

--- a/middleware/csrf_test.go
+++ b/middleware/csrf_test.go
@@ -876,7 +876,7 @@ func TestCSRF_Metrics(t *testing.T) {
 
 	// Wrap with metrics middleware to provide registry in context
 	metricsMw := metrics.NewMiddleware(reg, config.MetricsConfig{
-		Enabled:       true,
+		Enabled:       config.Bool(true),
 		PathLabelFunc: func(p string) string { return p },
 	})
 	wrapped := metricsMw(mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -941,7 +941,7 @@ func TestCSRF_TokenGenerationFailsClosed(t *testing.T) {
 
 	// Wrap with metrics middleware to provide registry in context
 	metricsMw := metrics.NewMiddleware(reg, config.MetricsConfig{
-		Enabled:       true,
+		Enabled:       config.Bool(true),
 		PathLabelFunc: func(p string) string { return p },
 	})
 	wrapped := metricsMw(mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1000,7 +1000,7 @@ func TestCSRF_TokenGenerationFailsClosed_POST(t *testing.T) {
 
 	// Wrap with metrics middleware to provide registry in context
 	metricsMw := metrics.NewMiddleware(reg, config.MetricsConfig{
-		Enabled:       true,
+		Enabled:       config.Bool(true),
 		PathLabelFunc: func(p string) string { return p },
 	})
 	wrapped := metricsMw(mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/middleware/etag_test.go
+++ b/middleware/etag_test.go
@@ -1240,7 +1240,7 @@ func TestETag_Metrics(t *testing.T) {
 
 	// Wrap with metrics middleware to provide registry in context
 	metricsMw := metrics.NewMiddleware(reg, config.MetricsConfig{
-		Enabled:       true,
+		Enabled:       config.Bool(true),
 		PathLabelFunc: func(p string) string { return p },
 	})
 

--- a/middleware/jwt_auth_test.go
+++ b/middleware/jwt_auth_test.go
@@ -2075,7 +2075,7 @@ func TestJWTAuth_Metrics(t *testing.T) {
 
 	// Wrap with metrics middleware to provide registry in context
 	metricsMw := metrics.NewMiddleware(reg, config.MetricsConfig{
-		Enabled:       true,
+		Enabled:       config.Bool(true),
 		PathLabelFunc: func(p string) string { return p },
 	})
 	wrapped := metricsMw(mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/middleware/rate_limit_test.go
+++ b/middleware/rate_limit_test.go
@@ -326,7 +326,7 @@ func TestRateLimit_Metrics(t *testing.T) {
 
 	// Wrap with metrics middleware to provide registry in context
 	metricsMw := metrics.NewMiddleware(reg, config.MetricsConfig{
-		Enabled:       true,
+		Enabled:       config.Bool(true),
 		PathLabelFunc: func(p string) string { return p },
 	})
 	wrapped := metricsMw(mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/middleware/recover_test.go
+++ b/middleware/recover_test.go
@@ -354,7 +354,7 @@ func TestRecover_Metrics(t *testing.T) {
 
 	// Wrap with metrics middleware to provide registry in context
 	metricsMw := metrics.NewMiddleware(reg, config.MetricsConfig{
-		Enabled:       true,
+		Enabled:       config.Bool(true),
 		PathLabelFunc: func(p string) string { return p },
 	})
 	wrapped := metricsMw(mw(panicHandler("test panic")))

--- a/middleware/request_body_size_test.go
+++ b/middleware/request_body_size_test.go
@@ -215,7 +215,7 @@ func TestRequestBodySize_Metrics(t *testing.T) {
 	mw := RequestBodySize(config.RequestBodySizeConfig{MaxBytes: 10})
 
 	metricsMw := metrics.NewMiddleware(reg, config.MetricsConfig{
-		Enabled:       true,
+		Enabled:       config.Bool(true),
 		PathLabelFunc: func(p string) string { return p },
 	})
 

--- a/middleware/timeout_test.go
+++ b/middleware/timeout_test.go
@@ -225,7 +225,7 @@ func TestTimeout_Metrics(t *testing.T) {
 
 	// Wrap with metrics middleware to provide registry in context
 	metricsMw := metrics.NewMiddleware(reg, config.MetricsConfig{
-		Enabled:       true,
+		Enabled:       config.Bool(true),
 		PathLabelFunc: func(p string) string { return p },
 	})
 	timeoutMw := Timeout(config.TimeoutConfig{Timeout: 50 * time.Millisecond})

--- a/pprof/doc.go
+++ b/pprof/doc.go
@@ -8,7 +8,7 @@
 // Use the default configuration:
 //
 //	app := zh.New()
-//	pp := pprof.New(app, pprof.DefaultConfig)
+//	pp := pprof.New(app)
 //	log.Printf("pprof credentials: %s / %s", pp.Auth.Username, pp.Auth.Password)
 //
 // Access profiles at http://localhost:8080/debug/pprof/
@@ -17,6 +17,12 @@
 //
 // Customize endpoints or provide explicit credentials:
 //
+//	// Override specific fields (uses defaults for rest)
+//	pprof.New(app, pprof.Config{
+//	    Prefix: "/admin/pprof",
+//	})
+//
+//	// Full custom config
 //	pprof.New(app, pprof.Config{
 //	    Prefix: "/debug/pprof",
 //	    Auth: &pprof.AuthConfig{

--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -9,7 +9,9 @@ import (
 	"strings"
 
 	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
 	"github.com/alexferl/zerohttp/httpx"
+	zconfig "github.com/alexferl/zerohttp/internal/config"
 	"github.com/alexferl/zerohttp/log"
 )
 
@@ -29,44 +31,54 @@ type Config struct {
 	Prefix string
 
 	// EnableIndex enables the index page listing all profiles
-	// Default: true
-	EnableIndex bool
+	// nil = use default (true)
+	// Default: nil
+	EnableIndex *bool
 
 	// EnableCmdline enables the cmdline endpoint
-	// Default: true
-	EnableCmdline bool
+	// nil = use default (true)
+	// Default: nil
+	EnableCmdline *bool
 
 	// EnableProfile enables the CPU profile endpoint
-	// Default: true
-	EnableProfile bool
+	// nil = use default (true)
+	// Default: nil
+	EnableProfile *bool
 
 	// EnableSymbol enables the symbol endpoint
-	// Default: true
-	EnableSymbol bool
+	// nil = use default (true)
+	// Default: nil
+	EnableSymbol *bool
 
 	// EnableTrace enables the trace endpoint
-	// Default: true
-	EnableTrace bool
+	// nil = use default (true)
+	// Default: nil
+	EnableTrace *bool
 
 	// EnableHeap enables the heap profile endpoint
-	// Default: true
-	EnableHeap bool
+	// nil = use default (true)
+	// Default: nil
+	EnableHeap *bool
 
 	// EnableGoroutine enables the goroutine profile endpoint
-	// Default: true
-	EnableGoroutine bool
+	// nil = use default (true)
+	// Default: nil
+	EnableGoroutine *bool
 
 	// EnableThreadCreate enables the threadcreate profile endpoint
-	// Default: true
-	EnableThreadCreate bool
+	// nil = use default (true)
+	// Default: nil
+	EnableThreadCreate *bool
 
 	// EnableBlock enables the block profile endpoint
-	// Default: true
-	EnableBlock bool
+	// nil = use default (true)
+	// Default: nil
+	EnableBlock *bool
 
 	// EnableMutex enables the mutex profile endpoint
-	// Default: true
-	EnableMutex bool
+	// nil = use default (true)
+	// Default: nil
+	EnableMutex *bool
 
 	// Auth is the basic auth configuration.
 	// If nil, a random password will be generated.
@@ -96,43 +108,57 @@ type AuthConfig struct {
 // Modify this to change system-wide defaults.
 var DefaultConfig = Config{
 	Prefix:             "/debug/pprof",
-	EnableIndex:        true,
-	EnableCmdline:      true,
-	EnableProfile:      true,
-	EnableSymbol:       true,
-	EnableTrace:        true,
-	EnableHeap:         true,
-	EnableGoroutine:    true,
-	EnableThreadCreate: true,
-	EnableBlock:        true,
-	EnableMutex:        true,
+	EnableIndex:        config.Bool(true),
+	EnableCmdline:      config.Bool(true),
+	EnableProfile:      config.Bool(true),
+	EnableSymbol:       config.Bool(true),
+	EnableTrace:        config.Bool(true),
+	EnableHeap:         config.Bool(true),
+	EnableGoroutine:    config.Bool(true),
+	EnableThreadCreate: config.Bool(true),
+	EnableBlock:        config.Bool(true),
+	EnableMutex:        config.Bool(true),
 	Auth:               nil,
 	AllowedIPs:         []string{"127.0.0.1/8", "::1/128"}, // localhost only by default
 }
 
 // New creates and registers all pprof endpoints with the provided configuration.
+// Uses DefaultConfig if no config is provided, or merges user config with defaults.
 // Returns a PProf struct containing the configuration and actual auth credentials used.
 //
-// Use DefaultConfig for default values:
+// Examples:
 //
-//	pp := pprof.New(app, pprof.DefaultConfig)
+//	// Use defaults
+//	pp := pprof.New(app)
 //	// Access auto-generated credentials:
 //	// pp.Auth.Username, pp.Auth.Password
 //
-// Or customize specific fields:
+//	// Override specific fields
+//	pp := pprof.New(app, pprof.Config{
+//	    Prefix: "/admin/pprof",
+//	})
 //
-//	cfg := pprof.DefaultConfig
-//	cfg.Prefix = "/admin/pprof"
-//	pp := pprof.New(app, cfg)
+//	// Full custom config
+//	pp := pprof.New(app, pprof.Config{
+//	    Prefix:             "/debug/pprof",
+//	    EnableIndex:        true,
+//	    EnableCmdline:      true,
+//	    Auth:               &pprof.AuthConfig{Username: "admin", Password: "secret"},
+//	    AllowedIPs:         []string{"127.0.0.1/8", "::1/128"},
+//	})
 //
-// To disable authentication:
-//
-//	cfg := pprof.DefaultConfig
-//	cfg.Auth = &pprof.AuthConfig{}  // empty = no auth
-//	pp := pprof.New(app, cfg)
-func New(app *zh.Server, cfg Config) *PProf {
-	prefix := cfg.Prefix
-	auth := cfg.Auth
+//	// Disable authentication
+//	pp := pprof.New(app, pprof.Config{
+//	    Auth: &pprof.AuthConfig{},  // empty = no auth
+//	})
+func New(app *zh.Server, cfg ...Config) *PProf {
+	c := DefaultConfig
+	if len(cfg) > 0 {
+		zconfig.Merge(&c, cfg[0])
+	}
+
+	prefix := c.Prefix
+	auth := c.Auth
 	logger := app.Logger()
 
 	if auth == nil {
@@ -149,7 +175,7 @@ func New(app *zh.Server, cfg Config) *PProf {
 	}
 
 	// Parse allowed IPs (nil means use default localhost-only)
-	allowedIPs := cfg.AllowedIPs
+	allowedIPs := c.AllowedIPs
 	if allowedIPs == nil {
 		allowedIPs = []string{"127.0.0.1/8", "::1/128"}
 	}
@@ -167,7 +193,7 @@ func New(app *zh.Server, cfg Config) *PProf {
 	}
 
 	pp := &PProf{
-		Config: cfg,
+		Config: c,
 		Auth:   auth,
 	}
 
@@ -194,35 +220,35 @@ func New(app *zh.Server, cfg Config) *PProf {
 		return handler
 	}
 
-	if cfg.EnableIndex {
+	if config.BoolOrDefault(c.EnableIndex, true) {
 		app.GET(prefix+"/", wrapFunc(stdpprof.Index))
 	}
-	if cfg.EnableCmdline {
+	if config.BoolOrDefault(c.EnableCmdline, true) {
 		app.GET(prefix+"/cmdline", wrapFunc(stdpprof.Cmdline))
 	}
-	if cfg.EnableProfile {
+	if config.BoolOrDefault(c.EnableProfile, true) {
 		app.GET(prefix+"/profile", wrapFunc(stdpprof.Profile))
 	}
-	if cfg.EnableSymbol {
+	if config.BoolOrDefault(c.EnableSymbol, true) {
 		app.GET(prefix+"/symbol", wrapFunc(stdpprof.Symbol))
 		app.POST(prefix+"/symbol", wrapFunc(stdpprof.Symbol))
 	}
-	if cfg.EnableTrace {
+	if config.BoolOrDefault(c.EnableTrace, true) {
 		app.GET(prefix+"/trace", wrapFunc(stdpprof.Trace))
 	}
-	if cfg.EnableHeap {
+	if config.BoolOrDefault(c.EnableHeap, true) {
 		app.GET(prefix+"/heap", wrapHandler(stdpprof.Handler("heap")))
 	}
-	if cfg.EnableGoroutine {
+	if config.BoolOrDefault(c.EnableGoroutine, true) {
 		app.GET(prefix+"/goroutine", wrapHandler(stdpprof.Handler("goroutine")))
 	}
-	if cfg.EnableThreadCreate {
+	if config.BoolOrDefault(c.EnableThreadCreate, true) {
 		app.GET(prefix+"/threadcreate", wrapHandler(stdpprof.Handler("threadcreate")))
 	}
-	if cfg.EnableBlock {
+	if config.BoolOrDefault(c.EnableBlock, true) {
 		app.GET(prefix+"/block", wrapHandler(stdpprof.Handler("block")))
 	}
-	if cfg.EnableMutex {
+	if config.BoolOrDefault(c.EnableMutex, true) {
 		app.GET(prefix+"/mutex", wrapHandler(stdpprof.Handler("mutex")))
 	}
 

--- a/pprof/pprof_test.go
+++ b/pprof/pprof_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
 )
 
 // setupPProf creates a test server with pprof endpoints and returns the server and pprof instance.
@@ -80,38 +81,92 @@ func makeRequestFromIP(t *testing.T, app *zh.Server, method, path, clientIP, use
 	return rec
 }
 
+func TestNewWithNoConfig(t *testing.T) {
+	// Test calling New without any config (uses defaults)
+	app := zh.New()
+	pp := New(app)
+
+	if pp == nil {
+		t.Fatal("expected PProf instance, got nil")
+	}
+
+	if pp.Config.Prefix != "/debug/pprof" {
+		t.Errorf("expected prefix '/debug/pprof', got '%s'", pp.Config.Prefix)
+	}
+
+	if pp.Auth == nil {
+		t.Fatal("expected Auth to be auto-generated")
+	}
+
+	if pp.Auth.Username != "pprof" {
+		t.Errorf("expected default username 'pprof', got '%s'", pp.Auth.Username)
+	}
+}
+
+func TestNewWithPartialConfig(t *testing.T) {
+	// Test partial config merging with defaults
+	app := zh.New()
+
+	// Only override prefix, rest should use defaults
+	pp := New(app, Config{
+		Prefix: "/custom/pprof",
+	})
+
+	if pp.Config.Prefix != "/custom/pprof" {
+		t.Errorf("expected prefix '/custom/pprof', got '%s'", pp.Config.Prefix)
+	}
+
+	// Auth should still be auto-generated (nil in partial config = use default behavior)
+	if pp.Auth == nil {
+		t.Fatal("expected Auth to be auto-generated")
+	}
+
+	// Other fields should use defaults
+	if !*pp.Config.EnableIndex {
+		t.Error("expected EnableIndex to be true from defaults")
+	}
+
+	if !*pp.Config.EnableHeap {
+		t.Error("expected EnableHeap to be true from defaults")
+	}
+
+	if len(pp.Config.AllowedIPs) != 2 {
+		t.Errorf("expected 2 allowed IPs from defaults, got %d", len(pp.Config.AllowedIPs))
+	}
+}
+
 func TestDefaultConfig(t *testing.T) {
 	if DefaultConfig.Prefix != "/debug/pprof" {
 		t.Errorf("expected prefix '/debug/pprof', got '%s'", DefaultConfig.Prefix)
 	}
-	if !DefaultConfig.EnableIndex {
+	if !config.BoolOrDefault(DefaultConfig.EnableIndex, false) {
 		t.Error("expected EnableIndex to be true")
 	}
-	if !DefaultConfig.EnableCmdline {
+	if !config.BoolOrDefault(DefaultConfig.EnableCmdline, false) {
 		t.Error("expected EnableCmdline to be true")
 	}
-	if !DefaultConfig.EnableProfile {
+	if !config.BoolOrDefault(DefaultConfig.EnableProfile, false) {
 		t.Error("expected EnableProfile to be true")
 	}
-	if !DefaultConfig.EnableSymbol {
+	if !config.BoolOrDefault(DefaultConfig.EnableSymbol, false) {
 		t.Error("expected EnableSymbol to be true")
 	}
-	if !DefaultConfig.EnableTrace {
+	if !config.BoolOrDefault(DefaultConfig.EnableTrace, false) {
 		t.Error("expected EnableTrace to be true")
 	}
-	if !DefaultConfig.EnableHeap {
+	if !config.BoolOrDefault(DefaultConfig.EnableHeap, false) {
 		t.Error("expected EnableHeap to be true")
 	}
-	if !DefaultConfig.EnableGoroutine {
+	if !config.BoolOrDefault(DefaultConfig.EnableGoroutine, false) {
 		t.Error("expected EnableGoroutine to be true")
 	}
-	if !DefaultConfig.EnableThreadCreate {
+	if !config.BoolOrDefault(DefaultConfig.EnableThreadCreate, false) {
 		t.Error("expected EnableThreadCreate to be true")
 	}
-	if !DefaultConfig.EnableBlock {
+	if !config.BoolOrDefault(DefaultConfig.EnableBlock, false) {
 		t.Error("expected EnableBlock to be true")
 	}
-	if !DefaultConfig.EnableMutex {
+	if !config.BoolOrDefault(DefaultConfig.EnableMutex, false) {
 		t.Error("expected EnableMutex to be true")
 	}
 	if DefaultConfig.Auth != nil {
@@ -174,8 +229,8 @@ func TestNewWithAuth(t *testing.T) {
 
 func TestNewWithDisabledEndpoints(t *testing.T) {
 	cfg := DefaultConfig
-	cfg.EnableIndex = false
-	cfg.EnableCmdline = false
+	cfg.EnableIndex = config.Bool(false)
+	cfg.EnableCmdline = config.Bool(false)
 	app, _ := setupPProf(t, &cfg)
 
 	// Test disabled index endpoint

--- a/server.go
+++ b/server.go
@@ -166,7 +166,7 @@ type Server struct {
 //	    WriteTimeout: 15 * time.Second,
 //	    Logger:       myLogger,
 //	    Metrics: config.MetricsConfig{
-//	        Enabled: false, // Disable metrics
+//	        Enabled: config.Bool(false), // Disable metrics
 //	    },
 //	})
 //
@@ -205,7 +205,7 @@ func New(cfg ...config.Config) *Server {
 		sseProvider:        c.Extensions.SSEProvider,
 		metricsRegistry:    registry,
 		metricsServer:      metricsServer,
-		metricsServerAddr:  c.Metrics.ServerAddr,
+		metricsServerAddr:  config.StringOrDefault(c.Metrics.ServerAddr, ""),
 		validator:          c.Validator,
 		logger:             logger,
 		preStartupHooks:    c.Lifecycle.PreStartupHooks,
@@ -745,7 +745,9 @@ func mergeConfig(cfg ...config.Config) config.Config {
 		zconfig.Merge(&c, userCfg)
 		// Handle fields that must always be copied (even if zero value)
 		// ServerAddr can be set to empty string to disable separate metrics server
-		c.Metrics.ServerAddr = userCfg.Metrics.ServerAddr
+		if userCfg.Metrics.ServerAddr != nil {
+			c.Metrics.ServerAddr = userCfg.Metrics.ServerAddr
+		}
 	}
 	return c
 }
@@ -806,24 +808,40 @@ func needsTLSServer(c config.Config) bool {
 
 // createMetricsRegistry creates metrics registry if enabled.
 func createMetricsRegistry(c config.Config) metrics.Registry {
-	if c.Metrics.Enabled {
-		return metrics.NewRegistry()
-	}
-	return nil
-}
-
-// createMetricsServer creates a separate metrics server if ServerAddr is set.
-func createMetricsServer(c config.Config, registry metrics.Registry) *http.Server {
-	if !c.Metrics.Enabled || registry == nil || c.Metrics.ServerAddr == "" {
+	if c.Metrics.Enabled != nil && !*c.Metrics.Enabled {
 		return nil
 	}
+	return metrics.NewRegistry()
+}
+
+// createMetricsServer creates a separate metrics server if ServerAddr indicates a separate server.
+// Returns nil if ServerAddr is empty (metrics on main server) or metrics disabled.
+func createMetricsServer(c config.Config, registry metrics.Registry) *http.Server {
+	if registry == nil {
+		return nil
+	}
+	serverAddr := config.StringOrDefault(c.Metrics.ServerAddr, "localhost:9090")
+	if serverAddr == "" {
+		return nil // Metrics on main server, not a separate server
+	}
+
+	metricsHandler := metrics.Handler(registry)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Only serve metrics on the configured endpoint
+		if r.URL.Path != c.Metrics.Endpoint {
+			http.NotFound(w, r)
+			return
+		}
+		metricsHandler.ServeHTTP(w, r)
+	})
+
 	return &http.Server{
-		Addr:              c.Metrics.ServerAddr,
+		Addr:              serverAddr,
 		ReadTimeout:       DefaultReadTimeout,
 		ReadHeaderTimeout: DefaultReadHeaderTimeout,
 		WriteTimeout:      DefaultWriteTimeout,
 		IdleTimeout:       DefaultIdleTimeout,
-		Handler:           metrics.Handler(registry),
+		Handler:           handler,
 	}
 }
 
@@ -833,7 +851,7 @@ func setupMiddleware(s *Server, c config.Config, registry metrics.Registry) {
 
 	// Add metrics middleware first so it will be innermost after reverse,
 	// running inside Recover and able to capture status codes written by other middleware
-	if c.Metrics.Enabled && registry != nil {
+	if registry != nil {
 		middlewares = append(middlewares, metrics.NewMiddleware(registry, c.Metrics))
 	}
 
@@ -871,7 +889,12 @@ func setupServerHandlers(s *Server, router Router) {
 
 // registerMetricsEndpoint registers the metrics endpoint on the main router if needed.
 func registerMetricsEndpoint(s *Server, c config.Config, registry metrics.Registry) {
-	if c.Metrics.Enabled && registry != nil && c.Metrics.ServerAddr == "" {
+	// Register on main server only if ServerAddr is explicitly set to empty string
+	serverAddr := ""
+	if c.Metrics.ServerAddr != nil {
+		serverAddr = *c.Metrics.ServerAddr
+	}
+	if registry != nil && c.Metrics.ServerAddr != nil && serverAddr == "" {
 		s.logger.Warn("Metrics endpoint registered on main server (set Metrics.ServerAddr to isolate)", log.F("endpoint", c.Metrics.Endpoint))
 		s.GET(c.Metrics.Endpoint, metrics.Handler(registry))
 	}

--- a/server_metrics_test.go
+++ b/server_metrics_test.go
@@ -13,6 +13,75 @@ import (
 	"github.com/alexferl/zerohttp/config"
 )
 
+// TestServer_MetricsServerAddrDefault verifies that ServerAddr defaults to localhost:9090
+// when metrics are enabled but ServerAddr is not explicitly set (nil).
+func TestServer_MetricsServerAddrDefault(t *testing.T) {
+	// Get available port for main server
+	mainListener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to create main listener: %v", err)
+	}
+	mainAddr := mainListener.Addr().String()
+	if err := mainListener.Close(); err != nil {
+		t.Fatalf("failed to close main listener: %v", err)
+	}
+
+	srv := New(config.Config{
+		Addr:    mainAddr,
+		Metrics: config.MetricsConfig{
+			// ServerAddr not set (nil) - should default to localhost:9090
+		},
+	})
+
+	// Verify metrics addr is the default
+	addr := srv.MetricsAddr()
+	if addr != "localhost:9090" {
+		t.Errorf("expected metrics addr to default to localhost:9090, got %s", addr)
+	}
+}
+
+// TestServer_MetricsExplicitEmptyServerAddr verifies that explicitly setting ServerAddr to empty
+// string (via config.String("")) serves metrics on the main server.
+func TestServer_MetricsExplicitEmptyServerAddr(t *testing.T) {
+	srv := New(config.Config{
+		Metrics: config.MetricsConfig{
+			ServerAddr: config.String(""), // Explicitly empty - use main server
+		},
+	})
+
+	// Register a test route
+	srv.GET("/test", HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return R.JSON(w, http.StatusOK, M{"ok": true})
+	}))
+
+	// Create test server
+	server := httptest.NewServer(srv)
+	defer server.Close()
+
+	// Make a request
+	resp, err := http.Get(server.URL + "/test")
+	if err != nil {
+		t.Fatalf("failed to make request: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	// Metrics should be on main server
+	resp, err = http.Get(server.URL + "/metrics")
+	if err != nil {
+		t.Fatalf("failed to get metrics: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("expected metrics on main server to return 200, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "http_requests_total") {
+		t.Error("metrics should contain http_requests_total")
+	}
+}
+
 // TestServer_MetricsDedicatedServer verifies that a dedicated metrics server starts
 // on the configured address when ServerAddr is set.
 func TestServer_MetricsDedicatedServer(t *testing.T) {
@@ -38,8 +107,7 @@ func TestServer_MetricsDedicatedServer(t *testing.T) {
 	srv := New(config.Config{
 		Addr: mainAddr,
 		Metrics: config.MetricsConfig{
-			Enabled:    true,
-			ServerAddr: metricsAddr,
+			ServerAddr: config.String(metricsAddr),
 			Endpoint:   "/metrics",
 		},
 	})
@@ -98,7 +166,7 @@ func TestServer_MetricsDedicatedServer(t *testing.T) {
 func TestServer_MetricsAddr_NoServer(t *testing.T) {
 	srv := New(config.Config{
 		Metrics: config.MetricsConfig{
-			Enabled: false,
+			Enabled: config.Bool(false),
 		},
 	})
 
@@ -133,8 +201,7 @@ func TestServer_MetricsDedicatedServerNotExposedOnMainServer(t *testing.T) {
 	srv := New(config.Config{
 		Addr: mainAddr,
 		Metrics: config.MetricsConfig{
-			Enabled:    true,
-			ServerAddr: metricsAddr,
+			ServerAddr: config.String(metricsAddr),
 			Endpoint:   "/metrics",
 		},
 	})
@@ -261,7 +328,7 @@ func TestServer_RequestContextCancellation(t *testing.T) {
 func TestServer_MetricsRecordsErrors(t *testing.T) {
 	app := New(config.Config{
 		Metrics: config.MetricsConfig{
-			Enabled: true,
+			ServerAddr: config.String(""), // Empty to use main server for metrics
 		},
 	})
 
@@ -354,7 +421,7 @@ func TestServer_MetricsRecordsErrors(t *testing.T) {
 func TestServer_MetricsRecordsPanic(t *testing.T) {
 	app := New(config.Config{
 		Metrics: config.MetricsConfig{
-			Enabled: true,
+			ServerAddr: config.String(""), // Empty to use main server for metrics
 		},
 	})
 


### PR DESCRIPTION
- healthcheck: New() now uses variadic cfg ...Config with config.Merge()
- metrics: NewMiddleware() uses variadic config, Enabled changed to *bool
- pprof: New() uses variadic config, all Enable* fields changed to *bool
- config: add BoolOrDefault() helper for *bool dereferencing
- server: fix metrics ServerAddr defaulting and path routing bugs
- tests: update all *bool field usages to use config.Bool()