### PR TITLE
fix: SSE streaming, metrics defaults, and 404/405 responses

### DIFF
--- a/internal/rwutil/response_writer.go
+++ b/internal/rwutil/response_writer.go
@@ -52,6 +52,14 @@ func (rw *ResponseWriter) HeaderWritten() bool {
 	return rw.headerWritten
 }
 
+// Flush implements http.Flusher to support streaming responses like SSE.
+// If the underlying ResponseWriter does not support flushing, this is a no-op.
+func (rw *ResponseWriter) Flush() {
+	if f, ok := rw.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 // FlusherResponseWriter wraps ResponseWriter and implements http.Flusher.
 // Use this when the underlying ResponseWriter may support flushing.
 type FlusherResponseWriter struct {
@@ -84,5 +92,6 @@ func (frw *FlusherResponseWriter) Flush() {
 // Ensure interface compliance at compile time.
 var (
 	_ http.ResponseWriter = (*ResponseWriter)(nil)
+	_ http.Flusher        = (*ResponseWriter)(nil)
 	_ http.Flusher        = (*FlusherResponseWriter)(nil)
 )

--- a/internal/rwutil/response_writer_test.go
+++ b/internal/rwutil/response_writer_test.go
@@ -6,6 +6,16 @@ import (
 	"testing"
 )
 
+// flusherRecorder is a test ResponseWriter that implements http.Flusher
+type flusherRecorder struct {
+	*httptest.ResponseRecorder
+	flushed bool
+}
+
+func (f *flusherRecorder) Flush() {
+	f.flushed = true
+}
+
 func TestNewResponseWriter(t *testing.T) {
 	rec := httptest.NewRecorder()
 	rw := NewResponseWriter(rec)
@@ -134,5 +144,79 @@ func TestFlusherResponseWriter_Flush(t *testing.T) {
 	// The recorder should have the data
 	if rec.Body.String() != "data" {
 		t.Errorf("expected body %q, got %q", "data", rec.Body.String())
+	}
+}
+
+func TestResponseWriter_Flush(t *testing.T) {
+	tests := []struct {
+		name              string
+		underlyingFlusher bool
+		expectFlushCalled bool
+	}{
+		{
+			name:              "flush passes through to underlying Flusher",
+			underlyingFlusher: true,
+			expectFlushCalled: true,
+		},
+		{
+			name:              "flush no-op when underlying doesn't implement Flusher",
+			underlyingFlusher: false,
+			expectFlushCalled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var base http.ResponseWriter
+			var flushCalled *bool
+
+			if tt.underlyingFlusher {
+				rec := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+				base = rec
+				flushCalled = &rec.flushed
+			} else {
+				rec := httptest.NewRecorder()
+				base = rec
+				flushCalled = new(bool)
+			}
+
+			// Wrap with ResponseWriter
+			rw := NewResponseWriter(base)
+
+			// Call Flush
+			rw.Flush()
+
+			if *flushCalled != tt.expectFlushCalled {
+				t.Errorf("expected flush called=%v, got=%v", tt.expectFlushCalled, *flushCalled)
+			}
+		})
+	}
+}
+
+func TestResponseWriter_Flush_SupportsSSE(t *testing.T) {
+	rec := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+
+	// Wrap with ResponseWriter
+	rw := NewResponseWriter(rec)
+
+	// Verify it implements Flusher
+	var f http.Flusher
+	f, ok := interface{}(rw).(http.Flusher)
+	if !ok {
+		t.Fatal("expected ResponseWriter to implement http.Flusher")
+	}
+
+	// Write and flush like SSE would
+	rw.Header().Set("Content-Type", "text/event-stream")
+	rw.WriteHeader(http.StatusOK)
+	_, _ = rw.Write([]byte("data: hello\n\n"))
+	f.Flush()
+
+	if !rec.flushed {
+		t.Error("expected Flush to be called on underlying ResponseWriter")
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
 	}
 }

--- a/metrics/middleware.go
+++ b/metrics/middleware.go
@@ -34,6 +34,13 @@ func (w *responseWriter) Write(b []byte) (int, error) {
 	return n, err
 }
 
+// Flush implements http.Flusher to support streaming responses like SSE.
+func (w *responseWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 // labelSet holds pre-allocated label slices to avoid allocations per request.
 type labelSet struct {
 	inFlight  []string

--- a/metrics/middleware_test.go
+++ b/metrics/middleware_test.go
@@ -10,6 +10,16 @@ import (
 	"github.com/alexferl/zerohttp/config"
 )
 
+// flusherRecorder is a test ResponseWriter that implements http.Flusher
+type flusherRecorder struct {
+	*httptest.ResponseRecorder
+	flushed bool
+}
+
+func (f *flusherRecorder) Flush() {
+	f.flushed = true
+}
+
 func TestNewMiddleware_NoConfig(t *testing.T) {
 	// Test calling NewMiddleware with no config (uses defaults)
 	// When a registry is passed, metrics should be recorded
@@ -861,5 +871,89 @@ func TestMiddleware_RegistryInContext(t *testing.T) {
 
 	if ctxRegistry != reg {
 		t.Error("expected context registry to be the same as the one passed to middleware")
+	}
+}
+
+func TestMiddleware_responseWriter_Flush(t *testing.T) {
+	tests := []struct {
+		name              string
+		underlyingFlusher bool
+		expectFlushCalled bool
+	}{
+		{
+			name:              "flush passes through to underlying Flusher",
+			underlyingFlusher: true,
+			expectFlushCalled: true,
+		},
+		{
+			name:              "flush no-op when underlying doesn't implement Flusher",
+			underlyingFlusher: false,
+			expectFlushCalled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var base http.ResponseWriter
+			var flushCalled *bool
+
+			if tt.underlyingFlusher {
+				rec := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+				base = rec
+				flushCalled = &rec.flushed
+			} else {
+				rec := httptest.NewRecorder()
+				base = rec
+				flushCalled = new(bool)
+			}
+
+			// Wrap with responseWriter
+			rw := &responseWriter{
+				ResponseWriter: base,
+			}
+
+			// Call Flush
+			rw.Flush()
+
+			if *flushCalled != tt.expectFlushCalled {
+				t.Errorf("expected flush called=%v, got=%v", tt.expectFlushCalled, *flushCalled)
+			}
+		})
+	}
+}
+
+func TestMiddleware_responseWriter_Flush_SupportsSSE(t *testing.T) {
+	rec := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+
+	reg := NewRegistry()
+	middleware := NewMiddleware(reg, config.MetricsConfig{
+		Enabled:       config.Bool(true),
+		PathLabelFunc: func(p string) string { return p },
+	})
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Try to get a Flusher from the writer
+		f, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("expected ResponseWriter to implement http.Flusher")
+			return
+		}
+
+		// Write and flush like SSE would
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: hello\n\n"))
+		f.Flush()
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	handler.ServeHTTP(rec, req)
+
+	if !rec.flushed {
+		t.Error("expected Flush to be called on underlying ResponseWriter")
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
 	}
 }

--- a/middleware/rate_limit.go
+++ b/middleware/rate_limit.go
@@ -54,7 +54,10 @@ func RateLimit(cfg ...config.RateLimitConfig) func(http.Handler) http.Handler {
 			now := time.Now()
 			allowed, remaining, resetTime := store.CheckAndRecord(r.Context(), key, now)
 
-			if c.IncludeHeaders {
+			// Skip headers for SSE connections to avoid interfering with streaming responses
+			isSSE := r.Header.Get(httpx.HeaderAccept) == httpx.MIMETextEventStream
+
+			if c.IncludeHeaders && !isSSE {
 				w.Header().Set(httpx.HeaderXRateLimitLimit, strconv.Itoa(c.Rate))
 				w.Header().Set(httpx.HeaderXRateLimitRemaining, strconv.Itoa(remaining))
 				w.Header().Set(httpx.HeaderXRateLimitReset, strconv.FormatInt(resetTime.Unix(), 10))

--- a/middleware/request_body_size.go
+++ b/middleware/request_body_size.go
@@ -66,3 +66,11 @@ func (lrw *limitResponseWriter) Write(p []byte) (int, error) {
 	}
 	return lrw.ResponseWriter.Write(p)
 }
+
+// Flush implements http.Flusher to support streaming responses like SSE.
+// It passes the flush through to the underlying ResponseWriter if it supports Flusher.
+func (lrw *limitResponseWriter) Flush() {
+	if f, ok := lrw.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}

--- a/middleware/request_body_size_test.go
+++ b/middleware/request_body_size_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -258,5 +259,85 @@ func TestRequestBodySize_Metrics(t *testing.T) {
 	}
 	if rejected != 1 {
 		t.Errorf("expected 1 rejected request, got %d", rejected)
+	}
+}
+
+func TestRequestBodySize_Flush(t *testing.T) {
+	tests := []struct {
+		name              string
+		underlyingFlusher bool
+		expectFlushCalled bool
+	}{
+		{
+			name:              "flush passes through to underlying Flusher",
+			underlyingFlusher: true,
+			expectFlushCalled: true,
+		},
+		{
+			name:              "flush no-op when underlying doesn't implement Flusher",
+			underlyingFlusher: false,
+			expectFlushCalled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var base http.ResponseWriter
+			var flushCalled *bool
+
+			if tt.underlyingFlusher {
+				rec := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+				base = rec
+				flushCalled = &rec.flushed
+			} else {
+				rec := httptest.NewRecorder()
+				base = rec
+				flushCalled = new(bool) // always false
+			}
+
+			// Wrap with limitResponseWriter
+			lrw := &limitResponseWriter{
+				ResponseWriter: base,
+			}
+
+			// Call Flush
+			lrw.Flush()
+
+			if *flushCalled != tt.expectFlushCalled {
+				t.Errorf("expected flush called=%v, got=%v", tt.expectFlushCalled, *flushCalled)
+			}
+		})
+	}
+}
+
+func TestRequestBodySize_Flush_SupportsSSE(t *testing.T) {
+	// This test verifies that SSE streaming works through the middleware
+	rec := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+
+	mw := RequestBodySize(config.RequestBodySizeConfig{MaxBytes: 1024})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Try to get a Flusher from the writer
+		f, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("expected ResponseWriter to implement http.Flusher")
+			return
+		}
+
+		// Write and flush like SSE would
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: hello\n\n"))
+		f.Flush()
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	handler.ServeHTTP(rec, req)
+
+	if !rec.flushed {
+		t.Error("expected Flush to be called on underlying ResponseWriter")
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
 	}
 }

--- a/middleware/request_logger.go
+++ b/middleware/request_logger.go
@@ -201,6 +201,14 @@ func (rw *bodyCapturingResponseWriter) bodyString() string {
 	return body
 }
 
+// Flush implements http.Flusher to support streaming responses like SSE.
+// It passes the flush through to the underlying ResponseWriter if it supports Flusher.
+func (rw *bodyCapturingResponseWriter) Flush() {
+	if f, ok := rw.ResponseWriter.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 // captureRequestBody reads and restores the request body.
 func captureRequestBody(r *http.Request, maxSize int) string {
 	if r.Body == nil || r.Body == http.NoBody {

--- a/middleware/request_logger_test.go
+++ b/middleware/request_logger_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/alexferl/zerohttp/config"
 	"github.com/alexferl/zerohttp/httpx"
+	"github.com/alexferl/zerohttp/internal/rwutil"
 	"github.com/alexferl/zerohttp/log"
 	"github.com/alexferl/zerohttp/zhtest"
 )
@@ -882,4 +884,90 @@ func TestRequestLogger_AllowedPaths(t *testing.T) {
 			t.Error("Expected request_body to be present when AllowedPaths is empty")
 		}
 	})
+}
+
+func TestRequestLogger_Flush(t *testing.T) {
+	tests := []struct {
+		name              string
+		underlyingFlusher bool
+		expectFlushCalled bool
+	}{
+		{
+			name:              "flush passes through to underlying Flusher",
+			underlyingFlusher: true,
+			expectFlushCalled: true,
+		},
+		{
+			name:              "flush no-op when underlying doesn't implement Flusher",
+			underlyingFlusher: false,
+			expectFlushCalled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := &requestLoggerMockLogger{}
+
+			var base http.ResponseWriter
+			var flushCalled *bool
+
+			if tt.underlyingFlusher {
+				rec := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+				base = rec
+				flushCalled = &rec.flushed
+			} else {
+				rec := httptest.NewRecorder()
+				base = rec
+				flushCalled = new(bool)
+			}
+
+			// Create bodyCapturingResponseWriter directly
+			bcrw := &bodyCapturingResponseWriter{
+				ResponseWriter: rwutil.NewResponseWriter(base),
+			}
+
+			// Call Flush
+			bcrw.Flush()
+
+			if *flushCalled != tt.expectFlushCalled {
+				t.Errorf("expected flush called=%v, got=%v", tt.expectFlushCalled, *flushCalled)
+			}
+
+			_ = logger // suppress unused warning
+		})
+	}
+}
+
+func TestRequestLogger_Flush_SupportsSSE(t *testing.T) {
+	logger := &requestLoggerMockLogger{}
+	rec := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+
+	middleware := RequestLogger(logger, config.RequestLoggerConfig{
+		Fields: []config.LogField{config.FieldPath, config.FieldStatus},
+	})
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Try to get a Flusher from the writer
+		f, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("expected ResponseWriter to implement http.Flusher")
+			return
+		}
+
+		// Write and flush like SSE would
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: hello\n\n"))
+		f.Flush()
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	handler.ServeHTTP(rec, req)
+
+	if !rec.flushed {
+		t.Error("expected Flush to be called on underlying ResponseWriter")
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
 }

--- a/middleware/reverse_proxy.go
+++ b/middleware/reverse_proxy.go
@@ -37,6 +37,13 @@ func (rec *proxyResponseRecorder) WriteHeader(code int) {
 	rec.ResponseWriter.WriteHeader(code)
 }
 
+// Flush implements http.Flusher to support streaming responses like SSE.
+func (rec *proxyResponseRecorder) Flush() {
+	if f, ok := rec.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 // backend represents a single upstream with health tracking
 type backend struct {
 	config.Backend

--- a/middleware/reverse_proxy_test.go
+++ b/middleware/reverse_proxy_test.go
@@ -693,3 +693,51 @@ func TestReverseProxy_HealthCheckCleanup(t *testing.T) {
 		t.Fatalf("expected status 200 after cleanup, got %d", rec2.Code)
 	}
 }
+
+func TestReverseProxy_proxyResponseRecorder_Flush(t *testing.T) {
+	tests := []struct {
+		name              string
+		underlyingFlusher bool
+		expectFlushCalled bool
+	}{
+		{
+			name:              "flush passes through to underlying Flusher",
+			underlyingFlusher: true,
+			expectFlushCalled: true,
+		},
+		{
+			name:              "flush no-op when underlying doesn't implement Flusher",
+			underlyingFlusher: false,
+			expectFlushCalled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var base http.ResponseWriter
+			var flushCalled *bool
+
+			if tt.underlyingFlusher {
+				rec := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+				base = rec
+				flushCalled = &rec.flushed
+			} else {
+				rec := httptest.NewRecorder()
+				base = rec
+				flushCalled = new(bool)
+			}
+
+			// Wrap with proxyResponseRecorder
+			prr := &proxyResponseRecorder{
+				ResponseWriter: base,
+			}
+
+			// Call Flush
+			prr.Flush()
+
+			if *flushCalled != tt.expectFlushCalled {
+				t.Errorf("expected flush called=%v, got=%v", tt.expectFlushCalled, *flushCalled)
+			}
+		})
+	}
+}

--- a/middleware/timeout.go
+++ b/middleware/timeout.go
@@ -143,3 +143,27 @@ func (tw *timeoutWriter) writeHeaderLocked(code int) {
 	tw.wroteHeader = true
 	tw.code = code
 }
+
+// Flush implements http.Flusher. Flushes buffered content to the underlying writer.
+func (tw *timeoutWriter) Flush() {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+
+	if tw.err != nil {
+		return
+	}
+
+	if !tw.wroteHeader {
+		tw.writeHeaderLocked(http.StatusOK)
+	}
+
+	// Flush buffered content to underlying writer
+	if tw.wbuf.Len() > 0 {
+		_, _ = tw.w.Write(tw.wbuf.Bytes())
+		tw.wbuf.Reset()
+	}
+
+	if f, ok := tw.w.(http.Flusher); ok {
+		f.Flush()
+	}
+}

--- a/middleware/timeout_test.go
+++ b/middleware/timeout_test.go
@@ -260,3 +260,80 @@ func TestTimeout_Metrics(t *testing.T) {
 		t.Errorf("expected 1 timeout metric, got %d", len(timeoutCounter.Metrics))
 	}
 }
