### PR TITLE
feat: add X-Cache header and improve compression config

### DIFF
--- a/config/compress.go
+++ b/config/compress.go
@@ -14,6 +14,21 @@ const (
 	Deflate = CompressionAlgorithm(httpx.ContentEncodingDeflate)
 )
 
+// DefaultCompressTypes are the MIME types compressed by default.
+var DefaultCompressTypes = []string{
+	httpx.MIMETextHTML,
+	httpx.MIMETextCSS,
+	httpx.MIMETextPlain,
+	httpx.MIMETextJavaScript,
+	httpx.MIMEApplicationJavaScript,
+	httpx.MIMEApplicationJSON,
+	httpx.MIMEApplicationXML,
+	httpx.MIMETextXML,
+	httpx.MIMEApplicationRSSXML,
+	httpx.MIMEApplicationAtomXML,
+	httpx.MIMEImageSVGXML,
+}
+
 // CompressionEncoder is the interface for compression encoders.
 // Users can implement this interface to provide custom compression algorithms
 // (e.g., Brotli, zstd) without adding dependencies to the core library.
@@ -52,7 +67,7 @@ type CompressionEncoder interface {
 //	}
 //
 //	cfg := config.CompressConfig{
-//	    Provider: MyCompressorProvider{},
+//	    Providers: []config.CompressionProvider{MyCompressorProvider{}},
 //	}
 type CompressionProvider interface {
 	// GetEncoder returns a CompressionEncoder for the given encoding, or nil if not supported.
@@ -74,29 +89,17 @@ type CompressConfig struct {
 	// ExemptPaths contains paths to skip compression
 	ExemptPaths []string
 
-	// Provider is an optional custom compression provider.
-	// If set, the provider's encoders will be used in addition to built-in gzip/deflate.
+	// Providers are optional custom compression providers.
+	// If set, the providers' encoders will be used in addition to built-in gzip/deflate.
 	// This allows users to add Brotli, zstd, or other algorithms without core dependencies.
 	// Default: nil (use only built-in gzip/deflate)
-	Provider CompressionProvider
+	Providers []CompressionProvider
 }
 
 // DefaultCompressConfig contains the default values for compression configuration.
 var DefaultCompressConfig = CompressConfig{
-	Level: 6,
-	Types: []string{
-		httpx.MIMETextHTML,
-		"text/css",
-		httpx.MIMETextPlain,
-		"text/javascript",
-		"application/javascript",
-		httpx.MIMEApplicationJSON,
-		"application/xml",
-		"text/xml",
-		"application/rss+xml",
-		"application/atom+xml",
-		"image/svg+xml",
-	},
+	Level:       6,
+	Types:       DefaultCompressTypes,
 	Algorithms:  []CompressionAlgorithm{Gzip, Deflate},
 	ExemptPaths: []string{},
 }

--- a/examples/middleware/compress_brotli/main.go
+++ b/examples/middleware/compress_brotli/main.go
@@ -46,7 +46,7 @@ func main() {
 	app.Use(middleware.Compress(config.CompressConfig{
 		Level:      6,
 		Algorithms: []config.CompressionAlgorithm{"br", config.Gzip, config.Deflate},
-		Provider:   BrotliProvider{},
+		Providers:  []config.CompressionProvider{BrotliProvider{}},
 	}))
 
 	app.GET("/", zerohttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {

--- a/examples/middleware/compress_zstd/main.go
+++ b/examples/middleware/compress_zstd/main.go
@@ -59,7 +59,7 @@ func main() {
 	app.Use(middleware.Compress(config.CompressConfig{
 		Level:      6,
 		Algorithms: []config.CompressionAlgorithm{"zstd", config.Gzip, config.Deflate},
-		Provider:   ZstdProvider{},
+		Providers:  []config.CompressionProvider{ZstdProvider{}},
 	}))
 
 	app.GET("/", zerohttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {

--- a/httpx/httpx.go
+++ b/httpx/httpx.go
@@ -27,11 +27,19 @@ const (
 	MIMETextPlain                 = "text/plain"
 	MIMETextPlainCharset          = "text/plain; charset=utf-8"
 	MIMETextEventStream           = "text/event-stream"
+	MIMETextCSS                   = "text/css"
+	MIMETextJavaScript            = "text/javascript"
 	MIMEApplicationJSON           = "application/json"
 	MIMEApplicationJSONCharset    = "application/json; charset=utf-8"
+	MIMEApplicationJavaScript     = "application/javascript"
+	MIMEApplicationXML            = "application/xml"
 	MIMEApplicationProblemJSON    = "application/problem+json"
 	MIMEApplicationFormURLEncoded = "application/x-www-form-urlencoded"
+	MIMEApplicationRSSXML         = "application/rss+xml"
+	MIMEApplicationAtomXML        = "application/atom+xml"
 	MIMEMultipartFormData         = "multipart/form-data"
+	MIMETextXML                   = "text/xml"
+	MIMEImageSVGXML               = "image/svg+xml"
 )
 
 // Request Headers

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -362,10 +362,10 @@ func Compress(cfg ...config.CompressConfig) func(http.Handler) http.Handler {
 		compressor.algorithms[alg] = true
 	}
 
-	// Add custom encoders from provider if set
-	if c.Provider != nil {
+	// Add custom encoders from providers if set
+	for _, provider := range c.Providers {
 		for _, alg := range c.Algorithms {
-			if encoder := c.Provider.GetEncoder(string(alg)); encoder != nil {
+			if encoder := provider.GetEncoder(string(alg)); encoder != nil {
 				compressor.SetEncoder(encoder.Encoding(), func(w io.Writer, level int) io.Writer {
 					return encoder.Encode(w, level)
 				})

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -812,7 +812,7 @@ func TestCompressionProvider(t *testing.T) {
 		mw := Compress(config.CompressConfig{
 			Types:      []string{"text/plain"},
 			Algorithms: []config.CompressionAlgorithm{"nop", config.Gzip},
-			Provider:   provider,
+			Providers:  []config.CompressionProvider{provider},
 		})
 
 		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -838,7 +838,7 @@ func TestCompressionProvider(t *testing.T) {
 		mw := Compress(config.CompressConfig{
 			Types:      []string{"text/plain"},
 			Algorithms: []config.CompressionAlgorithm{config.Gzip},
-			Provider:   provider,
+			Providers:  []config.CompressionProvider{provider},
 		})
 
 		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -866,7 +866,7 @@ func TestCompressionProvider(t *testing.T) {
 			Types:      []string{"text/plain"},
 			Algorithms: []config.CompressionAlgorithm{"testlevel"},
 			Level:      9,
-			Provider:   provider,
+			Providers:  []config.CompressionProvider{provider},
 		})
 
 		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -896,7 +896,7 @@ func TestCompressionProvider(t *testing.T) {
 		mw := Compress(config.CompressConfig{
 			Types:      []string{"text/plain"},
 			Algorithms: []config.CompressionAlgorithm{"custom1", "custom2"},
-			Provider:   provider,
+			Providers:  []config.CompressionProvider{provider},
 		})
 
 		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -928,7 +928,7 @@ func TestCompressionProvider(t *testing.T) {
 		mw := Compress(config.CompressConfig{
 			Types:      []string{"text/plain"},
 			Algorithms: []config.CompressionAlgorithm{config.Gzip, "custom"},
-			Provider:   provider,
+			Providers:  []config.CompressionProvider{provider},
 		})
 
 		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -951,11 +951,47 @@ func TestCompressionProvider(t *testing.T) {
 		zhtest.AssertWith(t, rr2).Header(httpx.HeaderContentEncoding, "custom")
 	})
 
+	t.Run("multiple providers", func(t *testing.T) {
+		encoder1 := &testEncoder{encoding: "brotli"}
+		encoder2 := &testEncoder{encoding: "zstd"}
+		provider1 := &testProvider{encoders: map[string]config.CompressionEncoder{
+			"brotli": encoder1,
+		}}
+		provider2 := &testProvider{encoders: map[string]config.CompressionEncoder{
+			"zstd": encoder2,
+		}}
+
+		mw := Compress(config.CompressConfig{
+			Types:      []string{"text/plain"},
+			Algorithms: []config.CompressionAlgorithm{"brotli", "zstd"},
+			Providers:  []config.CompressionProvider{provider1, provider2},
+		})
+
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set(httpx.HeaderContentType, httpx.MIMETextPlain)
+			_, _ = w.Write([]byte("test content"))
+		}))
+
+		// Test first provider's encoder
+		req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req1.Header.Set(httpx.HeaderAcceptEncoding, "brotli")
+		rr1 := httptest.NewRecorder()
+		handler.ServeHTTP(rr1, req1)
+		zhtest.AssertWith(t, rr1).Header(httpx.HeaderContentEncoding, "brotli")
+
+		// Test second provider's encoder
+		req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req2.Header.Set(httpx.HeaderAcceptEncoding, "zstd")
+		rr2 := httptest.NewRecorder()
+		handler.ServeHTTP(rr2, req2)
+		zhtest.AssertWith(t, rr2).Header(httpx.HeaderContentEncoding, "zstd")
+	})
+
 	t.Run("nil provider uses defaults only", func(t *testing.T) {
 		mw := Compress(config.CompressConfig{
 			Types:      []string{"text/plain"},
 			Algorithms: []config.CompressionAlgorithm{config.Gzip},
-			Provider:   nil,
+			Providers:  nil,
 		})
 
 		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
- Add X-Cache response header with configurable name via CacheStatusHeader
- Change CompressConfig.Provider to Providers []CompressionProvider slice
- Add DefaultCompressTypes constant for compression MIME types
- Add missing MIME type constants (CSS, JavaScript, XML, RSS, Atom, SVG)
- Add cache_redis example demonstrating Redis cache store