+
+func TestTimeout_Flush(t *testing.T) {
+	tests := []struct {
+		name              string
+		underlyingFlusher bool
+		expectFlushCalled bool
+	}{
+		{
+			name:              "flush passes through to underlying Flusher",
+			underlyingFlusher: true,
+			expectFlushCalled: true,
+		},
+		{
+			name:              "flush no-op when underlying doesn't implement Flusher",
+			underlyingFlusher: false,
+			expectFlushCalled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var base http.ResponseWriter
+			var flushCalled *bool
+
+			if tt.underlyingFlusher {
+				rec := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+				base = rec
+				flushCalled = &rec.flushed
+			} else {
+				rec := httptest.NewRecorder()
+				base = rec
+				flushCalled = new(bool)
+			}
+
+			// Create timeoutWriter
+			tw := &timeoutWriter{
+				w:   base,
+				req: httptest.NewRequest(http.MethodGet, "/", nil),
+				h:   make(http.Header),
+			}
+
+			// Call Flush
+			tw.Flush()
+
+			if *flushCalled != tt.expectFlushCalled {
+				t.Errorf("expected flush called=%v, got=%v", tt.expectFlushCalled, *flushCalled)
+			}
+		})
+	}
+}
+
+func TestTimeout_Flush_WritesBufferedData(t *testing.T) {
+	rec := httptest.NewRecorder()
+
+	// Create timeoutWriter
+	tw := &timeoutWriter{
+		w:   rec,
+		req: httptest.NewRequest(http.MethodGet, "/", nil),
+		h:   make(http.Header),
+	}
+
+	// Write some data (buffered)
+	_, _ = tw.Write([]byte("hello"))
+
+	// Buffered data should not be written yet
+	if rec.Body.String() != "" {
+		t.Error("expected data to be buffered, not written yet")
+	}
+
+	// Flush should write buffered data
+	tw.Flush()
+
+	// Now data should be written
+	if rec.Body.String() != "hello" {
+		t.Errorf("expected body 'hello', got '%s'", rec.Body.String())
+	}
+}

--- a/router.go
+++ b/router.go
@@ -163,6 +163,13 @@ func (h *headResponseWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+// Flush implements http.Flusher to support streaming responses like SSE.
+func (h *headResponseWriter) Flush() {
+	if f, ok := h.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 // Unwrap allows middleware to access the underlying ResponseWriter
 func (h *headResponseWriter) Unwrap() http.ResponseWriter {
 	return h.ResponseWriter
@@ -754,7 +761,11 @@ func (r *defaultRouter) catchAllHandler() http.HandlerFunc {
 		// Must hold lock while reading from the inner map to avoid races
 		// with handle() which writes to the same inner map.
 		r.routesMu.RLock()
-		methods, exists := r.registeredRoutes[req.URL.Path]
+
+		// Check if this path matches any registered route pattern
+		// For parameterized routes, we need to match the pattern, not exact path
+		methods, exists := r.findMatchingRoute(req.URL.Path)
+
 		if exists {
 			// Auto-generate OPTIONS response
 			if req.Method == http.MethodOptions {
@@ -810,18 +821,108 @@ func (r *defaultRouter) catchAllHandler() http.HandlerFunc {
 	}
 }
 
+// findMatchingRoute checks if the request path matches any registered route pattern.
+// It returns the methods map and true if a match is found.
+// This handles parameterized routes like /hello/{name} matching /hello/as.
+func (r *defaultRouter) findMatchingRoute(path string) (map[string]bool, bool) {
+	// First try exact match (fast path for static routes)
+	if methods, exists := r.registeredRoutes[path]; exists {
+		return methods, true
+	}
+
+	// For parameterized routes, we need to check each pattern
+	// Go's ServeMux uses patterns like /hello/{name}
+	// We need to check if our path matches any registered pattern
+	for pattern, methods := range r.registeredRoutes {
+		if matchPattern(pattern, path) {
+			return methods, true
+		}
+	}
+
+	return nil, false
+}
+
+// matchPattern checks if a path matches a route pattern.
+// It handles parameterized segments like {name} and wildcards like {...}
+func matchPattern(pattern, path string) bool {
+	// Split pattern and path into segments
+	patternParts := strings.Split(strings.Trim(pattern, "/"), "/")
+	pathParts := strings.Split(strings.Trim(path, "/"), "/")
+
+	// Different number of segments means no match (unless pattern ends with wildcard)
+	if len(patternParts) != len(pathParts) {
+		// Check for wildcard at end
+		if len(patternParts) > 0 && patternParts[len(patternParts)-1] == "..." {
+			// Wildcard matches everything, check prefix
+			if len(pathParts) >= len(patternParts)-1 {
+				patternParts = patternParts[:len(patternParts)-1]
+				pathParts = pathParts[:len(patternParts)]
+			} else {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+
+	// Compare each segment
+	for i, p := range patternParts {
+		if i >= len(pathParts) {
+			return false
+		}
+
+		// Parameterized segment like {name} or {name...}
+		if strings.HasPrefix(p, "{") && strings.HasSuffix(p, "}") {
+			// This is a parameter, it matches any value
+			continue
+		}
+
+		// Parameterized segment with wildcard like {name...}
+		if strings.HasPrefix(p, "{") && strings.HasSuffix(p, "...}") {
+			// This matches the rest of the path
+			return true
+		}
+
+		// Wildcard segment
+		if p == "..." {
+			return true
+		}
+
+		// Exact match required
+		if p != pathParts[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
 // defaultNotFoundHandler is the default handler for 404 Not Found responses.
-// It returns a pre-encoded plain text response for optimal performance.
+// It checks the Accept header and returns JSON problem detail when requested.
 var defaultNotFoundHandler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Check if client accepts JSON/problem detail
+	accept := r.Header.Get(httpx.HeaderAccept)
+	if strings.Contains(accept, httpx.MIMEApplicationJSON) || strings.Contains(accept, httpx.MIMEApplicationProblemJSON) {
+		jsonNotFoundHandler(w, r)
+		return
+	}
+	// Default to plain text
 	w.Header().Set(httpx.HeaderContentType, httpx.MIMETextPlainCharset)
 	w.WriteHeader(http.StatusNotFound)
 	_, _ = w.Write([]byte("Requested resource was not found\n"))
 })
 
 // defaultMethodNotAllowedHandler is the default handler for 405 Method Not Allowed responses.
-// It returns a pre-encoded plain text response for optimal performance.
+// It checks the Accept header and returns JSON problem detail when requested.
 // The "Allow" header should be set by the caller to indicate which methods are allowed.
 var defaultMethodNotAllowedHandler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Check if client accepts JSON/problem detail
+	accept := r.Header.Get(httpx.HeaderAccept)
+	if strings.Contains(accept, httpx.MIMEApplicationJSON) || strings.Contains(accept, httpx.MIMEApplicationProblemJSON) {
+		jsonMethodNotAllowedHandler(w, r)
+		return
+	}
+	// Default to plain text
 	w.Header().Set(httpx.HeaderContentType, httpx.MIMETextPlainCharset)
 	w.WriteHeader(http.StatusMethodNotAllowed)
 	_, _ = w.Write([]byte("HTTP method is not allowed\n"))

--- a/router_test.go
+++ b/router_test.go
@@ -897,6 +897,11 @@ func TestMatchPattern(t *testing.T) {
 		{"static prefix mismatch", "/hello/{name}", "/world/test", false},
 		{"multiple params", "/users/{id}/posts/{slug}", "/users/123/posts/hello", true},
 		{"multiple params mismatch", "/users/{id}/posts/{slug}", "/users/123/comments/hello", false},
+		{"wildcard not enough segments", "/files/...", "/", false},
+		{"param with wildcard - root only", "/api/{version}/...", "/api/v1", true},
+		{"empty path", "/hello", "", false},
+		{"root only", "/", "/", true},
+		{"root mismatch", "/", "/hello", false},
 	}
 
 	for _, tt := range tests {

--- a/router_test.go
+++ b/router_test.go
@@ -15,6 +15,16 @@ import (
 	"github.com/alexferl/zerohttp/zhtest"
 )
 
+// flusherRecorder is a test ResponseWriter that implements http.Flusher
+type flusherRecorder struct {
+	*httptest.ResponseRecorder
+	flushed bool
+}
+
+func (f *flusherRecorder) Flush() {
+	f.flushed = true
+}
+
 func testMiddleware(name string, calls *[]string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -696,6 +706,111 @@ func TestRouter_ErrorHandlers(t *testing.T) {
 		contentType := w.Header().Get(httpx.HeaderContentType)
 		if contentType != httpx.MIMETextPlainCharset {
 			t.Errorf("expected Content-Type %q, got %q", httpx.MIMETextPlainCharset, contentType)
+		}
+	})
+
+	// Test for parameterized routes returning 405 instead of 404
+	t.Run("405 for parameterized routes", func(t *testing.T) {
+		router := NewRouter()
+		router.GET("/hello/{name}", testHandler("get"))
+
+		// POST to a path that matches the parameterized route pattern
+		// should return 405 (method not allowed), not 404 (not found)
+		req := httptest.NewRequest(http.MethodPost, "/hello/as", nil)
+		req.Header.Set(httpx.HeaderAccept, httpx.MIMEApplicationJSON)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		zhtest.AssertWith(t, w).Status(http.StatusMethodNotAllowed)
+
+		// Should be JSON problem detail response
+		contentType := w.Header().Get(httpx.HeaderContentType)
+		if contentType != httpx.MIMEApplicationProblemJSON {
+			t.Errorf("expected Content-Type %q, got %q", httpx.MIMEApplicationProblemJSON, contentType)
+		}
+
+		// Allow header should contain GET (and implicit HEAD)
+		allowHeader := w.Header().Get(httpx.HeaderAllow)
+		if allowHeader == "" {
+			t.Error("expected Allow header to be set for 405 response")
+		}
+		if !strings.Contains(allowHeader, http.MethodGet) {
+			t.Errorf("expected Allow header to contain GET, got '%s'", allowHeader)
+		}
+	})
+
+	t.Run("405 for parameterized routes with multiple methods", func(t *testing.T) {
+		router := NewRouter()
+		router.GET("/users/{id}", testHandler("get"))
+		router.PUT("/users/{id}", testHandler("put"))
+		router.DELETE("/users/{id}", testHandler("delete"))
+
+		// POST should not be allowed
+		req := httptest.NewRequest(http.MethodPost, "/users/123", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		zhtest.AssertWith(t, w).Status(http.StatusMethodNotAllowed)
+
+		// Allow header should contain all registered methods
+		allowHeader := w.Header().Get(httpx.HeaderAllow)
+		if !strings.Contains(allowHeader, http.MethodGet) {
+			t.Errorf("expected Allow header to contain GET, got '%s'", allowHeader)
+		}
+		if !strings.Contains(allowHeader, http.MethodPut) {
+			t.Errorf("expected Allow header to contain PUT, got '%s'", allowHeader)
+		}
+		if !strings.Contains(allowHeader, http.MethodDelete) {
+			t.Errorf("expected Allow header to contain DELETE, got '%s'", allowHeader)
+		}
+		if !strings.Contains(allowHeader, http.MethodHead) {
+			t.Errorf("expected Allow header to contain implicit HEAD, got '%s'", allowHeader)
+		}
+	})
+
+	t.Run("OPTIONS for parameterized routes", func(t *testing.T) {
+		router := NewRouter()
+		router.GET("/items/{id}", testHandler("get"))
+		router.POST("/items/{id}", testHandler("post"))
+
+		// OPTIONS should return allowed methods
+		req := httptest.NewRequest(http.MethodOptions, "/items/abc", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		zhtest.AssertWith(t, w).Status(http.StatusNoContent)
+
+		allowHeader := w.Header().Get(httpx.HeaderAllow)
+		if !strings.Contains(allowHeader, http.MethodGet) {
+			t.Errorf("expected Allow header to contain GET, got '%s'", allowHeader)
+		}
+		if !strings.Contains(allowHeader, http.MethodPost) {
+			t.Errorf("expected Allow header to contain POST, got '%s'", allowHeader)
+		}
+		if !strings.Contains(allowHeader, http.MethodHead) {
+			t.Errorf("expected Allow header to contain implicit HEAD, got '%s'", allowHeader)
+		}
+		if !strings.Contains(allowHeader, http.MethodOptions) {
+			t.Errorf("expected Allow header to contain OPTIONS, got '%s'", allowHeader)
+		}
+	})
+
+	t.Run("404 for non-matching parameterized paths", func(t *testing.T) {
+		router := NewRouter()
+		router.GET("/hello/{name}", testHandler("get"))
+
+		// Different number of path segments should 404
+		req := httptest.NewRequest(http.MethodGet, "/hello/foo/bar", nil)
+		req.Header.Set(httpx.HeaderAccept, httpx.MIMEApplicationJSON)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		zhtest.AssertWith(t, w).Status(http.StatusNotFound)
+
+		// Content-Type should be JSON problem detail
+		contentType := w.Header().Get(httpx.HeaderContentType)
+		if contentType != httpx.MIMEApplicationProblemJSON {
+			t.Errorf("expected Content-Type %q, got %q", httpx.MIMEApplicationProblemJSON, contentType)
 		}
 	})
 }
@@ -1831,4 +1946,150 @@ func TestRouter_ConcurrentMixedOperations(t *testing.T) {
 
 		wg.Wait()
 	})
+}
+
+func TestHeadResponseWriter_Flush(t *testing.T) {
+	tests := []struct {
+		name              string
+		underlyingFlusher bool
+		expectFlushCalled bool
+	}{
+		{
+			name:              "flush passes through to underlying Flusher",
+			underlyingFlusher: true,
+			expectFlushCalled: true,
+		},
+		{
+			name:              "flush no-op when underlying doesn't implement Flusher",
+			underlyingFlusher: false,
+			expectFlushCalled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var base http.ResponseWriter
+			var flushCalled *bool
+
+			if tt.underlyingFlusher {
+				rec := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+				base = rec
+				flushCalled = &rec.flushed
+			} else {
+				rec := httptest.NewRecorder()
+				base = rec
+				flushCalled = new(bool)
+			}
+
+			// Wrap with headResponseWriter
+			hrw := &headResponseWriter{
+				ResponseWriter: base,
+			}
+
+			// Call Flush
+			hrw.Flush()
+
+			if *flushCalled != tt.expectFlushCalled {
+				t.Errorf("expected flush called=%v, got=%v", tt.expectFlushCalled, *flushCalled)
+			}
+		})
+	}
+}
+
+// TestDefaultNotFoundHandler_AcceptJSON verifies that the default NotFound handler
+// returns Problem Detail when Accept header contains application/json.
+func TestDefaultNotFoundHandler_AcceptJSON(t *testing.T) {
+	router := NewRouter()
+
+	// Make a request with Accept: application/json
+	req := httptest.NewRequest(http.MethodGet, "/not-found", nil)
+	req.Header.Set(httpx.HeaderAccept, httpx.MIMEApplicationJSON)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	// Should return JSON Problem Detail
+	zhtest.AssertWith(t, w).
+		Status(http.StatusNotFound).
+		Header(httpx.HeaderContentType, httpx.MIMEApplicationProblemJSON).
+		BodyContains(`"title":"Not Found"`).
+		BodyContains(`"status":404`)
+}
+
+// TestDefaultNotFoundHandler_AcceptProblemJSON verifies that the default NotFound handler
+// returns Problem Detail when Accept header contains application/problem+json.
+func TestDefaultNotFoundHandler_AcceptProblemJSON(t *testing.T) {
+	router := NewRouter()
+
+	// Make a request with Accept: application/problem+json
+	req := httptest.NewRequest(http.MethodGet, "/not-found", nil)
+	req.Header.Set(httpx.HeaderAccept, httpx.MIMEApplicationProblemJSON)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	// Should return JSON Problem Detail
+	zhtest.AssertWith(t, w).
+		Status(http.StatusNotFound).
+		Header(httpx.HeaderContentType, httpx.MIMEApplicationProblemJSON).
+		BodyContains(`"title":"Not Found"`).
+		BodyContains(`"status":404`)
+}
+
+// TestDefaultNotFoundHandler_NoAcceptHeader verifies that the default NotFound handler
+// returns plain text when no Accept header is set.
+func TestDefaultNotFoundHandler_NoAcceptHeader(t *testing.T) {
+	router := NewRouter()
+
+	// Make a request without Accept header
+	req := httptest.NewRequest(http.MethodGet, "/not-found", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	// Should return plain text
+	zhtest.AssertWith(t, w).
+		Status(http.StatusNotFound).
+		Header(httpx.HeaderContentType, httpx.MIMETextPlainCharset).
+		BodyContains("Requested resource was not found")
+}
+
+// TestDefaultMethodNotAllowedHandler_AcceptJSON verifies that the default MethodNotAllowed handler
+// returns Problem Detail when Accept header contains application/json.
+func TestDefaultMethodNotAllowedHandler_AcceptJSON(t *testing.T) {
+	router := NewRouter()
+	router.GET("/test", testHandler("GET handler"))
+
+	// Make a POST request with Accept: application/json
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req.Header.Set(httpx.HeaderAccept, httpx.MIMEApplicationJSON)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	// Should return JSON Problem Detail
+	zhtest.AssertWith(t, w).
+		Status(http.StatusMethodNotAllowed).
+		Header(httpx.HeaderContentType, httpx.MIMEApplicationProblemJSON).
+		BodyContains(`"title":"Method Not Allowed"`).
+		BodyContains(`"status":405`)
+}
+
+// TestDefaultMethodNotAllowedHandler_NoAcceptHeader verifies that the default MethodNotAllowed handler
+// returns plain text when no Accept header is set.
+func TestDefaultMethodNotAllowedHandler_NoAcceptHeader(t *testing.T) {
+	router := NewRouter()
+	router.GET("/test", testHandler("GET handler"))
+
+	// Make a POST request without Accept header
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	// Should return plain text
+	zhtest.AssertWith(t, w).
+		Status(http.StatusMethodNotAllowed).
+		Header(httpx.HeaderContentType, httpx.MIMETextPlainCharset).
+		BodyContains("HTTP method is not allowed")
 }

--- a/router_test.go
+++ b/router_test.go
@@ -813,6 +813,100 @@ func TestRouter_ErrorHandlers(t *testing.T) {
 			t.Errorf("expected Content-Type %q, got %q", httpx.MIMEApplicationProblemJSON, contentType)
 		}
 	})
+
+	// Test wildcard patterns like /files/...
+	t.Run("405 for wildcard routes", func(t *testing.T) {
+		router := NewRouter()
+		router.GET("/files/...", testHandler("get"))
+
+		// POST to a path that matches the wildcard pattern
+		req := httptest.NewRequest(http.MethodPost, "/files/docs/readme.txt", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		zhtest.AssertWith(t, w).Status(http.StatusMethodNotAllowed)
+
+		// Allow header should contain GET
+		allowHeader := w.Header().Get(httpx.HeaderAllow)
+		if !strings.Contains(allowHeader, http.MethodGet) {
+			t.Errorf("expected Allow header to contain GET, got '%s'", allowHeader)
+		}
+	})
+
+	t.Run("OPTIONS for wildcard routes", func(t *testing.T) {
+		router := NewRouter()
+		router.GET("/static/...", testHandler("get"))
+
+		// OPTIONS should return allowed methods
+		req := httptest.NewRequest(http.MethodOptions, "/static/css/main.css", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		zhtest.AssertWith(t, w).Status(http.StatusNoContent)
+
+		allowHeader := w.Header().Get(httpx.HeaderAllow)
+		if !strings.Contains(allowHeader, http.MethodGet) {
+			t.Errorf("expected Allow header to contain GET, got '%s'", allowHeader)
+		}
+	})
+
+	// Test wildcard with parameter like /api/{version}/...
+	t.Run("405 for parameter with wildcard", func(t *testing.T) {
+		router := NewRouter()
+		router.GET("/api/{version}/...", testHandler("get"))
+
+		// POST to a path that matches the pattern
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/users", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		zhtest.AssertWith(t, w).Status(http.StatusMethodNotAllowed)
+	})
+
+	t.Run("OPTIONS for parameter with wildcard", func(t *testing.T) {
+		router := NewRouter()
+		router.GET("/api/{version}/...", testHandler("get"))
+
+		// OPTIONS should work
+		req := httptest.NewRequest(http.MethodOptions, "/api/v2/items", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		zhtest.AssertWith(t, w).Status(http.StatusNoContent)
+	})
+}
+
+func TestMatchPattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		path    string
+		want    bool
+	}{
+		{"exact match", "/hello", "/hello", true},
+		{"exact mismatch", "/hello", "/world", false},
+		{"param match", "/hello/{name}", "/hello/as", true},
+		{"param different value", "/hello/{name}", "/hello/world", true},
+		{"param no match - extra segments", "/hello/{name}", "/hello/foo/bar", false},
+		{"param no match - missing segments", "/hello/{name}", "/hello", false},
+		{"wildcard match single", "/files/...", "/files/readme.txt", true},
+		{"wildcard match deep", "/files/...", "/files/a/b/c/d.txt", true},
+		{"wildcard no match - less segments", "/files/...", "/other", false},
+		{"param with wildcard", "/api/{version}/...", "/api/v1/users", true},
+		{"param with wildcard deep", "/api/{version}/...", "/api/v2/a/b/c", true},
+		{"static prefix mismatch", "/hello/{name}", "/world/test", false},
+		{"multiple params", "/users/{id}/posts/{slug}", "/users/123/posts/hello", true},
+		{"multiple params mismatch", "/users/{id}/posts/{slug}", "/users/123/comments/hello", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchPattern(tt.pattern, tt.path)
+			if got != tt.want {
+				t.Errorf("matchPattern(%q, %q) = %v, want %v", tt.pattern, tt.path, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestRouter_Configuration(t *testing.T) {

--- a/server.go
+++ b/server.go
@@ -807,8 +807,9 @@ func needsTLSServer(c config.Config) bool {
 }
 
 // createMetricsRegistry creates metrics registry if enabled.
+// Metrics are only enabled when explicitly set to true (not nil).
 func createMetricsRegistry(c config.Config) metrics.Registry {
-	if c.Metrics.Enabled != nil && !*c.Metrics.Enabled {
+	if c.Metrics.Enabled == nil || !*c.Metrics.Enabled {
 		return nil
 	}
 	return metrics.NewRegistry()

--- a/server_metrics_test.go
+++ b/server_metrics_test.go
@@ -13,8 +13,27 @@ import (
 	"github.com/alexferl/zerohttp/config"
 )
 
+// TestServer_MetricsDisabledByDefault verifies that metrics server does NOT start
+// when Enabled is nil (the default).
+func TestServer_MetricsDisabledByDefault(t *testing.T) {
+	srv := New(config.Config{
+		// Enabled is nil by default - metrics should be disabled
+	})
+
+	// Verify metrics addr is empty when disabled
+	addr := srv.MetricsAddr()
+	if addr != "" {
+		t.Errorf("expected metrics to be disabled (empty addr), got %s", addr)
+	}
+
+	// Verify metrics registry is nil
+	if srv.Metrics() != nil {
+		t.Error("expected metrics registry to be nil when disabled")
+	}
+}
+
 // TestServer_MetricsServerAddrDefault verifies that ServerAddr defaults to localhost:9090
-// when metrics are enabled but ServerAddr is not explicitly set (nil).
+// when metrics are explicitly enabled but ServerAddr is not explicitly set (nil).
 func TestServer_MetricsServerAddrDefault(t *testing.T) {
 	// Get available port for main server
 	mainListener, err := net.Listen("tcp", "localhost:0")
@@ -27,8 +46,9 @@ func TestServer_MetricsServerAddrDefault(t *testing.T) {
 	}
 
 	srv := New(config.Config{
-		Addr:    mainAddr,
+		Addr: mainAddr,
 		Metrics: config.MetricsConfig{
+			Enabled: config.Bool(true), // Explicitly enable metrics
 			// ServerAddr not set (nil) - should default to localhost:9090
 		},
 	})
@@ -45,6 +65,7 @@ func TestServer_MetricsServerAddrDefault(t *testing.T) {
 func TestServer_MetricsExplicitEmptyServerAddr(t *testing.T) {
 	srv := New(config.Config{
 		Metrics: config.MetricsConfig{
+			Enabled:    config.Bool(true), // Explicitly enable metrics
 			ServerAddr: config.String(""), // Explicitly empty - use main server
 		},
 	})
@@ -107,6 +128,7 @@ func TestServer_MetricsDedicatedServer(t *testing.T) {
 	srv := New(config.Config{
 		Addr: mainAddr,
 		Metrics: config.MetricsConfig{
+			Enabled:    config.Bool(true), // Explicitly enable metrics
 			ServerAddr: config.String(metricsAddr),
 			Endpoint:   "/metrics",
 		},
@@ -201,6 +223,7 @@ func TestServer_MetricsDedicatedServerNotExposedOnMainServer(t *testing.T) {
 	srv := New(config.Config{
 		Addr: mainAddr,
 		Metrics: config.MetricsConfig{
+			Enabled:    config.Bool(true), // Explicitly enable metrics
 			ServerAddr: config.String(metricsAddr),
 			Endpoint:   "/metrics",
 		},
@@ -328,6 +351,7 @@ func TestServer_RequestContextCancellation(t *testing.T) {
 func TestServer_MetricsRecordsErrors(t *testing.T) {
 	app := New(config.Config{
 		Metrics: config.MetricsConfig{
+			Enabled:    config.Bool(true), // Explicitly enable metrics
 			ServerAddr: config.String(""), // Empty to use main server for metrics
 		},
 	})
@@ -421,6 +445,7 @@ func TestServer_MetricsRecordsErrors(t *testing.T) {
 func TestServer_MetricsRecordsPanic(t *testing.T) {
 	app := New(config.Config{
 		Metrics: config.MetricsConfig{
+			Enabled:    config.Bool(true), // Explicitly enable metrics
 			ServerAddr: config.String(""), // Empty to use main server for metrics
 		},
 	})

--- a/sse.go
+++ b/sse.go
@@ -82,12 +82,12 @@ func normalizeLineEndings(s string) string {
 // Content-Type middleware on SSE routes.
 func setupSSEResponse(w http.ResponseWriter) (http.Flusher, error) {
 	if w.Header().Get(httpx.HeaderContentType) != "" {
-		return nil, fmt.Errorf("sse: response headers already sent")
+		return nil, fmt.Errorf("sse: response headers already sent (Content-Type: %s)", w.Header().Get(httpx.HeaderContentType))
 	}
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		return nil, fmt.Errorf("sse: streaming not supported")
+		return nil, fmt.Errorf("sse: streaming not supported (ResponseWriter type: %T)", w)
 	}
 
 	w.Header().Set(httpx.HeaderContentType, httpx.MIMETextEventStream)


### PR DESCRIPTION
- Add Flush() to all response writer wrappers for SSE support
- Fix metrics server to be opt-in (disabled by default)
- Fix 404/405 to return Problem Detail JSON when Accept header requests it
- Fix 405 handling for parameterized routes (/hello/{name})
- Add comprehensive tests for all fixes