### PR TITLE
feat: add IncludedPaths support to all middlewares

### DIFF
--- a/config/basic_auth.go
+++ b/config/basic_auth.go
@@ -11,14 +11,26 @@ type BasicAuthConfig struct {
 	// Validator is a custom function to validate credentials (optional)
 	Validator func(username, password string) bool
 
-	// ExemptPaths contains paths that skip basic auth (e.g., /health, /login, /signup)
-	ExemptPaths []string
+	// ExcludedPaths contains paths that skip basic auth.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// Cannot be used with IncludedPaths - setting both will panic.
+	// Default: []
+	ExcludedPaths []string
+
+	// IncludedPaths contains paths where basic auth is explicitly applied.
+	// If set, basic auth will only occur for paths matching these patterns.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// If empty, basic auth applies to all paths (subject to ExcludedPaths).
+	// Cannot be used with ExcludedPaths - setting both will panic.
+	// Default: []
+	IncludedPaths []string
 }
 
 // DefaultBasicAuthConfig contains the default basic authentication configuration
 var DefaultBasicAuthConfig = BasicAuthConfig{
-	Realm:       "Restricted",
-	Credentials: nil,
-	Validator:   nil,
-	ExemptPaths: []string{},
+	Realm:         "Restricted",
+	Credentials:   nil,
+	Validator:     nil,
+	ExcludedPaths: []string{},
+	IncludedPaths: []string{},
 }

--- a/config/basic_auth_test.go
+++ b/config/basic_auth_test.go
@@ -15,8 +15,11 @@ func TestBasicAuthConfig_DefaultValues(t *testing.T) {
 	if cfg.Validator != nil {
 		t.Error("expected default validator to be nil")
 	}
-	if len(cfg.ExemptPaths) != 0 {
-		t.Errorf("expected default exempt paths to be empty, got %d paths", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 0 {
+		t.Errorf("expected default excluded paths to be empty, got %d paths", len(cfg.ExcludedPaths))
+	}
+	if len(cfg.IncludedPaths) != 0 {
+		t.Errorf("expected default included paths to be empty, got %d paths", len(cfg.IncludedPaths))
 	}
 }
 
@@ -70,20 +73,38 @@ func TestBasicAuthConfig_CustomValues(t *testing.T) {
 		}
 	})
 
-	t.Run("custom exempt paths", func(t *testing.T) {
-		exemptPaths := []string{"/health", "/metrics", "/login", "/signup"}
+	t.Run("custom excluded paths", func(t *testing.T) {
+		excludedPaths := []string{"/health", "/metrics", "/login", "/signup"}
 		cfg := BasicAuthConfig{
-			ExemptPaths: exemptPaths,
+			ExcludedPaths: excludedPaths,
 		}
-		if len(cfg.ExemptPaths) != 4 {
-			t.Errorf("expected 4 exempt paths, got %d", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 4 {
+			t.Errorf("expected 4 excluded paths, got %d", len(cfg.ExcludedPaths))
 		}
 		expectedPaths := map[string]bool{
 			"/health": true, "/metrics": true, "/login": true, "/signup": true,
 		}
-		for _, path := range cfg.ExemptPaths {
+		for _, path := range cfg.ExcludedPaths {
 			if !expectedPaths[path] {
-				t.Errorf("unexpected exempt path: %s", path)
+				t.Errorf("unexpected excluded path: %s", path)
+			}
+		}
+	})
+
+	t.Run("custom included paths", func(t *testing.T) {
+		includedPaths := []string{"/admin", "/api/private/"}
+		cfg := BasicAuthConfig{
+			IncludedPaths: includedPaths,
+		}
+		if len(cfg.IncludedPaths) != 2 {
+			t.Errorf("expected 2 included paths, got %d", len(cfg.IncludedPaths))
+		}
+		expectedPaths := map[string]bool{
+			"/admin": true, "/api/private/": true,
+		}
+		for _, path := range cfg.IncludedPaths {
+			if !expectedPaths[path] {
+				t.Errorf("unexpected allowed path: %s", path)
 			}
 		}
 	})
@@ -91,16 +112,18 @@ func TestBasicAuthConfig_CustomValues(t *testing.T) {
 
 func TestBasicAuthConfig_MultipleFields(t *testing.T) {
 	credentials := map[string]string{"admin": "secret123", "user": "pass456"}
-	exemptPaths := []string{"/public", "/health"}
+	excludedPaths := []string{"/public", "/health"}
+	includedPaths := []string{"/admin", "/api/"}
 	validator := func(username, password string) bool {
 		return username == "custom" && password == "validate"
 	}
 
 	cfg := BasicAuthConfig{
-		Realm:       "Custom Realm",
-		Credentials: credentials,
-		Validator:   validator,
-		ExemptPaths: exemptPaths,
+		Realm:         "Custom Realm",
+		Credentials:   credentials,
+		Validator:     validator,
+		ExcludedPaths: excludedPaths,
+		IncludedPaths: includedPaths,
 	}
 
 	if cfg.Realm != "Custom Realm" {
@@ -118,8 +141,11 @@ func TestBasicAuthConfig_MultipleFields(t *testing.T) {
 	if !cfg.Validator("custom", "validate") {
 		t.Error("expected custom validator to work")
 	}
-	if len(cfg.ExemptPaths) != 2 {
-		t.Errorf("expected 2 exempt paths, got %d", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 2 {
+		t.Errorf("expected 2 excluded paths, got %d", len(cfg.ExcludedPaths))
+	}
+	if len(cfg.IncludedPaths) != 2 {
+		t.Errorf("expected 2 included paths, got %d", len(cfg.IncludedPaths))
 	}
 }
 
@@ -145,24 +171,45 @@ func TestBasicAuthConfig_EdgeCases(t *testing.T) {
 		}
 	})
 
-	t.Run("empty exempt paths", func(t *testing.T) {
+	t.Run("empty excluded paths", func(t *testing.T) {
 		cfg := BasicAuthConfig{
-			ExemptPaths: []string{},
+			ExcludedPaths: []string{},
 		}
-		if cfg.ExemptPaths == nil {
-			t.Error("expected exempt paths slice to be initialized, not nil")
+		if cfg.ExcludedPaths == nil {
+			t.Error("expected excluded paths slice to be initialized, not nil")
 		}
-		if len(cfg.ExemptPaths) != 0 {
-			t.Errorf("expected empty exempt paths slice, got %d entries", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 0 {
+			t.Errorf("expected empty excluded paths slice, got %d entries", len(cfg.ExcludedPaths))
 		}
 	})
 
-	t.Run("nil exempt paths", func(t *testing.T) {
+	t.Run("nil excluded paths", func(t *testing.T) {
 		cfg := BasicAuthConfig{
-			ExemptPaths: nil,
+			ExcludedPaths: nil,
 		}
-		if cfg.ExemptPaths != nil {
-			t.Error("expected exempt paths to remain nil when nil is passed")
+		if cfg.ExcludedPaths != nil {
+			t.Error("expected excluded paths to remain nil when nil is passed")
+		}
+	})
+
+	t.Run("empty included paths", func(t *testing.T) {
+		cfg := BasicAuthConfig{
+			IncludedPaths: []string{},
+		}
+		if cfg.IncludedPaths == nil {
+			t.Error("expected included paths slice to be initialized, not nil")
+		}
+		if len(cfg.IncludedPaths) != 0 {
+			t.Errorf("expected empty included paths slice, got %d entries", len(cfg.IncludedPaths))
+		}
+	})
+
+	t.Run("nil included paths", func(t *testing.T) {
+		cfg := BasicAuthConfig{
+			IncludedPaths: nil,
+		}
+		if cfg.IncludedPaths != nil {
+			t.Error("expected included paths to remain nil when nil is passed")
 		}
 	})
 }

--- a/config/cache.go
+++ b/config/cache.go
@@ -69,9 +69,19 @@ type CacheConfig struct {
 	// Default: nil
 	Store CacheStore
 
-	// ExemptPaths are paths that should not be cached.
+	// ExcludedPaths are paths that should not be cached.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// Cannot be used with IncludedPaths - setting both will panic.
 	// Default: []
-	ExemptPaths []string
+	ExcludedPaths []string
+
+	// IncludedPaths contains paths where caching is explicitly applied.
+	// If set, caching will only occur for paths matching these patterns.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// If empty, caching applies to all paths (subject to ExcludedPaths).
+	// Cannot be used with ExcludedPaths - setting both will panic.
+	// Default: []
+	IncludedPaths []string
 
 	// StatusCodes is a list of status codes that can be cached.
 	// Default: [200, 201, 204, 301, 302, 304, 307, 308]
@@ -84,13 +94,14 @@ type CacheConfig struct {
 
 // DefaultCacheConfig is the default configuration for the cache middleware.
 var DefaultCacheConfig = CacheConfig{
-	CacheControl: "private, max-age=60",
-	DefaultTTL:   time.Minute,
-	MaxBodySize:  10 * 1024 * 1024,
-	MaxEntries:   10000,
-	ETag:         true,
-	LastModified: true,
-	Vary:         []string{httpx.HeaderAccept, httpx.HeaderAcceptEncoding, httpx.HeaderAcceptLanguage},
-	ExemptPaths:  []string{},
-	StatusCodes:  []int{200, 201, 204, 301, 302, 304, 307, 308},
+	CacheControl:  "private, max-age=60",
+	DefaultTTL:    time.Minute,
+	MaxBodySize:   10 * 1024 * 1024,
+	MaxEntries:    10000,
+	ETag:          true,
+	LastModified:  true,
+	Vary:          []string{httpx.HeaderAccept, httpx.HeaderAcceptEncoding, httpx.HeaderAcceptLanguage},
+	ExcludedPaths: []string{},
+	IncludedPaths: []string{},
+	StatusCodes:   []int{200, 201, 204, 301, 302, 304, 307, 308},
 }

--- a/config/cache_test.go
+++ b/config/cache_test.go
@@ -48,8 +48,12 @@ func TestDefaultCacheConfig(t *testing.T) {
 			t.Error("expected Store to be nil by default")
 		}
 
-		if len(cfg.ExemptPaths) != 0 {
-			t.Errorf("expected ExemptPaths to be empty, got %v", cfg.ExemptPaths)
+		if len(cfg.ExcludedPaths) != 0 {
+			t.Errorf("expected ExcludedPaths to be empty, got %v", cfg.ExcludedPaths)
+		}
+
+		if len(cfg.IncludedPaths) != 0 {
+			t.Errorf("expected IncludedPaths to be empty, got %v", cfg.IncludedPaths)
 		}
 
 		expectedStatusCodes := []int{200, 201, 204, 301, 302, 304, 307, 308}
@@ -89,16 +93,16 @@ func TestCacheConfigCustomization(t *testing.T) {
 		customStore := &mockCacheStore{}
 
 		cfg := CacheConfig{
-			CacheControl: "public, max-age=3600",
-			DefaultTTL:   time.Hour,
-			MaxBodySize:  5 * 1024 * 1024,
-			MaxEntries:   5000,
-			ETag:         false,
-			LastModified: false,
-			Vary:         []string{"Accept"},
-			Store:        customStore,
-			ExemptPaths:  []string{"/api/live", "/health"},
-			StatusCodes:  []int{200, 201},
+			CacheControl:  "public, max-age=3600",
+			DefaultTTL:    time.Hour,
+			MaxBodySize:   5 * 1024 * 1024,
+			MaxEntries:    5000,
+			ETag:          false,
+			LastModified:  false,
+			Vary:          []string{"Accept"},
+			Store:         customStore,
+			ExcludedPaths: []string{"/api/live", "/health"},
+			StatusCodes:   []int{200, 201},
 		}
 
 		if cfg.CacheControl != "public, max-age=3600" {
@@ -129,8 +133,78 @@ func TestCacheConfigCustomization(t *testing.T) {
 			t.Error("expected custom store to be set")
 		}
 
-		if len(cfg.ExemptPaths) != 2 {
-			t.Errorf("expected 2 exempt paths, got %d", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 2 {
+			t.Errorf("expected 2 excluded paths, got %d", len(cfg.ExcludedPaths))
+		}
+	})
+}
+
+func TestCacheConfig_IncludedPaths(t *testing.T) {
+	t.Run("custom included paths", func(t *testing.T) {
+		includedPaths := []string{"/api/public", "/health"}
+		cfg := CacheConfig{
+			CacheControl:  DefaultCacheConfig.CacheControl,
+			DefaultTTL:    DefaultCacheConfig.DefaultTTL,
+			MaxBodySize:   DefaultCacheConfig.MaxBodySize,
+			MaxEntries:    DefaultCacheConfig.MaxEntries,
+			ETag:          DefaultCacheConfig.ETag,
+			LastModified:  DefaultCacheConfig.LastModified,
+			Vary:          DefaultCacheConfig.Vary,
+			StatusCodes:   DefaultCacheConfig.StatusCodes,
+			IncludedPaths: includedPaths,
+		}
+		if len(cfg.IncludedPaths) != 2 {
+			t.Errorf("expected 2 included paths, got %d", len(cfg.IncludedPaths))
+		}
+		if cfg.IncludedPaths[0] != "/api/public" {
+			t.Errorf("expected first allowed path to be /api/public, got %s", cfg.IncludedPaths[0])
+		}
+		if cfg.IncludedPaths[1] != "/health" {
+			t.Errorf("expected second allowed path to be /health, got %s", cfg.IncludedPaths[1])
+		}
+	})
+
+	t.Run("both excluded and included paths", func(t *testing.T) {
+		excludedPaths := []string{"/api/live", "/health"}
+		includedPaths := []string{"/api/public"}
+		cfg := CacheConfig{
+			CacheControl:  DefaultCacheConfig.CacheControl,
+			DefaultTTL:    DefaultCacheConfig.DefaultTTL,
+			MaxBodySize:   DefaultCacheConfig.MaxBodySize,
+			MaxEntries:    DefaultCacheConfig.MaxEntries,
+			ETag:          DefaultCacheConfig.ETag,
+			LastModified:  DefaultCacheConfig.LastModified,
+			Vary:          DefaultCacheConfig.Vary,
+			StatusCodes:   DefaultCacheConfig.StatusCodes,
+			ExcludedPaths: excludedPaths,
+			IncludedPaths: includedPaths,
+		}
+		if len(cfg.ExcludedPaths) != 2 {
+			t.Errorf("expected 2 excluded paths, got %d", len(cfg.ExcludedPaths))
+		}
+		if len(cfg.IncludedPaths) != 1 {
+			t.Errorf("expected 1 allowed path, got %d", len(cfg.IncludedPaths))
+		}
+	})
+
+	t.Run("empty included paths", func(t *testing.T) {
+		cfg := CacheConfig{
+			IncludedPaths: []string{},
+		}
+		if cfg.IncludedPaths == nil {
+			t.Error("expected included paths slice to be initialized, not nil")
+		}
+		if len(cfg.IncludedPaths) != 0 {
+			t.Errorf("expected empty included paths slice, got %d entries", len(cfg.IncludedPaths))
+		}
+	})
+
+	t.Run("nil included paths", func(t *testing.T) {
+		cfg := CacheConfig{
+			IncludedPaths: nil,
+		}
+		if cfg.IncludedPaths != nil {
+			t.Error("expected included paths to remain nil when nil is passed")
 		}
 	})
 }

--- a/config/compress.go
+++ b/config/compress.go
@@ -86,8 +86,19 @@ type CompressConfig struct {
 	// Algorithms are compression algorithms to support (defaults to gzip, deflate)
 	Algorithms []CompressionAlgorithm
 
-	// ExemptPaths contains paths to skip compression
-	ExemptPaths []string
+	// ExcludedPaths contains paths to skip compression.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// Cannot be used with IncludedPaths - setting both will panic.
+	// Default: []
+	ExcludedPaths []string
+
+	// IncludedPaths contains paths where compression is explicitly applied.
+	// If set, compression will only occur for paths matching these patterns.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// If empty, compression applies to all paths (subject to ExcludedPaths).
+	// Cannot be used with ExcludedPaths - setting both will panic.
+	// Default: []
+	IncludedPaths []string
 
 	// Providers are optional custom compression providers.
 	// If set, the providers' encoders will be used in addition to built-in gzip/deflate.
@@ -98,8 +109,9 @@ type CompressConfig struct {
 
 // DefaultCompressConfig contains the default values for compression configuration.
 var DefaultCompressConfig = CompressConfig{
-	Level:       6,
-	Types:       DefaultCompressTypes,
-	Algorithms:  []CompressionAlgorithm{Gzip, Deflate},
-	ExemptPaths: []string{},
+	Level:         6,
+	Types:         DefaultCompressTypes,
+	Algorithms:    []CompressionAlgorithm{Gzip, Deflate},
+	ExcludedPaths: []string{},
+	IncludedPaths: []string{},
 }

--- a/config/compress_test.go
+++ b/config/compress_test.go
@@ -16,8 +16,11 @@ func TestCompressConfig_DefaultValues(t *testing.T) {
 	if len(cfg.Algorithms) != 2 {
 		t.Errorf("expected 2 default algorithms, got %d", len(cfg.Algorithms))
 	}
-	if len(cfg.ExemptPaths) != 0 {
-		t.Errorf("expected default exempt paths to be empty, got %d paths", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 0 {
+		t.Errorf("expected default excluded paths to be empty, got %d paths", len(cfg.ExcludedPaths))
+	}
+	if len(cfg.IncludedPaths) != 0 {
+		t.Errorf("expected default included paths to be empty, got %d paths", len(cfg.IncludedPaths))
 	}
 
 	expectedAlgorithms := []CompressionAlgorithm{Gzip, Deflate}
@@ -43,10 +46,10 @@ func TestCompressConfig_DefaultValues(t *testing.T) {
 func TestCompressConfig_StructAssignment(t *testing.T) {
 	t.Run("level assignment", func(t *testing.T) {
 		cfg := CompressConfig{
-			Level:       9,
-			Types:       DefaultCompressConfig.Types,
-			Algorithms:  DefaultCompressConfig.Algorithms,
-			ExemptPaths: []string{},
+			Level:         9,
+			Types:         DefaultCompressConfig.Types,
+			Algorithms:    DefaultCompressConfig.Algorithms,
+			ExcludedPaths: []string{},
 		}
 		if cfg.Level != 9 {
 			t.Errorf("expected level = 9, got %d", cfg.Level)
@@ -56,10 +59,10 @@ func TestCompressConfig_StructAssignment(t *testing.T) {
 	t.Run("types assignment", func(t *testing.T) {
 		types := []string{"text/html", "application/json", "text/css", "application/xml"}
 		cfg := CompressConfig{
-			Level:       6,
-			Types:       types,
-			Algorithms:  DefaultCompressConfig.Algorithms,
-			ExemptPaths: []string{},
+			Level:         6,
+			Types:         types,
+			Algorithms:    DefaultCompressConfig.Algorithms,
+			ExcludedPaths: []string{},
 		}
 		if !reflect.DeepEqual(cfg.Types, types) {
 			t.Errorf("expected types = %v, got %v", types, cfg.Types)
@@ -69,26 +72,43 @@ func TestCompressConfig_StructAssignment(t *testing.T) {
 	t.Run("algorithms assignment", func(t *testing.T) {
 		algorithms := []CompressionAlgorithm{Gzip}
 		cfg := CompressConfig{
-			Level:       6,
-			Types:       DefaultCompressConfig.Types,
-			Algorithms:  algorithms,
-			ExemptPaths: []string{},
+			Level:         6,
+			Types:         DefaultCompressConfig.Types,
+			Algorithms:    algorithms,
+			ExcludedPaths: []string{},
 		}
 		if !reflect.DeepEqual(cfg.Algorithms, algorithms) {
 			t.Errorf("expected algorithms = %v, got %v", algorithms, cfg.Algorithms)
 		}
 	})
 
-	t.Run("exempt paths assignment", func(t *testing.T) {
-		exemptPaths := []string{"/api/stream", "/download", "/static/images", "/videos"}
+	t.Run("excluded paths assignment", func(t *testing.T) {
+		excludedPaths := []string{"/api/stream", "/download", "/static/images", "/videos"}
 		cfg := CompressConfig{
-			Level:       6,
-			Types:       DefaultCompressConfig.Types,
-			Algorithms:  DefaultCompressConfig.Algorithms,
-			ExemptPaths: exemptPaths,
+			Level:         6,
+			Types:         DefaultCompressConfig.Types,
+			Algorithms:    DefaultCompressConfig.Algorithms,
+			ExcludedPaths: excludedPaths,
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Errorf("expected exempt paths = %v, got %v", exemptPaths, cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Errorf("expected excluded paths = %v, got %v", excludedPaths, cfg.ExcludedPaths)
+		}
+	})
+
+	t.Run("included paths assignment", func(t *testing.T) {
+		includedPaths := []string{"/api/public", "/health"}
+		cfg := CompressConfig{
+			Level:         6,
+			Types:         DefaultCompressConfig.Types,
+			Algorithms:    DefaultCompressConfig.Algorithms,
+			ExcludedPaths: []string{},
+			IncludedPaths: includedPaths,
+		}
+		if len(cfg.IncludedPaths) != 2 {
+			t.Errorf("expected 2 included paths, got %d", len(cfg.IncludedPaths))
+		}
+		if !reflect.DeepEqual(cfg.IncludedPaths, includedPaths) {
+			t.Errorf("expected included paths = %v, got %v", includedPaths, cfg.IncludedPaths)
 		}
 	})
 }
@@ -96,13 +116,13 @@ func TestCompressConfig_StructAssignment(t *testing.T) {
 func TestCompressConfig_MultipleFields(t *testing.T) {
 	types := []string{"application/json", "text/html", "text/css"}
 	algorithms := []CompressionAlgorithm{Deflate}
-	exemptPaths := []string{"/large-files", "/api/binary"}
+	excludedPaths := []string{"/large-files", "/api/binary"}
 
 	cfg := CompressConfig{
-		Level:       3,
-		Types:       types,
-		Algorithms:  algorithms,
-		ExemptPaths: exemptPaths,
+		Level:         3,
+		Types:         types,
+		Algorithms:    algorithms,
+		ExcludedPaths: excludedPaths,
 	}
 
 	if cfg.Level != 3 {
@@ -114,18 +134,22 @@ func TestCompressConfig_MultipleFields(t *testing.T) {
 	if len(cfg.Algorithms) != 1 || cfg.Algorithms[0] != Deflate {
 		t.Errorf("expected algorithm = %s, got %v", Deflate, cfg.Algorithms)
 	}
-	if len(cfg.ExemptPaths) != 2 {
-		t.Errorf("expected 2 exempt paths, got %d", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 2 {
+		t.Errorf("expected 2 excluded paths, got %d", len(cfg.ExcludedPaths))
+	}
+	if len(cfg.IncludedPaths) != 0 {
+		t.Errorf("expected 0 included paths, got %d", len(cfg.IncludedPaths))
 	}
 }
 
 func TestCompressConfig_EdgeCases(t *testing.T) {
 	t.Run("empty slices", func(t *testing.T) {
 		cfg := CompressConfig{
-			Level:       6,
-			Types:       []string{},
-			Algorithms:  []CompressionAlgorithm{},
-			ExemptPaths: []string{},
+			Level:         6,
+			Types:         []string{},
+			Algorithms:    []CompressionAlgorithm{},
+			ExcludedPaths: []string{},
+			IncludedPaths: []string{},
 		}
 
 		if cfg.Types == nil || len(cfg.Types) != 0 {
@@ -134,17 +158,21 @@ func TestCompressConfig_EdgeCases(t *testing.T) {
 		if cfg.Algorithms == nil || len(cfg.Algorithms) != 0 {
 			t.Errorf("expected empty algorithms slice, got %v", cfg.Algorithms)
 		}
-		if cfg.ExemptPaths == nil || len(cfg.ExemptPaths) != 0 {
-			t.Errorf("expected empty exempt paths slice, got %v", cfg.ExemptPaths)
+		if cfg.ExcludedPaths == nil || len(cfg.ExcludedPaths) != 0 {
+			t.Errorf("expected empty excluded paths slice, got %v", cfg.ExcludedPaths)
+		}
+		if cfg.IncludedPaths == nil || len(cfg.IncludedPaths) != 0 {
+			t.Errorf("expected empty included paths slice, got %v", cfg.IncludedPaths)
 		}
 	})
 
 	t.Run("nil slices", func(t *testing.T) {
 		cfg := CompressConfig{
-			Level:       6,
-			Types:       nil,
-			Algorithms:  nil,
-			ExemptPaths: nil,
+			Level:         6,
+			Types:         nil,
+			Algorithms:    nil,
+			ExcludedPaths: nil,
+			IncludedPaths: nil,
 		}
 
 		if cfg.Types != nil {
@@ -153,8 +181,11 @@ func TestCompressConfig_EdgeCases(t *testing.T) {
 		if cfg.Algorithms != nil {
 			t.Error("expected algorithms to be nil")
 		}
-		if cfg.ExemptPaths != nil {
-			t.Error("expected exempt paths to be nil")
+		if cfg.ExcludedPaths != nil {
+			t.Error("expected excluded paths to be nil")
+		}
+		if cfg.IncludedPaths != nil {
+			t.Error("expected included paths to be nil")
 		}
 	})
 
@@ -162,10 +193,10 @@ func TestCompressConfig_EdgeCases(t *testing.T) {
 		testCases := []int{-1, 0, 1, 5, 9, 10}
 		for _, level := range testCases {
 			cfg := CompressConfig{
-				Level:       level,
-				Types:       DefaultCompressConfig.Types,
-				Algorithms:  DefaultCompressConfig.Algorithms,
-				ExemptPaths: []string{},
+				Level:         level,
+				Types:         DefaultCompressConfig.Types,
+				Algorithms:    DefaultCompressConfig.Algorithms,
+				ExcludedPaths: []string{},
 			}
 			if cfg.Level != level {
 				t.Errorf("expected level = %d, got %d", level, cfg.Level)
@@ -178,10 +209,10 @@ func TestCompressConfig_CustomScenarios(t *testing.T) {
 	t.Run("mixed algorithms", func(t *testing.T) {
 		algorithms := []CompressionAlgorithm{Deflate, Gzip}
 		cfg := CompressConfig{
-			Level:       6,
-			Types:       DefaultCompressConfig.Types,
-			Algorithms:  algorithms,
-			ExemptPaths: []string{},
+			Level:         6,
+			Types:         DefaultCompressConfig.Types,
+			Algorithms:    algorithms,
+			ExcludedPaths: []string{},
 		}
 		if len(cfg.Algorithms) != 2 {
 			t.Errorf("expected 2 algorithms, got %d", len(cfg.Algorithms))
@@ -199,10 +230,10 @@ func TestCompressConfig_CustomScenarios(t *testing.T) {
 			"text/csv",
 		}
 		cfg := CompressConfig{
-			Level:       6,
-			Types:       customTypes,
-			Algorithms:  DefaultCompressConfig.Algorithms,
-			ExemptPaths: []string{},
+			Level:         6,
+			Types:         customTypes,
+			Algorithms:    DefaultCompressConfig.Algorithms,
+			ExcludedPaths: []string{},
 		}
 		if !reflect.DeepEqual(cfg.Types, customTypes) {
 			t.Errorf("expected custom types %v, got %v", customTypes, cfg.Types)
@@ -210,7 +241,7 @@ func TestCompressConfig_CustomScenarios(t *testing.T) {
 	})
 
 	t.Run("path patterns", func(t *testing.T) {
-		exemptPaths := []string{
+		excludedPaths := []string{
 			"/api/v1/upload/*",
 			"/static/images/*",
 			"/download/*",
@@ -219,13 +250,13 @@ func TestCompressConfig_CustomScenarios(t *testing.T) {
 			"/health",
 		}
 		cfg := CompressConfig{
-			Level:       6,
-			Types:       DefaultCompressConfig.Types,
-			Algorithms:  DefaultCompressConfig.Algorithms,
-			ExemptPaths: exemptPaths,
+			Level:         6,
+			Types:         DefaultCompressConfig.Types,
+			Algorithms:    DefaultCompressConfig.Algorithms,
+			ExcludedPaths: excludedPaths,
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Errorf("expected exempt paths %v, got %v", exemptPaths, cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Errorf("expected excluded paths %v, got %v", excludedPaths, cfg.ExcludedPaths)
 		}
 	})
 }

--- a/config/content_encoding.go
+++ b/config/content_encoding.go
@@ -7,12 +7,24 @@ type ContentEncodingConfig struct {
 	// Encodings is a list of allowed content encodings (gzip, deflate, br, etc.)
 	Encodings []string
 
-	// ExemptPaths contains paths that skip content encoding validation
-	ExemptPaths []string
+	// ExcludedPaths contains paths that skip content encoding validation.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// Cannot be used with IncludedPaths - setting both will panic.
+	// Default: []
+	ExcludedPaths []string
+
+	// IncludedPaths contains paths where content encoding validation is explicitly applied.
+	// If set, validation will only occur for paths matching these patterns.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// If empty, validation applies to all paths (subject to ExcludedPaths).
+	// Cannot be used with ExcludedPaths - setting both will panic.
+	// Default: []
+	IncludedPaths []string
 }
 
 // DefaultContentEncodingConfig contains the default values for content encoding configuration.
 var DefaultContentEncodingConfig = ContentEncodingConfig{
-	Encodings:   []string{httpx.ContentEncodingGzip, httpx.ContentEncodingDeflate},
-	ExemptPaths: []string{},
+	Encodings:     []string{httpx.ContentEncodingGzip, httpx.ContentEncodingDeflate},
+	ExcludedPaths: []string{},
+	IncludedPaths: []string{},
 }

--- a/config/content_encoding_test.go
+++ b/config/content_encoding_test.go
@@ -10,8 +10,11 @@ func TestContentEncodingConfig_DefaultValues(t *testing.T) {
 	if len(cfg.Encodings) != 2 {
 		t.Errorf("expected 2 default encodings, got %d", len(cfg.Encodings))
 	}
-	if len(cfg.ExemptPaths) != 0 {
-		t.Errorf("expected default exempt paths to be empty, got %d paths", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 0 {
+		t.Errorf("expected default excluded paths to be empty, got %d paths", len(cfg.ExcludedPaths))
+	}
+	if len(cfg.IncludedPaths) != 0 {
+		t.Errorf("expected default included paths to be empty, got %d paths", len(cfg.IncludedPaths))
 	}
 	expectedEncodings := []string{"gzip", "deflate"}
 	if !reflect.DeepEqual(cfg.Encodings, expectedEncodings) {
@@ -54,16 +57,29 @@ func TestContentEncodingConfig_StructAssignment(t *testing.T) {
 		}
 	})
 
-	t.Run("exempt paths assignment", func(t *testing.T) {
-		exemptPaths := []string{"/api/upload", "/health", "/metrics", "/static"}
+	t.Run("excluded paths assignment", func(t *testing.T) {
+		excludedPaths := []string{"/api/upload", "/health", "/metrics", "/static"}
 		cfg := ContentEncodingConfig{
-			ExemptPaths: exemptPaths,
+			ExcludedPaths: excludedPaths,
 		}
-		if len(cfg.ExemptPaths) != 4 {
-			t.Errorf("expected 4 exempt paths, got %d", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 4 {
+			t.Errorf("expected 4 excluded paths, got %d", len(cfg.ExcludedPaths))
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Errorf("expected exempt paths = %v, got %v", exemptPaths, cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Errorf("expected excluded paths = %v, got %v", excludedPaths, cfg.ExcludedPaths)
+		}
+	})
+
+	t.Run("included paths assignment", func(t *testing.T) {
+		includedPaths := []string{"/api/public", "/health"}
+		cfg := ContentEncodingConfig{
+			IncludedPaths: includedPaths,
+		}
+		if len(cfg.IncludedPaths) != 2 {
+			t.Errorf("expected 2 included paths, got %d", len(cfg.IncludedPaths))
+		}
+		if !reflect.DeepEqual(cfg.IncludedPaths, includedPaths) {
+			t.Errorf("expected included paths = %v, got %v", includedPaths, cfg.IncludedPaths)
 		}
 	})
 
@@ -85,10 +101,12 @@ func TestContentEncodingConfig_StructAssignment(t *testing.T) {
 
 func TestContentEncodingConfig_MultipleFields(t *testing.T) {
 	encodings := []string{"br", "gzip"}
-	exemptPaths := []string{"/upload", "/download"}
+	excludedPaths := []string{"/upload", "/download"}
+	includedPaths := []string{"/api/public"}
 	cfg := ContentEncodingConfig{
-		Encodings:   encodings,
-		ExemptPaths: exemptPaths,
+		Encodings:     encodings,
+		ExcludedPaths: excludedPaths,
+		IncludedPaths: includedPaths,
 	}
 
 	if len(cfg.Encodings) != 2 {
@@ -97,40 +115,54 @@ func TestContentEncodingConfig_MultipleFields(t *testing.T) {
 	if !reflect.DeepEqual(cfg.Encodings, encodings) {
 		t.Error("expected encodings to be set correctly")
 	}
-	if len(cfg.ExemptPaths) != 2 {
-		t.Errorf("expected 2 exempt paths, got %d", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 2 {
+		t.Errorf("expected 2 excluded paths, got %d", len(cfg.ExcludedPaths))
 	}
-	if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-		t.Error("expected exempt paths to be set correctly")
+	if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+		t.Error("expected excluded paths to be set correctly")
+	}
+	if len(cfg.IncludedPaths) != 1 {
+		t.Errorf("expected 1 allowed path, got %d", len(cfg.IncludedPaths))
+	}
+	if !reflect.DeepEqual(cfg.IncludedPaths, includedPaths) {
+		t.Error("expected included paths to be set correctly")
 	}
 }
 
 func TestContentEncodingConfig_EdgeCases(t *testing.T) {
 	t.Run("empty slices", func(t *testing.T) {
 		cfg := ContentEncodingConfig{
-			Encodings:   []string{},
-			ExemptPaths: []string{},
+			Encodings:     []string{},
+			ExcludedPaths: []string{},
+			IncludedPaths: []string{},
 		}
 
 		if cfg.Encodings == nil || len(cfg.Encodings) != 0 {
 			t.Errorf("expected empty encodings slice, got %v", cfg.Encodings)
 		}
-		if cfg.ExemptPaths == nil || len(cfg.ExemptPaths) != 0 {
-			t.Errorf("expected empty exempt paths slice, got %v", cfg.ExemptPaths)
+		if cfg.ExcludedPaths == nil || len(cfg.ExcludedPaths) != 0 {
+			t.Errorf("expected empty excluded paths slice, got %v", cfg.ExcludedPaths)
+		}
+		if cfg.IncludedPaths == nil || len(cfg.IncludedPaths) != 0 {
+			t.Errorf("expected empty included paths slice, got %v", cfg.IncludedPaths)
 		}
 	})
 
 	t.Run("nil slices", func(t *testing.T) {
 		cfg := ContentEncodingConfig{
-			Encodings:   nil,
-			ExemptPaths: nil,
+			Encodings:     nil,
+			ExcludedPaths: nil,
+			IncludedPaths: nil,
 		}
 
 		if cfg.Encodings != nil {
 			t.Error("expected encodings to remain nil when nil is passed")
 		}
-		if cfg.ExemptPaths != nil {
-			t.Error("expected exempt paths to remain nil when nil is passed")
+		if cfg.ExcludedPaths != nil {
+			t.Error("expected excluded paths to remain nil when nil is passed")
+		}
+		if cfg.IncludedPaths != nil {
+			t.Error("expected included paths to remain nil when nil is passed")
 		}
 	})
 
@@ -166,10 +198,10 @@ func TestContentEncodingConfig_EdgeCases(t *testing.T) {
 
 	t.Run("empty string values", func(t *testing.T) {
 		encodings := []string{"", "gzip", ""}
-		exemptPaths := []string{"", "/health", ""}
+		excludedPaths := []string{"", "/health", ""}
 		cfg := ContentEncodingConfig{
-			Encodings:   encodings,
-			ExemptPaths: exemptPaths,
+			Encodings:     encodings,
+			ExcludedPaths: excludedPaths,
 		}
 
 		if len(cfg.Encodings) != 3 {
@@ -181,12 +213,12 @@ func TestContentEncodingConfig_EdgeCases(t *testing.T) {
 			}
 		}
 
-		if len(cfg.ExemptPaths) != 3 {
-			t.Errorf("expected 3 exempt paths, got %d", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 3 {
+			t.Errorf("expected 3 excluded paths, got %d", len(cfg.ExcludedPaths))
 		}
-		for i, expectedPath := range exemptPaths {
-			if cfg.ExemptPaths[i] != expectedPath {
-				t.Errorf("expected exempt path[%d] = %q, got %q", i, expectedPath, cfg.ExemptPaths[i])
+		for i, expectedPath := range excludedPaths {
+			if cfg.ExcludedPaths[i] != expectedPath {
+				t.Errorf("expected excluded path[%d] = %q, got %q", i, expectedPath, cfg.ExcludedPaths[i])
 			}
 		}
 	})
@@ -194,7 +226,7 @@ func TestContentEncodingConfig_EdgeCases(t *testing.T) {
 
 func TestContentEncodingConfig_PathPatterns(t *testing.T) {
 	t.Run("pattern paths", func(t *testing.T) {
-		exemptPaths := []string{
+		excludedPaths := []string{
 			"/api/v1/upload/*",
 			"/static/*",
 			"/health",
@@ -204,18 +236,18 @@ func TestContentEncodingConfig_PathPatterns(t *testing.T) {
 			"/admin/files/*",
 		}
 		cfg := ContentEncodingConfig{
-			ExemptPaths: exemptPaths,
+			ExcludedPaths: excludedPaths,
 		}
-		if len(cfg.ExemptPaths) != len(exemptPaths) {
-			t.Errorf("expected %d exempt paths, got %d", len(exemptPaths), len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != len(excludedPaths) {
+			t.Errorf("expected %d excluded paths, got %d", len(excludedPaths), len(cfg.ExcludedPaths))
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Errorf("expected exempt paths = %v, got %v", exemptPaths, cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Errorf("expected excluded paths = %v, got %v", excludedPaths, cfg.ExcludedPaths)
 		}
 	})
 
 	t.Run("special character paths", func(t *testing.T) {
-		exemptPaths := []string{
+		excludedPaths := []string{
 			"/api-v1/upload",
 			"/static_files",
 			"/health-check",
@@ -225,13 +257,13 @@ func TestContentEncodingConfig_PathPatterns(t *testing.T) {
 			"/path/with/unicode-ñ",
 		}
 		cfg := ContentEncodingConfig{
-			ExemptPaths: exemptPaths,
+			ExcludedPaths: excludedPaths,
 		}
-		if len(cfg.ExemptPaths) != len(exemptPaths) {
-			t.Errorf("expected %d exempt paths, got %d", len(exemptPaths), len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != len(excludedPaths) {
+			t.Errorf("expected %d excluded paths, got %d", len(excludedPaths), len(cfg.ExcludedPaths))
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Errorf("expected exempt paths = %v, got %v", exemptPaths, cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Errorf("expected excluded paths = %v, got %v", excludedPaths, cfg.ExcludedPaths)
 		}
 	})
 }

--- a/config/content_type.go
+++ b/config/content_type.go
@@ -7,12 +7,24 @@ type ContentTypeConfig struct {
 	// ContentTypes is a list of allowed content types
 	ContentTypes []string
 
-	// ExemptPaths contains paths that skip content type validation
-	ExemptPaths []string
+	// ExcludedPaths contains paths that skip content type validation.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// Cannot be used with IncludedPaths - setting both will panic.
+	// Default: []
+	ExcludedPaths []string
+
+	// IncludedPaths contains paths where content type validation is explicitly applied.
+	// If set, validation will only occur for paths matching these patterns.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// If empty, validation applies to all paths (subject to ExcludedPaths).
+	// Cannot be used with ExcludedPaths - setting both will panic.
+	// Default: []
+	IncludedPaths []string
 }
 
 // DefaultContentTypeConfig contains the default values for content type configuration.
 var DefaultContentTypeConfig = ContentTypeConfig{
-	ContentTypes: []string{httpx.MIMEApplicationJSON, httpx.MIMEApplicationFormURLEncoded, httpx.MIMEMultipartFormData},
-	ExemptPaths:  []string{},
+	ContentTypes:  []string{httpx.MIMEApplicationJSON, httpx.MIMEApplicationFormURLEncoded, httpx.MIMEMultipartFormData},
+	ExcludedPaths: []string{},
+	IncludedPaths: []string{},
 }

--- a/config/content_type_test.go
+++ b/config/content_type_test.go
@@ -10,8 +10,11 @@ func TestContentTypeConfig_DefaultValues(t *testing.T) {
 	if len(cfg.ContentTypes) != 3 {
 		t.Errorf("expected 3 default content types, got %d", len(cfg.ContentTypes))
 	}
-	if len(cfg.ExemptPaths) != 0 {
-		t.Errorf("expected default exempt paths to be empty, got %d paths", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 0 {
+		t.Errorf("expected default excluded paths to be empty, got %d paths", len(cfg.ExcludedPaths))
+	}
+	if len(cfg.IncludedPaths) != 0 {
+		t.Errorf("expected default included paths to be empty, got %d paths", len(cfg.IncludedPaths))
 	}
 	expectedContentTypes := []string{
 		"application/json",
@@ -62,26 +65,41 @@ func TestContentTypeConfig_StructAssignment(t *testing.T) {
 		}
 	})
 
-	t.Run("exempt paths assignment", func(t *testing.T) {
-		exemptPaths := []string{"/api/upload", "/health", "/webhook", "/files"}
+	t.Run("excluded paths assignment", func(t *testing.T) {
+		excludedPaths := []string{"/api/upload", "/health", "/webhook", "/files"}
 		cfg := ContentTypeConfig{
-			ExemptPaths: exemptPaths,
+			ExcludedPaths: excludedPaths,
 		}
-		if len(cfg.ExemptPaths) != 4 {
-			t.Errorf("expected 4 exempt paths, got %d", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 4 {
+			t.Errorf("expected 4 excluded paths, got %d", len(cfg.ExcludedPaths))
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Errorf("expected exempt paths = %v, got %v", exemptPaths, cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Errorf("expected excluded paths = %v, got %v", excludedPaths, cfg.ExcludedPaths)
+		}
+	})
+
+	t.Run("included paths assignment", func(t *testing.T) {
+		includedPaths := []string{"/api/public", "/health"}
+		cfg := ContentTypeConfig{
+			IncludedPaths: includedPaths,
+		}
+		if len(cfg.IncludedPaths) != 2 {
+			t.Errorf("expected 2 included paths, got %d", len(cfg.IncludedPaths))
+		}
+		if !reflect.DeepEqual(cfg.IncludedPaths, includedPaths) {
+			t.Errorf("expected included paths = %v, got %v", includedPaths, cfg.IncludedPaths)
 		}
 	})
 }
 
 func TestContentTypeConfig_MultipleFields(t *testing.T) {
 	contentTypes := []string{"application/json", "text/xml"}
-	exemptPaths := []string{"/upload", "/download"}
+	excludedPaths := []string{"/upload", "/download"}
+	includedPaths := []string{"/api/public"}
 	cfg := ContentTypeConfig{
-		ContentTypes: contentTypes,
-		ExemptPaths:  exemptPaths,
+		ContentTypes:  contentTypes,
+		ExcludedPaths: excludedPaths,
+		IncludedPaths: includedPaths,
 	}
 
 	if len(cfg.ContentTypes) != 2 {
@@ -90,40 +108,54 @@ func TestContentTypeConfig_MultipleFields(t *testing.T) {
 	if !reflect.DeepEqual(cfg.ContentTypes, contentTypes) {
 		t.Error("expected content types to be set correctly")
 	}
-	if len(cfg.ExemptPaths) != 2 {
-		t.Errorf("expected 2 exempt paths, got %d", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 2 {
+		t.Errorf("expected 2 excluded paths, got %d", len(cfg.ExcludedPaths))
 	}
-	if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-		t.Error("expected exempt paths to be set correctly")
+	if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+		t.Error("expected excluded paths to be set correctly")
+	}
+	if len(cfg.IncludedPaths) != 1 {
+		t.Errorf("expected 1 allowed path, got %d", len(cfg.IncludedPaths))
+	}
+	if !reflect.DeepEqual(cfg.IncludedPaths, includedPaths) {
+		t.Error("expected included paths to be set correctly")
 	}
 }
 
 func TestContentTypeConfig_EdgeCases(t *testing.T) {
 	t.Run("empty slices", func(t *testing.T) {
 		cfg := ContentTypeConfig{
-			ContentTypes: []string{},
-			ExemptPaths:  []string{},
+			ContentTypes:  []string{},
+			ExcludedPaths: []string{},
+			IncludedPaths: []string{},
 		}
 
 		if cfg.ContentTypes == nil || len(cfg.ContentTypes) != 0 {
 			t.Errorf("expected empty content types slice, got %v", cfg.ContentTypes)
 		}
-		if cfg.ExemptPaths == nil || len(cfg.ExemptPaths) != 0 {
-			t.Errorf("expected empty exempt paths slice, got %v", cfg.ExemptPaths)
+		if cfg.ExcludedPaths == nil || len(cfg.ExcludedPaths) != 0 {
+			t.Errorf("expected empty excluded paths slice, got %v", cfg.ExcludedPaths)
+		}
+		if cfg.IncludedPaths == nil || len(cfg.IncludedPaths) != 0 {
+			t.Errorf("expected empty included paths slice, got %v", cfg.IncludedPaths)
 		}
 	})
 
 	t.Run("nil slices", func(t *testing.T) {
 		cfg := ContentTypeConfig{
-			ContentTypes: nil,
-			ExemptPaths:  nil,
+			ContentTypes:  nil,
+			ExcludedPaths: nil,
+			IncludedPaths: nil,
 		}
 
 		if cfg.ContentTypes != nil {
 			t.Error("expected content types to remain nil when nil is passed")
 		}
-		if cfg.ExemptPaths != nil {
-			t.Error("expected exempt paths to remain nil when nil is passed")
+		if cfg.ExcludedPaths != nil {
+			t.Error("expected excluded paths to remain nil when nil is passed")
+		}
+		if cfg.IncludedPaths != nil {
+			t.Error("expected included paths to remain nil when nil is passed")
 		}
 	})
 
@@ -179,17 +211,17 @@ func TestContentTypeConfig_EdgeCases(t *testing.T) {
 
 	t.Run("empty string values", func(t *testing.T) {
 		contentTypes := []string{"", "application/json", ""}
-		exemptPaths := []string{"", "/health", ""}
+		excludedPaths := []string{"", "/health", ""}
 		cfg := ContentTypeConfig{
-			ContentTypes: contentTypes,
-			ExemptPaths:  exemptPaths,
+			ContentTypes:  contentTypes,
+			ExcludedPaths: excludedPaths,
 		}
 
 		if len(cfg.ContentTypes) != 3 {
 			t.Errorf("expected 3 content types, got %d", len(cfg.ContentTypes))
 		}
-		if len(cfg.ExemptPaths) != 3 {
-			t.Errorf("expected 3 exempt paths, got %d", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 3 {
+			t.Errorf("expected 3 excluded paths, got %d", len(cfg.ExcludedPaths))
 		}
 
 		for i, expectedType := range contentTypes {
@@ -197,9 +229,9 @@ func TestContentTypeConfig_EdgeCases(t *testing.T) {
 				t.Errorf("expected content type[%d] = %q, got %q", i, expectedType, cfg.ContentTypes[i])
 			}
 		}
-		for i, expectedPath := range exemptPaths {
-			if cfg.ExemptPaths[i] != expectedPath {
-				t.Errorf("expected exempt path[%d] = %q, got %q", i, expectedPath, cfg.ExemptPaths[i])
+		for i, expectedPath := range excludedPaths {
+			if cfg.ExcludedPaths[i] != expectedPath {
+				t.Errorf("expected excluded path[%d] = %q, got %q", i, expectedPath, cfg.ExcludedPaths[i])
 			}
 		}
 	})
@@ -207,7 +239,7 @@ func TestContentTypeConfig_EdgeCases(t *testing.T) {
 
 func TestContentTypeConfig_PathPatterns(t *testing.T) {
 	t.Run("pattern paths", func(t *testing.T) {
-		exemptPaths := []string{
+		excludedPaths := []string{
 			"/api/v1/upload/*",
 			"/static/*",
 			"/health",
@@ -218,18 +250,18 @@ func TestContentTypeConfig_PathPatterns(t *testing.T) {
 			"/webhook/*",
 		}
 		cfg := ContentTypeConfig{
-			ExemptPaths: exemptPaths,
+			ExcludedPaths: excludedPaths,
 		}
-		if len(cfg.ExemptPaths) != len(exemptPaths) {
-			t.Errorf("expected %d exempt paths, got %d", len(exemptPaths), len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != len(excludedPaths) {
+			t.Errorf("expected %d excluded paths, got %d", len(excludedPaths), len(cfg.ExcludedPaths))
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Errorf("expected exempt paths = %v, got %v", exemptPaths, cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Errorf("expected excluded paths = %v, got %v", excludedPaths, cfg.ExcludedPaths)
 		}
 	})
 
 	t.Run("special character paths", func(t *testing.T) {
-		exemptPaths := []string{
+		excludedPaths := []string{
 			"/api-v1/upload",
 			"/static_files",
 			"/health-check",
@@ -240,13 +272,13 @@ func TestContentTypeConfig_PathPatterns(t *testing.T) {
 			"/files/test@example.com",
 		}
 		cfg := ContentTypeConfig{
-			ExemptPaths: exemptPaths,
+			ExcludedPaths: excludedPaths,
 		}
-		if len(cfg.ExemptPaths) != len(exemptPaths) {
-			t.Errorf("expected %d exempt paths, got %d", len(exemptPaths), len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != len(excludedPaths) {
+			t.Errorf("expected %d excluded paths, got %d", len(excludedPaths), len(cfg.ExcludedPaths))
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Errorf("expected exempt paths = %v, got %v", exemptPaths, cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Errorf("expected excluded paths = %v, got %v", excludedPaths, cfg.ExcludedPaths)
 		}
 	})
 }

--- a/config/cors.go
+++ b/config/cors.go
@@ -33,8 +33,19 @@ type CORSConfig struct {
 	// OptionsPassthrough allows OPTIONS requests to be passed to the next handler
 	OptionsPassthrough bool
 
-	// ExemptPaths contains paths that skip CORS processing
-	ExemptPaths []string
+	// ExcludedPaths contains paths that skip CORS processing.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// Cannot be used with IncludedPaths - setting both will panic.
+	// Default: []
+	ExcludedPaths []string
+
+	// IncludedPaths contains paths where CORS processing is explicitly applied.
+	// If set, CORS will only be processed for paths matching these patterns.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// If empty, CORS applies to all paths (subject to ExcludedPaths).
+	// Cannot be used with ExcludedPaths - setting both will panic.
+	// Default: []
+	IncludedPaths []string
 
 	// AllowOriginFunc is a custom function to validate origins dynamically.
 	// If set, this takes precedence over AllowedOrigins matching.
@@ -64,5 +75,6 @@ var DefaultCORSConfig = CORSConfig{
 	AllowCredentials:   false,
 	MaxAge:             86400, // 24 hours
 	OptionsPassthrough: false,
-	ExemptPaths:        []string{},
+	ExcludedPaths:      []string{},
+	IncludedPaths:      []string{},
 }

--- a/config/cors_test.go
+++ b/config/cors_test.go
@@ -34,8 +34,11 @@ func TestCORSConfig_DefaultValues(t *testing.T) {
 	if cfg.OptionsPassthrough != false {
 		t.Errorf("expected default options passthrough = false, got %t", cfg.OptionsPassthrough)
 	}
-	if len(cfg.ExemptPaths) != 0 {
-		t.Errorf("expected default exempt paths to be empty, got %d paths", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 0 {
+		t.Errorf("expected default excluded paths to be empty, got %d paths", len(cfg.ExcludedPaths))
+	}
+	if len(cfg.IncludedPaths) != 0 {
+		t.Errorf("expected default included paths to be empty, got %d paths", len(cfg.IncludedPaths))
 	}
 
 	// Test default method values
@@ -184,19 +187,35 @@ func TestCORSConfig_StructAssignment(t *testing.T) {
 		}
 	})
 
-	t.Run("exempt paths", func(t *testing.T) {
-		exemptPaths := []string{"/health", "/metrics", "/internal", "/debug"}
+	t.Run("excluded paths", func(t *testing.T) {
+		excludedPaths := []string{"/health", "/metrics", "/internal", "/debug"}
 		cfg := CORSConfig{
 			AllowedOrigins: DefaultCORSConfig.AllowedOrigins,
 			AllowedMethods: DefaultCORSConfig.AllowedMethods,
 			AllowedHeaders: DefaultCORSConfig.AllowedHeaders,
-			ExemptPaths:    exemptPaths,
+			ExcludedPaths:  excludedPaths,
 		}
-		if len(cfg.ExemptPaths) != 4 {
-			t.Errorf("expected 4 exempt paths, got %d", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 4 {
+			t.Errorf("expected 4 excluded paths, got %d", len(cfg.ExcludedPaths))
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Errorf("expected exempt paths = %v, got %v", exemptPaths, cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Errorf("expected excluded paths = %v, got %v", excludedPaths, cfg.ExcludedPaths)
+		}
+	})
+
+	t.Run("included paths", func(t *testing.T) {
+		includedPaths := []string{"/api/public", "/health"}
+		cfg := CORSConfig{
+			AllowedOrigins: DefaultCORSConfig.AllowedOrigins,
+			AllowedMethods: DefaultCORSConfig.AllowedMethods,
+			AllowedHeaders: DefaultCORSConfig.AllowedHeaders,
+			IncludedPaths:  includedPaths,
+		}
+		if len(cfg.IncludedPaths) != 2 {
+			t.Errorf("expected 2 included paths, got %d", len(cfg.IncludedPaths))
+		}
+		if !reflect.DeepEqual(cfg.IncludedPaths, includedPaths) {
+			t.Errorf("expected included paths = %v, got %v", includedPaths, cfg.IncludedPaths)
 		}
 	})
 }
@@ -206,7 +225,8 @@ func TestCORSConfig_MultipleFields(t *testing.T) {
 	methods := []string{http.MethodGet, http.MethodPost}
 	headers := []string{"Content-Type"}
 	exposedHeaders := []string{"X-Total-Count"}
-	exemptPaths := []string{"/health"}
+	excludedPaths := []string{"/health"}
+	includedPaths := []string{"/api/public"}
 	cfg := CORSConfig{
 		AllowedOrigins:     origins,
 		AllowedMethods:     methods,
@@ -215,7 +235,8 @@ func TestCORSConfig_MultipleFields(t *testing.T) {
 		AllowCredentials:   true,
 		MaxAge:             7200,
 		OptionsPassthrough: true,
-		ExemptPaths:        exemptPaths,
+		ExcludedPaths:      excludedPaths,
+		IncludedPaths:      includedPaths,
 	}
 
 	if !reflect.DeepEqual(cfg.AllowedOrigins, origins) {
@@ -239,8 +260,11 @@ func TestCORSConfig_MultipleFields(t *testing.T) {
 	if cfg.OptionsPassthrough != true {
 		t.Error("expected options passthrough to be true")
 	}
-	if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-		t.Error("expected exempt paths to be set correctly")
+	if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+		t.Error("expected excluded paths to be set correctly")
+	}
+	if !reflect.DeepEqual(cfg.IncludedPaths, includedPaths) {
+		t.Error("expected included paths to be set correctly")
 	}
 }
 
@@ -251,7 +275,8 @@ func TestCORSConfig_EdgeCases(t *testing.T) {
 			AllowedMethods: []string{},
 			AllowedHeaders: []string{},
 			ExposedHeaders: []string{},
-			ExemptPaths:    []string{},
+			ExcludedPaths:  []string{},
+			IncludedPaths:  []string{},
 		}
 
 		if cfg.AllowedOrigins == nil || len(cfg.AllowedOrigins) != 0 {
@@ -266,8 +291,11 @@ func TestCORSConfig_EdgeCases(t *testing.T) {
 		if cfg.ExposedHeaders == nil || len(cfg.ExposedHeaders) != 0 {
 			t.Errorf("expected empty exposed headers slice, got %v", cfg.ExposedHeaders)
 		}
-		if cfg.ExemptPaths == nil || len(cfg.ExemptPaths) != 0 {
-			t.Errorf("expected empty exempt paths slice, got %v", cfg.ExemptPaths)
+		if cfg.ExcludedPaths == nil || len(cfg.ExcludedPaths) != 0 {
+			t.Errorf("expected empty excluded paths slice, got %v", cfg.ExcludedPaths)
+		}
+		if cfg.IncludedPaths == nil || len(cfg.IncludedPaths) != 0 {
+			t.Errorf("expected empty included paths slice, got %v", cfg.IncludedPaths)
 		}
 	})
 
@@ -277,7 +305,8 @@ func TestCORSConfig_EdgeCases(t *testing.T) {
 			AllowedMethods: nil,
 			AllowedHeaders: nil,
 			ExposedHeaders: nil,
-			ExemptPaths:    nil,
+			ExcludedPaths:  nil,
+			IncludedPaths:  nil,
 		}
 
 		if cfg.AllowedOrigins != nil {
@@ -292,8 +321,11 @@ func TestCORSConfig_EdgeCases(t *testing.T) {
 		if cfg.ExposedHeaders != nil {
 			t.Error("expected exposed headers to be nil when nil is passed")
 		}
-		if cfg.ExemptPaths != nil {
-			t.Error("expected exempt paths to be nil when nil is passed")
+		if cfg.ExcludedPaths != nil {
+			t.Error("expected excluded paths to be nil when nil is passed")
+		}
+		if cfg.IncludedPaths != nil {
+			t.Error("expected included paths to be nil when nil is passed")
 		}
 	})
 

--- a/config/csrf.go
+++ b/config/csrf.go
@@ -40,13 +40,23 @@ type CSRFConfig struct {
 	// Default: Returns 403 Forbidden with plain text error
 	ErrorHandler http.HandlerFunc
 
-	// ExemptPaths contains paths that skip CSRF validation
-	// Default: []string{}
-	ExemptPaths []string
+	// ExcludedPaths contains paths that skip CSRF validation.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// Cannot be used with IncludedPaths - setting both will panic.
+	// Default: []
+	ExcludedPaths []string
 
-	// ExemptMethods contains HTTP methods that skip CSRF validation
+	// IncludedPaths contains paths where CSRF validation is explicitly applied.
+	// If set, CSRF will only be validated for paths matching these patterns.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// If empty, CSRF applies to all paths (subject to ExcludedPaths).
+	// Cannot be used with ExcludedPaths - setting both will panic.
+	// Default: []
+	IncludedPaths []string
+
+	// ExcludedMethods contains HTTP methods that skip CSRF validation
 	// Default: []string{http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace}
-	ExemptMethods []string
+	ExcludedMethods []string
 
 	// HMACKey is the secret key used for HMAC signing (REQUIRED)
 	// Must be set explicitly. The middleware will panic if not set.
@@ -61,15 +71,16 @@ type CSRFConfig struct {
 
 // DefaultCSRFConfig contains the default values for CSRF configuration
 var DefaultCSRFConfig = CSRFConfig{
-	CookieName:     "csrf_token",
-	CookieMaxAge:   86400, // 24 hours
-	CookieDomain:   "",
-	CookiePath:     "/",
-	CookieSecure:   Bool(true),
-	CookieSameSite: http.SameSiteStrictMode,
-	TokenLookup:    "header:X-CSRF-Token",
-	ErrorHandler:   nil,
-	ExemptPaths:    []string{},
-	ExemptMethods:  []string{http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace},
-	HMACKey:        nil,
+	CookieName:      "csrf_token",
+	CookieMaxAge:    86400, // 24 hours
+	CookieDomain:    "",
+	CookiePath:      "/",
+	CookieSecure:    Bool(true),
+	CookieSameSite:  http.SameSiteStrictMode,
+	TokenLookup:     "header:X-CSRF-Token",
+	ErrorHandler:    nil,
+	ExcludedPaths:   []string{},
+	IncludedPaths:   []string{},
+	ExcludedMethods: []string{http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace},
+	HMACKey:         nil,
 }

--- a/config/csrf_test.go
+++ b/config/csrf_test.go
@@ -40,12 +40,16 @@ func TestCSRFConfig_DefaultValues(t *testing.T) {
 		t.Error("expected default ErrorHandler to be nil")
 	}
 
-	if len(cfg.ExemptPaths) != 0 {
-		t.Errorf("expected default ExemptPaths to be empty, got %d paths", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 0 {
+		t.Errorf("expected default ExcludedPaths to be empty, got %d paths", len(cfg.ExcludedPaths))
 	}
 
-	if len(cfg.ExemptMethods) != 4 {
-		t.Errorf("expected default ExemptMethods to have 4 methods, got %d", len(cfg.ExemptMethods))
+	if len(cfg.IncludedPaths) != 0 {
+		t.Errorf("expected default IncludedPaths to be empty, got %d paths", len(cfg.IncludedPaths))
+	}
+
+	if len(cfg.ExcludedMethods) != 4 {
+		t.Errorf("expected default ExcludedMethods to have 4 methods, got %d", len(cfg.ExcludedMethods))
 	}
 
 	if cfg.HMACKey != nil {
@@ -144,7 +148,46 @@ func TestCSRFConfig_CustomValues(t *testing.T) {
 	})
 }
 
-func TestCSRFConfig_ExemptMethods(t *testing.T) {
+func TestCSRFConfig_IncludedPaths(t *testing.T) {
+	t.Run("custom included paths", func(t *testing.T) {
+		includedPaths := []string{"/api/public", "/health"}
+		cfg := CSRFConfig{
+			IncludedPaths: includedPaths,
+		}
+		if len(cfg.IncludedPaths) != 2 {
+			t.Errorf("expected 2 included paths, got %d", len(cfg.IncludedPaths))
+		}
+		if cfg.IncludedPaths[0] != "/api/public" {
+			t.Errorf("expected first allowed path to be /api/public, got %s", cfg.IncludedPaths[0])
+		}
+		if cfg.IncludedPaths[1] != "/health" {
+			t.Errorf("expected second allowed path to be /health, got %s", cfg.IncludedPaths[1])
+		}
+	})
+
+	t.Run("empty included paths", func(t *testing.T) {
+		cfg := CSRFConfig{
+			IncludedPaths: []string{},
+		}
+		if cfg.IncludedPaths == nil {
+			t.Error("expected included paths slice to be initialized, not nil")
+		}
+		if len(cfg.IncludedPaths) != 0 {
+			t.Errorf("expected empty included paths slice, got %d entries", len(cfg.IncludedPaths))
+		}
+	})
+
+	t.Run("nil included paths", func(t *testing.T) {
+		cfg := CSRFConfig{
+			IncludedPaths: nil,
+		}
+		if cfg.IncludedPaths != nil {
+			t.Error("expected included paths to remain nil when nil is passed")
+		}
+	})
+}
+
+func TestCSRFConfig_ExcludedMethods(t *testing.T) {
 	cfg := DefaultCSRFConfig
 
 	expectedMethods := map[string]bool{
@@ -154,9 +197,9 @@ func TestCSRFConfig_ExemptMethods(t *testing.T) {
 		http.MethodTrace:   true,
 	}
 
-	for _, method := range cfg.ExemptMethods {
+	for _, method := range cfg.ExcludedMethods {
 		if !expectedMethods[method] {
-			t.Errorf("unexpected exempt method: %s", method)
+			t.Errorf("unexpected excluded method: %s", method)
 		}
 	}
 }

--- a/config/doc.go
+++ b/config/doc.go
@@ -36,7 +36,7 @@
 //	        "admin": "secret-password",
 //	    },
 //	    Realm: "Restricted Area",
-//	    ExemptPaths: []string{"/health"},
+//	    ExcludedPaths: []string{"/health"},
 //	}))
 //
 // # JWT Authentication
@@ -44,7 +44,7 @@
 //	cfg := config.JWTAuthConfig{
 //	    TokenStore:     myTokenStore,
 //	    RequiredClaims: []string{"sub"},
-//	    ExemptPaths:    []string{"/login", "/register"},
+//	    ExcludedPaths:    []string{"/login", "/register"},
 //	}
 //	app.Use(middleware.JWTAuth(cfg))
 //
@@ -141,7 +141,7 @@
 //	    Metrics: config.MetricsConfig{
 //	        Enabled:  true,
 //	        Endpoint: "/metrics",
-//	        ExcludePaths: []string{"/health", "/readyz"},
+//	        ExcludedPaths: []string{"/health", "/readyz"},
 //	    },
 //	})
 //

--- a/config/etag.go
+++ b/config/etag.go
@@ -34,11 +34,22 @@ type ETagConfig struct {
 	// SkipContentTypes contains content types that should not have ETags generated
 	SkipContentTypes map[string]struct{}
 
-	// ExemptPaths contains paths to skip ETag generation
-	ExemptPaths []string
+	// ExcludedPaths contains paths to skip ETag generation.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// Cannot be used with IncludedPaths - setting both will panic.
+	// Default: []
+	ExcludedPaths []string
 
-	// ExemptFunc is a custom function to determine if ETag generation should be skipped for a request
-	ExemptFunc func(r *http.Request) bool
+	// IncludedPaths contains paths where ETag generation is explicitly applied.
+	// If set, ETag will only be generated for paths matching these patterns.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// If empty, ETag applies to all paths (subject to ExcludedPaths).
+	// Cannot be used with ExcludedPaths - setting both will panic.
+	// Default: []
+	IncludedPaths []string
+
+	// ExcludedFunc is a custom function to determine if ETag generation should be skipped for a request
+	ExcludedFunc func(r *http.Request) bool
 }
 
 // DefaultETagConfig contains the default values for ETag configuration
@@ -66,6 +77,7 @@ var DefaultETagConfig = ETagConfig{
 	SkipContentTypes: map[string]struct{}{
 		httpx.MIMETextEventStream: {}, // SSE streaming
 	},
-	ExemptPaths: []string{},
-	ExemptFunc:  nil,
+	ExcludedPaths: []string{},
+	IncludedPaths: []string{},
+	ExcludedFunc:  nil,
 }

--- a/config/etag_test.go
+++ b/config/etag_test.go
@@ -28,12 +28,16 @@ func TestDefaultETagConfig(t *testing.T) {
 		t.Error("expected default SkipContentTypes to be non-nil")
 	}
 
-	if len(cfg.ExemptPaths) != 0 {
-		t.Errorf("expected default ExemptPaths to be empty, got %d", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 0 {
+		t.Errorf("expected default ExcludedPaths to be empty, got %d", len(cfg.ExcludedPaths))
 	}
 
-	if cfg.ExemptFunc != nil {
-		t.Error("expected default ExemptFunc to be nil")
+	if len(cfg.IncludedPaths) != 0 {
+		t.Errorf("expected default IncludedPaths to be empty, got %d", len(cfg.IncludedPaths))
+	}
+
+	if cfg.ExcludedFunc != nil {
+		t.Error("expected default ExcludedFunc to be nil")
 	}
 
 	// Check some specific skip status codes
@@ -125,53 +129,73 @@ func TestETagConfig_StructAssignment(t *testing.T) {
 		}
 	})
 
-	t.Run("exempt paths assignment", func(t *testing.T) {
+	t.Run("excluded paths assignment", func(t *testing.T) {
 		paths := []string{"/api/stream", "/health"}
 		cfg := ETagConfig{
-			ExemptPaths: paths,
+			ExcludedPaths: paths,
 		}
-		if len(cfg.ExemptPaths) != 2 {
-			t.Errorf("expected 2 exempt paths, got %d", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 2 {
+			t.Errorf("expected 2 excluded paths, got %d", len(cfg.ExcludedPaths))
 		}
-		if cfg.ExemptPaths[0] != "/api/stream" {
-			t.Errorf("expected first path to be /api/stream, got %s", cfg.ExemptPaths[0])
+		if cfg.ExcludedPaths[0] != "/api/stream" {
+			t.Errorf("expected first path to be /api/stream, got %s", cfg.ExcludedPaths[0])
 		}
-		if cfg.ExemptPaths[1] != "/health" {
-			t.Errorf("expected second path to be /health, got %s", cfg.ExemptPaths[1])
+		if cfg.ExcludedPaths[1] != "/health" {
+			t.Errorf("expected second path to be /health, got %s", cfg.ExcludedPaths[1])
 		}
 	})
 
-	t.Run("exempt func assignment", func(t *testing.T) {
+	t.Run("included paths assignment", func(t *testing.T) {
+		paths := []string{"/api/public", "/health"}
+		cfg := ETagConfig{
+			IncludedPaths: paths,
+		}
+		if len(cfg.IncludedPaths) != 2 {
+			t.Errorf("expected 2 included paths, got %d", len(cfg.IncludedPaths))
+		}
+		if cfg.IncludedPaths[0] != "/api/public" {
+			t.Errorf("expected first path to be /api/public, got %s", cfg.IncludedPaths[0])
+		}
+		if cfg.IncludedPaths[1] != "/health" {
+			t.Errorf("expected second path to be /health, got %s", cfg.IncludedPaths[1])
+		}
+	})
+
+	t.Run("excluded func assignment", func(t *testing.T) {
 		fn := func(r *http.Request) bool {
 			return r.Header.Get("X-Skip-ETag") == "true"
 		}
 		cfg := ETagConfig{
-			ExemptFunc: fn,
+			ExcludedFunc: fn,
 		}
-		if cfg.ExemptFunc == nil {
-			t.Fatal("expected ExemptFunc to be set")
+		if cfg.ExcludedFunc == nil {
+			t.Fatal("expected ExcludedFunc to be set")
 		}
 		// Test the function
 		req := &http.Request{
 			Header: http.Header{"X-Skip-Etag": []string{"true"}},
 		}
-		if !cfg.ExemptFunc(req) {
-			t.Error("expected ExemptFunc to return true for X-Skip-ETag: true")
+		if !cfg.ExcludedFunc(req) {
+			t.Error("expected ExcludedFunc to return true for X-Skip-ETag: true")
 		}
 		req2 := &http.Request{
 			Header: http.Header{},
 		}
-		if cfg.ExemptFunc(req2) {
-			t.Error("expected ExemptFunc to return false when X-Skip-ETag is not set")
+		if cfg.ExcludedFunc(req2) {
+			t.Error("expected ExcludedFunc to return false when X-Skip-ETag is not set")
 		}
 	})
 }
 
 func TestETagConfig_MultipleFields(t *testing.T) {
+	excludedPaths := []string{"/api/stream"}
+	includedPaths := []string{"/api/public"}
 	cfg := ETagConfig{
 		Algorithm:     MD5,
 		Weak:          Bool(false),
 		MaxBufferSize: 2 * 1024 * 1024,
+		ExcludedPaths: excludedPaths,
+		IncludedPaths: includedPaths,
 	}
 
 	if cfg.Algorithm != MD5 {
@@ -184,5 +208,13 @@ func TestETagConfig_MultipleFields(t *testing.T) {
 
 	if cfg.MaxBufferSize != 2*1024*1024 {
 		t.Errorf("expected MaxBufferSize to be 2MB, got %d", cfg.MaxBufferSize)
+	}
+
+	if len(cfg.ExcludedPaths) != 1 {
+		t.Errorf("expected 1 excluded path, got %d", len(cfg.ExcludedPaths))
+	}
+
+	if len(cfg.IncludedPaths) != 1 {
+		t.Errorf("expected 1 allowed path, got %d", len(cfg.IncludedPaths))
 	}
 }

--- a/config/hmac_auth.go
+++ b/config/hmac_auth.go
@@ -46,9 +46,19 @@ type HMACAuthConfig struct {
 	// Default: ["content-type"]
 	OptionalHeaders []string
 
-	// ExemptPaths are paths that skip HMAC validation.
+	// ExcludedPaths are paths that skip HMAC validation.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// Cannot be used with IncludedPaths - setting both will panic.
 	// Default: []
-	ExemptPaths []string
+	ExcludedPaths []string
+
+	// IncludedPaths contains paths where HMAC validation is explicitly applied.
+	// If set, HMAC validation will only occur for paths matching these patterns.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// If empty, HMAC validation applies to all paths (subject to ExcludedPaths).
+	// Cannot be used with ExcludedPaths - setting both will panic.
+	// Default: []
+	IncludedPaths []string
 
 	// ErrorHandler is called when HMAC validation fails.
 	// Default: Returns 401 Unauthorized with RFC 9457 Problem Details
@@ -100,7 +110,8 @@ var DefaultHMACAuthConfig = HMACAuthConfig{
 	ClockSkewGrace:       1 * time.Minute,
 	RequiredHeaders:      []string{"host", "x-timestamp"},
 	OptionalHeaders:      []string{"content-type"},
-	ExemptPaths:          []string{},
+	ExcludedPaths:        []string{},
+	IncludedPaths:        []string{},
 	ErrorHandler:         nil,
 	AuthHeaderName:       httpx.HeaderAuthorization,
 	TimestampHeader:      httpx.HeaderXTimestamp,

--- a/config/hmac_auth_test.go
+++ b/config/hmac_auth_test.go
@@ -36,6 +36,9 @@ func TestHMACAuthConfig_DefaultValues(t *testing.T) {
 	if cfg.CredentialStore != nil {
 		t.Error("expected default CredentialStore to be nil")
 	}
+	if len(cfg.IncludedPaths) != 0 {
+		t.Errorf("expected default IncludedPaths to be empty, got %d paths", len(cfg.IncludedPaths))
+	}
 }
 
 func TestHMACHashAlgorithm_String(t *testing.T) {
@@ -70,7 +73,8 @@ func TestHMACAuthConfig_CustomValues(t *testing.T) {
 		ClockSkewGrace:       2 * time.Minute,
 		RequiredHeaders:      []string{"host", "x-timestamp", "x-request-id"},
 		OptionalHeaders:      []string{"content-type", "x-correlation-id"},
-		ExemptPaths:          []string{"/health", "/metrics"},
+		ExcludedPaths:        []string{"/health", "/metrics"},
+		IncludedPaths:        []string{"/api/public"},
 		ErrorHandler:         customErrorHandler,
 		AuthHeaderName:       "X-Authorization",
 		TimestampHeader:      "X-Date",
@@ -115,8 +119,12 @@ func TestHMACAuthConfig_CustomValues(t *testing.T) {
 		t.Error("expected ErrorHandler to be set")
 	}
 
-	if len(cfg.ExemptPaths) != 2 {
-		t.Errorf("expected 2 exempt paths, got %d", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 2 {
+		t.Errorf("expected 2 excluded paths, got %d", len(cfg.ExcludedPaths))
+	}
+
+	if len(cfg.IncludedPaths) != 1 {
+		t.Errorf("expected 1 allowed path, got %d", len(cfg.IncludedPaths))
 	}
 
 	if len(cfg.RequiredHeaders) != 3 {
@@ -129,7 +137,8 @@ func TestHMACAuthConfig_EmptySlices(t *testing.T) {
 		CredentialStore: func(id string) []string { return nil },
 		RequiredHeaders: []string{},
 		OptionalHeaders: []string{},
-		ExemptPaths:     []string{},
+		ExcludedPaths:   []string{},
+		IncludedPaths:   []string{},
 	}
 
 	if cfg.RequiredHeaders == nil {
@@ -140,8 +149,12 @@ func TestHMACAuthConfig_EmptySlices(t *testing.T) {
 		t.Error("OptionalHeaders should not be nil, should be empty slice")
 	}
 
-	if cfg.ExemptPaths == nil {
-		t.Error("ExemptPaths should not be nil, should be empty slice")
+	if cfg.ExcludedPaths == nil {
+		t.Error("ExcludedPaths should not be nil, should be empty slice")
+	}
+
+	if cfg.IncludedPaths == nil {
+		t.Error("IncludedPaths should not be nil, should be empty slice")
 	}
 }
 

--- a/config/host_validation.go
+++ b/config/host_validation.go
@@ -28,8 +28,19 @@ type HostValidationConfig struct {
 	// Defaults to "Invalid Host header"
 	Message string
 
-	// ExemptPaths contains paths to skip host validation
-	ExemptPaths []string
+	// ExcludedPaths contains paths to skip host validation.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// Cannot be used with IncludedPaths - setting both will panic.
+	// Default: []
+	ExcludedPaths []string
+
+	// IncludedPaths contains paths where host validation is explicitly applied.
+	// If set, host validation will only occur for paths matching these patterns.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// If empty, host validation applies to all paths (subject to ExcludedPaths).
+	// Cannot be used with ExcludedPaths - setting both will panic.
+	// Default: []
+	IncludedPaths []string
 }
 
 // DefaultHostValidationConfig contains default values for host validation
@@ -39,5 +50,6 @@ var DefaultHostValidationConfig = HostValidationConfig{
 	StrictPort:      false,
 	StatusCode:      400,
 	Message:         "Invalid Host header",
-	ExemptPaths:     []string{},
+	ExcludedPaths:   []string{},
+	IncludedPaths:   []string{},
 }

--- a/config/host_validation_test.go
+++ b/config/host_validation_test.go
@@ -23,8 +23,11 @@ func TestHostValidationConfig_DefaultValues(t *testing.T) {
 	if cfg.Message != "Invalid Host header" {
 		t.Errorf("expected default Message to be 'Invalid Host header', got '%s'", cfg.Message)
 	}
-	if len(cfg.ExemptPaths) != 0 {
-		t.Errorf("expected default ExemptPaths to be empty, got %d paths", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 0 {
+		t.Errorf("expected default ExcludedPaths to be empty, got %d paths", len(cfg.ExcludedPaths))
+	}
+	if len(cfg.IncludedPaths) != 0 {
+		t.Errorf("expected default IncludedPaths to be empty, got %d paths", len(cfg.IncludedPaths))
 	}
 }
 
@@ -35,7 +38,8 @@ func TestHostValidationConfig_CustomValues(t *testing.T) {
 		StrictPort:      true,
 		StatusCode:      http.StatusForbidden,
 		Message:         "Forbidden host",
-		ExemptPaths:     []string{"/health", "/metrics"},
+		ExcludedPaths:   []string{"/health", "/metrics"},
+		IncludedPaths:   []string{"/api/public"},
 	}
 
 	if len(cfg.AllowedHosts) != 2 {
@@ -59,8 +63,11 @@ func TestHostValidationConfig_CustomValues(t *testing.T) {
 	if cfg.Message != "Forbidden host" {
 		t.Errorf("expected Message to be 'Forbidden host', got '%s'", cfg.Message)
 	}
-	if len(cfg.ExemptPaths) != 2 {
-		t.Errorf("expected 2 exempt paths, got %d", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 2 {
+		t.Errorf("expected 2 excluded paths, got %d", len(cfg.ExcludedPaths))
+	}
+	if len(cfg.IncludedPaths) != 1 {
+		t.Errorf("expected 1 allowed path, got %d", len(cfg.IncludedPaths))
 	}
 }
 
@@ -126,55 +133,109 @@ func TestHostValidationConfig_StatusCodeOptions(t *testing.T) {
 	}
 }
 
-func TestHostValidationConfig_ExemptPaths(t *testing.T) {
+func TestHostValidationConfig_ExcludedPaths(t *testing.T) {
 	tests := []struct {
-		name         string
-		exemptPaths  []string
-		expectedLen  int
-		expectedPath string
+		name          string
+		excludedPaths []string
+		expectedLen   int
+		expectedPath  string
 	}{
 		{
-			name:         "health and metrics",
-			exemptPaths:  []string{"/health", "/metrics"},
-			expectedLen:  2,
-			expectedPath: "/health",
+			name:          "health and metrics",
+			excludedPaths: []string{"/health", "/metrics"},
+			expectedLen:   2,
+			expectedPath:  "/health",
 		},
 		{
-			name:         "single path",
-			exemptPaths:  []string{"/api/status"},
-			expectedLen:  1,
-			expectedPath: "/api/status",
+			name:          "single path",
+			excludedPaths: []string{"/api/status"},
+			expectedLen:   1,
+			expectedPath:  "/api/status",
 		},
 		{
-			name:         "wildcard paths",
-			exemptPaths:  []string{"/health/*", "/public/*"},
-			expectedLen:  2,
-			expectedPath: "/health/*",
+			name:          "wildcard paths",
+			excludedPaths: []string{"/health/*", "/public/*"},
+			expectedLen:   2,
+			expectedPath:  "/health/*",
 		},
 		{
-			name:         "empty paths",
-			exemptPaths:  []string{},
-			expectedLen:  0,
-			expectedPath: "",
+			name:          "empty paths",
+			excludedPaths: []string{},
+			expectedLen:   0,
+			expectedPath:  "",
 		},
 		{
-			name:         "nil paths",
-			exemptPaths:  nil,
-			expectedLen:  0,
-			expectedPath: "",
+			name:          "nil paths",
+			excludedPaths: nil,
+			expectedLen:   0,
+			expectedPath:  "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := HostValidationConfig{
-				ExemptPaths: tt.exemptPaths,
+				ExcludedPaths: tt.excludedPaths,
 			}
-			if len(cfg.ExemptPaths) != tt.expectedLen {
-				t.Errorf("expected %d exempt paths, got %d", tt.expectedLen, len(cfg.ExemptPaths))
+			if len(cfg.ExcludedPaths) != tt.expectedLen {
+				t.Errorf("expected %d excluded paths, got %d", tt.expectedLen, len(cfg.ExcludedPaths))
 			}
-			if tt.expectedLen > 0 && cfg.ExemptPaths[0] != tt.expectedPath {
-				t.Errorf("expected first path to be '%s', got '%s'", tt.expectedPath, cfg.ExemptPaths[0])
+			if tt.expectedLen > 0 && cfg.ExcludedPaths[0] != tt.expectedPath {
+				t.Errorf("expected first path to be '%s', got '%s'", tt.expectedPath, cfg.ExcludedPaths[0])
+			}
+		})
+	}
+}
+
+func TestHostValidationConfig_IncludedPaths(t *testing.T) {
+	tests := []struct {
+		name          string
+		includedPaths []string
+		expectedLen   int
+		expectedPath  string
+	}{
+		{
+			name:          "public paths",
+			includedPaths: []string{"/api/public", "/health"},
+			expectedLen:   2,
+			expectedPath:  "/api/public",
+		},
+		{
+			name:          "single path",
+			includedPaths: []string{"/api/status"},
+			expectedLen:   1,
+			expectedPath:  "/api/status",
+		},
+		{
+			name:          "wildcard paths",
+			includedPaths: []string{"/public/*", "/api/v1/*"},
+			expectedLen:   2,
+			expectedPath:  "/public/*",
+		},
+		{
+			name:          "empty paths",
+			includedPaths: []string{},
+			expectedLen:   0,
+			expectedPath:  "",
+		},
+		{
+			name:          "nil paths",
+			includedPaths: nil,
+			expectedLen:   0,
+			expectedPath:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := HostValidationConfig{
+				IncludedPaths: tt.includedPaths,
+			}
+			if len(cfg.IncludedPaths) != tt.expectedLen {
+				t.Errorf("expected %d included paths, got %d", tt.expectedLen, len(cfg.IncludedPaths))
+			}
+			if tt.expectedLen > 0 && cfg.IncludedPaths[0] != tt.expectedPath {
+				t.Errorf("expected first path to be '%s', got '%s'", tt.expectedPath, cfg.IncludedPaths[0])
 			}
 		})
 	}

--- a/config/idempotency.go
+++ b/config/idempotency.go
@@ -65,9 +65,19 @@ type IdempotencyConfig struct {
 	// Default: false
 	Required bool
 
-	// ExemptPaths are paths that should skip idempotency check.
+	// ExcludedPaths are paths that should skip idempotency check.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// Cannot be used with IncludedPaths - setting both will panic.
 	// Default: []
-	ExemptPaths []string
+	ExcludedPaths []string
+
+	// IncludedPaths contains paths where idempotency check is explicitly applied.
+	// If set, idempotency check will only occur for paths matching these patterns.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// If empty, idempotency check applies to all paths (subject to ExcludedPaths).
+	// Cannot be used with ExcludedPaths - setting both will panic.
+	// Default: []
+	IncludedPaths []string
 
 	// MaxKeys limits the number of unique keys stored in the default
 	// in-memory store. Defaults to 10000. Set to 0 for unlimited (not recommended).
@@ -98,7 +108,8 @@ var DefaultIdempotencyConfig = IdempotencyConfig{
 	TTL:                   24 * time.Hour,
 	MaxBodySize:           1024 * 1024,
 	Required:              false,
-	ExemptPaths:           []string{},
+	ExcludedPaths:         []string{},
+	IncludedPaths:         []string{},
 	MaxKeys:               10000,
 	LockRetryInterval:     10 * time.Millisecond,
 	LockMaxRetries:        300,

--- a/config/idempotency_test.go
+++ b/config/idempotency_test.go
@@ -26,8 +26,12 @@ func TestDefaultIdempotencyConfig(t *testing.T) {
 			t.Error("expected Required to be false by default")
 		}
 
-		if len(cfg.ExemptPaths) != 0 {
-			t.Errorf("expected ExemptPaths to be empty, got %v", cfg.ExemptPaths)
+		if len(cfg.ExcludedPaths) != 0 {
+			t.Errorf("expected ExcludedPaths to be empty, got %v", cfg.ExcludedPaths)
+		}
+
+		if len(cfg.IncludedPaths) != 0 {
+			t.Errorf("expected IncludedPaths to be empty, got %v", cfg.IncludedPaths)
 		}
 
 		if cfg.Store != nil {
@@ -80,13 +84,14 @@ func TestIdempotencyConfigCustomization(t *testing.T) {
 		customStore := &mockIdempotencyStore{}
 
 		cfg := IdempotencyConfig{
-			HeaderName:  "X-Idempotency-Key",
-			TTL:         time.Hour,
-			MaxBodySize: 512 * 1024,
-			Store:       customStore,
-			Required:    true,
-			ExemptPaths: []string{"/webhook", "/callback"},
-			MaxKeys:     5000,
+			HeaderName:    "X-Idempotency-Key",
+			TTL:           time.Hour,
+			MaxBodySize:   512 * 1024,
+			Store:         customStore,
+			Required:      true,
+			ExcludedPaths: []string{"/webhook", "/callback"},
+			IncludedPaths: []string{"/api/public"},
+			MaxKeys:       5000,
 		}
 
 		if cfg.HeaderName != "X-Idempotency-Key" {
@@ -109,12 +114,56 @@ func TestIdempotencyConfigCustomization(t *testing.T) {
 			t.Error("expected Required to be true")
 		}
 
-		if len(cfg.ExemptPaths) != 2 {
-			t.Errorf("expected 2 exempt paths, got %d", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 2 {
+			t.Errorf("expected 2 excluded paths, got %d", len(cfg.ExcludedPaths))
+		}
+
+		if len(cfg.IncludedPaths) != 1 {
+			t.Errorf("expected 1 allowed path, got %d", len(cfg.IncludedPaths))
 		}
 
 		if cfg.MaxKeys != 5000 {
 			t.Errorf("expected MaxKeys 5000, got %d", cfg.MaxKeys)
+		}
+	})
+}
+
+func TestIdempotencyConfig_IncludedPaths(t *testing.T) {
+	t.Run("custom included paths", func(t *testing.T) {
+		includedPaths := []string{"/api/public", "/health"}
+		cfg := IdempotencyConfig{
+			HeaderName:    DefaultIdempotencyConfig.HeaderName,
+			TTL:           DefaultIdempotencyConfig.TTL,
+			MaxBodySize:   DefaultIdempotencyConfig.MaxBodySize,
+			MaxKeys:       DefaultIdempotencyConfig.MaxKeys,
+			IncludedPaths: includedPaths,
+		}
+		if len(cfg.IncludedPaths) != 2 {
+			t.Errorf("expected 2 included paths, got %d", len(cfg.IncludedPaths))
+		}
+		if cfg.IncludedPaths[0] != "/api/public" {
+			t.Errorf("expected first allowed path to be /api/public, got %s", cfg.IncludedPaths[0])
+		}
+	})
+
+	t.Run("empty included paths", func(t *testing.T) {
+		cfg := IdempotencyConfig{
+			IncludedPaths: []string{},
+		}
+		if cfg.IncludedPaths == nil {
+			t.Error("expected included paths slice to be initialized, not nil")
+		}
+		if len(cfg.IncludedPaths) != 0 {
+			t.Errorf("expected empty included paths slice, got %d entries", len(cfg.IncludedPaths))
+		}
+	})
+
+	t.Run("nil included paths", func(t *testing.T) {
+		cfg := IdempotencyConfig{
+			IncludedPaths: nil,
+		}
+		if cfg.IncludedPaths != nil {
+			t.Error("expected included paths to remain nil when nil is passed")
 		}
 	})
 }

--- a/config/jwt_auth.go
+++ b/config/jwt_auth.go
@@ -75,13 +75,23 @@ type JWTAuthConfig struct {
 	// Default: none
 	RequiredClaims []string
 
-	// ExemptPaths are paths that skip JWT validation.
+	// ExcludedPaths are paths that skip JWT validation.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// Cannot be used with IncludedPaths - setting both will panic.
 	// Default: []
-	ExemptPaths []string
+	ExcludedPaths []string
 
-	// ExemptMethods are HTTP methods that skip JWT validation.
-	// Default: [] (OPTIONS is always exempt)
-	ExemptMethods []string
+	// IncludedPaths contains paths where JWT validation is explicitly applied.
+	// If set, JWT validation will only occur for paths matching these patterns.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// If empty, JWT validation applies to all paths (subject to ExcludedPaths).
+	// Cannot be used with ExcludedPaths - setting both will panic.
+	// Default: []
+	IncludedPaths []string
+
+	// ExcludedMethods are HTTP methods that skip JWT validation.
+	// Default: [] (OPTIONS is always excluded)
+	ExcludedMethods []string
 
 	// ErrorHandler is called when JWT validation fails.
 	// Default: Returns 401/403 with RFC 9457 Problem Details
@@ -103,8 +113,9 @@ type JWTAuthConfig struct {
 // DefaultJWTAuthConfig provides sensible defaults
 var DefaultJWTAuthConfig = JWTAuthConfig{
 	TokenExtractor:  extractBearerToken,
-	ExemptPaths:     []string{},
-	ExemptMethods:   []string{},
+	ExcludedPaths:   []string{},
+	IncludedPaths:   []string{},
+	ExcludedMethods: []string{},
 	RequiredClaims:  []string{},
 	AccessTokenTTL:  15 * time.Minute,
 	RefreshTokenTTL: 7 * 24 * time.Hour,

--- a/config/jwt_auth_test.go
+++ b/config/jwt_auth_test.go
@@ -90,8 +90,8 @@ func TestJWTAuthConfig_Customization(t *testing.T) {
 	cfg := JWTAuthConfig{
 		TokenExtractor:  customExtractor,
 		RequiredClaims:  []string{"sub", "iss"},
-		ExemptPaths:     []string{"/health", "/metrics"},
-		ExemptMethods:   []string{http.MethodHead},
+		ExcludedPaths:   []string{"/health", "/metrics"},
+		ExcludedMethods: []string{http.MethodHead},
 		AccessTokenTTL:  30 * time.Minute,
 		RefreshTokenTTL: 30 * 24 * time.Hour,
 	}
@@ -107,16 +107,65 @@ func TestJWTAuthConfig_Customization(t *testing.T) {
 		t.Errorf("expected RequiredClaims [sub iss], got %v", cfg.RequiredClaims)
 	}
 
-	if len(cfg.ExemptPaths) != 2 || cfg.ExemptPaths[0] != "/health" || cfg.ExemptPaths[1] != "/metrics" {
-		t.Errorf("expected ExemptPaths [/health /metrics], got %v", cfg.ExemptPaths)
+	if len(cfg.ExcludedPaths) != 2 || cfg.ExcludedPaths[0] != "/health" || cfg.ExcludedPaths[1] != "/metrics" {
+		t.Errorf("expected ExcludedPaths [/health /metrics], got %v", cfg.ExcludedPaths)
 	}
 
-	if len(cfg.ExemptMethods) != 1 || cfg.ExemptMethods[0] != http.MethodHead {
-		t.Errorf("expected ExemptMethods [HEAD], got %v", cfg.ExemptMethods)
+	if len(cfg.IncludedPaths) != 0 {
+		t.Errorf("expected 0 included paths, got %d", len(cfg.IncludedPaths))
+	}
+
+	if len(cfg.ExcludedMethods) != 1 || cfg.ExcludedMethods[0] != http.MethodHead {
+		t.Errorf("expected ExcludedMethods [HEAD], got %v", cfg.ExcludedMethods)
 	}
 
 	if cfg.AccessTokenTTL != 30*time.Minute {
 		t.Errorf("expected AccessTokenTTL to be 30m, got %v", cfg.AccessTokenTTL)
+	}
+}
+
+func TestJWTAuthConfig_IncludedPaths(t *testing.T) {
+	customExtractor := func(r *http.Request) string {
+		return r.Header.Get("X-Custom-Token")
+	}
+
+	cfg := JWTAuthConfig{
+		TokenExtractor:  customExtractor,
+		RequiredClaims:  []string{"sub", "iss"},
+		ExcludedPaths:   []string{"/health"},
+		IncludedPaths:   []string{"/api/public", "/api/internal"},
+		ExcludedMethods: []string{http.MethodHead},
+		AccessTokenTTL:  30 * time.Minute,
+		RefreshTokenTTL: 30 * 24 * time.Hour,
+	}
+
+	if len(cfg.IncludedPaths) != 2 {
+		t.Errorf("expected 2 included paths, got %d", len(cfg.IncludedPaths))
+	}
+	if cfg.IncludedPaths[0] != "/api/public" {
+		t.Errorf("expected first allowed path to be /api/public, got %s", cfg.IncludedPaths[0])
+	}
+	if cfg.IncludedPaths[1] != "/api/internal" {
+		t.Errorf("expected second allowed path to be /api/internal, got %s", cfg.IncludedPaths[1])
+	}
+
+	// Test empty included paths
+	cfg2 := JWTAuthConfig{
+		IncludedPaths: []string{},
+	}
+	if cfg2.IncludedPaths == nil {
+		t.Error("expected included paths slice to be initialized, not nil")
+	}
+	if len(cfg2.IncludedPaths) != 0 {
+		t.Errorf("expected empty included paths slice, got %d entries", len(cfg2.IncludedPaths))
+	}
+
+	// Test nil included paths
+	cfg3 := JWTAuthConfig{
+		IncludedPaths: nil,
+	}
+	if cfg3.IncludedPaths != nil {
+		t.Error("expected included paths to remain nil when nil is passed")
 	}
 }
 

--- a/config/metrics.go
+++ b/config/metrics.go
@@ -28,9 +28,19 @@ type MetricsConfig struct {
 	// Default: []float64{100, 1000, 10000, 100000, 1000000, 10000000}
 	SizeBuckets []float64
 
-	// ExcludePaths are paths to exclude from metrics (e.g., health checks).
-	// Default: ["/health", "/metrics"]
-	ExcludePaths []string
+	// ExcludedPaths are paths to exclude from metrics (e.g., health checks).
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// Cannot be used with IncludedPaths - setting both will panic.
+	// Default: ["/metrics"]
+	ExcludedPaths []string
+
+	// IncludedPaths contains paths where metrics collection is explicitly applied.
+	// If set, metrics will only be collected for paths matching these patterns.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// If empty, metrics collection applies to all paths (subject to ExcludedPaths).
+	// Cannot be used with ExcludedPaths - setting both will panic.
+	// Default: []
+	IncludedPaths []string
 
 	// PathLabelFunc transforms path for labeling (e.g., normalize IDs).
 	// Default: identity function (path used as-is)
@@ -48,6 +58,7 @@ var DefaultMetricsConfig = MetricsConfig{
 	ServerAddr:      String("localhost:9090"),
 	DurationBuckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 	SizeBuckets:     []float64{100, 1000, 10000, 100000, 1000000, 10000000},
-	ExcludePaths:    []string{"/metrics"},
+	ExcludedPaths:   []string{"/metrics"},
+	IncludedPaths:   []string{},
 	PathLabelFunc:   func(p string) string { return p },
 }

--- a/config/metrics_test.go
+++ b/config/metrics_test.go
@@ -27,9 +27,9 @@ func TestDefaultMetricsConfig(t *testing.T) {
 		t.Errorf("expected SizeBuckets %v, got %v", expectedSizeBuckets, defaults.SizeBuckets)
 	}
 
-	expectedExcludePaths := []string{"/metrics"}
-	if !reflect.DeepEqual(defaults.ExcludePaths, expectedExcludePaths) {
-		t.Errorf("expected ExcludePaths %v, got %v", expectedExcludePaths, defaults.ExcludePaths)
+	expectedExcludedPaths := []string{"/metrics"}
+	if !reflect.DeepEqual(defaults.ExcludedPaths, expectedExcludedPaths) {
+		t.Errorf("expected ExcludedPaths %v, got %v", expectedExcludedPaths, defaults.ExcludedPaths)
 	}
 
 	if defaults.PathLabelFunc == nil {
@@ -45,6 +45,9 @@ func TestDefaultMetricsConfig(t *testing.T) {
 	if defaults.CustomLabels != nil {
 		t.Error("expected CustomLabels to be nil by default")
 	}
+	if len(defaults.IncludedPaths) != 0 {
+		t.Errorf("expected IncludedPaths to be empty, got %d paths", len(defaults.IncludedPaths))
+	}
 }
 
 func TestMetricsConfig_CustomLabels(t *testing.T) {
@@ -59,7 +62,7 @@ func TestMetricsConfig_CustomLabels(t *testing.T) {
 		ServerAddr:      String("localhost:9091"),
 		DurationBuckets: []float64{0.1, 0.5, 1.0},
 		SizeBuckets:     []float64{1000, 10000},
-		ExcludePaths:    []string{"/health", "/readyz"},
+		ExcludedPaths:   []string{"/health", "/readyz"},
 		PathLabelFunc:   func(p string) string { return "/normalized" },
 		CustomLabels:    customLabels,
 	}
@@ -80,8 +83,8 @@ func TestMetricsConfig_CustomLabels(t *testing.T) {
 		t.Errorf("expected 2 SizeBuckets, got %d", len(cfg.SizeBuckets))
 	}
 
-	if !reflect.DeepEqual(cfg.ExcludePaths, []string{"/health", "/readyz"}) {
-		t.Errorf("expected ExcludePaths [health readyz], got %v", cfg.ExcludePaths)
+	if !reflect.DeepEqual(cfg.ExcludedPaths, []string{"/health", "/readyz"}) {
+		t.Errorf("expected ExcludedPaths [health readyz], got %v", cfg.ExcludedPaths)
 	}
 
 	result := cfg.PathLabelFunc("/api/users/123")
@@ -109,4 +112,40 @@ func TestMetricsConfig_EmptyServerAddr(t *testing.T) {
 	if cfg.ServerAddr == nil || *cfg.ServerAddr != "" {
 		t.Errorf("expected ServerAddr to be empty, got %v", cfg.ServerAddr)
 	}
+}
+
+func TestMetricsConfig_IncludedPaths(t *testing.T) {
+	t.Run("custom included paths", func(t *testing.T) {
+		cfg := MetricsConfig{
+			Endpoint:      "/metrics",
+			IncludedPaths: []string{"/api/public", "/health"},
+		}
+		if len(cfg.IncludedPaths) != 2 {
+			t.Errorf("expected 2 included paths, got %d", len(cfg.IncludedPaths))
+		}
+		if cfg.IncludedPaths[0] != "/api/public" {
+			t.Errorf("expected first allowed path to be /api/public, got %s", cfg.IncludedPaths[0])
+		}
+	})
+
+	t.Run("empty included paths", func(t *testing.T) {
+		cfg := MetricsConfig{
+			IncludedPaths: []string{},
+		}
+		if cfg.IncludedPaths == nil {
+			t.Error("expected included paths slice to be initialized, not nil")
+		}
+		if len(cfg.IncludedPaths) != 0 {
+			t.Errorf("expected empty included paths slice, got %d entries", len(cfg.IncludedPaths))
+		}
+	})
+
+	t.Run("nil included paths", func(t *testing.T) {
+		cfg := MetricsConfig{
+			IncludedPaths: nil,
+		}
+		if cfg.IncludedPaths != nil {
+			t.Error("expected included paths to remain nil when nil is passed")
+		}
+	})
 }

--- a/config/rate_limit.go
+++ b/config/rate_limit.go
@@ -51,8 +51,19 @@ type RateLimitConfig struct {
 	// Headers to include in response
 	IncludeHeaders bool
 
-	// ExemptPaths contains paths to skip rate limiting
-	ExemptPaths []string
+	// ExcludedPaths contains paths to skip rate limiting.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// Cannot be used with IncludedPaths - setting both will panic.
+	// Default: []
+	ExcludedPaths []string
+
+	// IncludedPaths contains paths where rate limiting is explicitly applied.
+	// If set, rate limiting will only occur for paths matching these patterns.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// If empty, rate limiting applies to all paths (subject to ExcludedPaths).
+	// Cannot be used with ExcludedPaths - setting both will panic.
+	// Default: []
+	IncludedPaths []string
 
 	// Store is the storage backend for rate limiting.
 	// If nil, a secure in-memory store is used.
@@ -73,5 +84,6 @@ var DefaultRateLimitConfig = RateLimitConfig{
 	StatusCode:     http.StatusTooManyRequests,
 	Message:        "Rate limit exceeded",
 	IncludeHeaders: true,
-	ExemptPaths:    []string{},
+	ExcludedPaths:  []string{},
+	IncludedPaths:  []string{},
 }

--- a/config/rate_limit_test.go
+++ b/config/rate_limit_test.go
@@ -32,8 +32,11 @@ func TestRateLimitConfig_DefaultValues(t *testing.T) {
 	if cfg.IncludeHeaders != true {
 		t.Errorf("expected default include headers = true, got %t", cfg.IncludeHeaders)
 	}
-	if len(cfg.ExemptPaths) != 0 {
-		t.Errorf("expected default exempt paths to be empty, got %d paths", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 0 {
+		t.Errorf("expected default excluded paths to be empty, got %d paths", len(cfg.ExcludedPaths))
+	}
+	if len(cfg.IncludedPaths) != 0 {
+		t.Errorf("expected default included paths to be empty, got %d paths", len(cfg.IncludedPaths))
 	}
 }
 
@@ -86,16 +89,29 @@ func TestRateLimitConfig_StructAssignment(t *testing.T) {
 		}
 	})
 
-	t.Run("exempt paths", func(t *testing.T) {
-		exemptPaths := []string{"/health", "/metrics", "/ping", "/status"}
+	t.Run("excluded paths", func(t *testing.T) {
+		excludedPaths := []string{"/health", "/metrics", "/ping", "/status"}
 		cfg := RateLimitConfig{
-			ExemptPaths: exemptPaths,
+			ExcludedPaths: excludedPaths,
 		}
-		if len(cfg.ExemptPaths) != 4 {
-			t.Errorf("expected 4 exempt paths, got %d", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 4 {
+			t.Errorf("expected 4 excluded paths, got %d", len(cfg.ExcludedPaths))
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Errorf("expected exempt paths = %v, got %v", exemptPaths, cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Errorf("expected excluded paths = %v, got %v", excludedPaths, cfg.ExcludedPaths)
+		}
+	})
+
+	t.Run("included paths", func(t *testing.T) {
+		includedPaths := []string{"/api/public", "/health"}
+		cfg := RateLimitConfig{
+			IncludedPaths: includedPaths,
+		}
+		if len(cfg.IncludedPaths) != 2 {
+			t.Errorf("expected 2 included paths, got %d", len(cfg.IncludedPaths))
+		}
+		if !reflect.DeepEqual(cfg.IncludedPaths, includedPaths) {
+			t.Errorf("expected included paths = %v, got %v", includedPaths, cfg.IncludedPaths)
 		}
 	})
 
@@ -116,7 +132,8 @@ func TestRateLimitConfig_MultipleFields(t *testing.T) {
 	customExtractor := func(r *http.Request) string {
 		return r.Header.Get(httpx.HeaderAuthorization)
 	}
-	exemptPaths := []string{"/public", "/health"}
+	excludedPaths := []string{"/public", "/health"}
+	includedPaths := []string{"/api/public"}
 	cfg := RateLimitConfig{
 		Rate:           200,
 		Window:         5 * time.Minute,
@@ -125,7 +142,8 @@ func TestRateLimitConfig_MultipleFields(t *testing.T) {
 		StatusCode:     http.StatusForbidden,
 		Message:        "Rate limit reached",
 		IncludeHeaders: false,
-		ExemptPaths:    exemptPaths,
+		ExcludedPaths:  excludedPaths,
+		IncludedPaths:  includedPaths,
 	}
 
 	if cfg.Rate != 200 {
@@ -149,8 +167,14 @@ func TestRateLimitConfig_MultipleFields(t *testing.T) {
 	if cfg.IncludeHeaders != false {
 		t.Errorf("expected include headers = false, got %t", cfg.IncludeHeaders)
 	}
-	if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-		t.Error("expected exempt paths to be set correctly")
+	if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+		t.Error("expected excluded paths to be set correctly")
+	}
+	if len(cfg.IncludedPaths) != 1 {
+		t.Errorf("expected 1 allowed path, got %d", len(cfg.IncludedPaths))
+	}
+	if !reflect.DeepEqual(cfg.IncludedPaths, includedPaths) {
+		t.Error("expected included paths to be set correctly")
 	}
 
 	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
@@ -214,19 +238,35 @@ func TestRateLimitConfig_EdgeCases(t *testing.T) {
 		}
 	})
 
-	t.Run("empty and nil exempt paths", func(t *testing.T) {
+	t.Run("empty and nil excluded paths", func(t *testing.T) {
 		cfg := RateLimitConfig{
-			ExemptPaths: []string{},
+			ExcludedPaths: []string{},
 		}
-		if cfg.ExemptPaths == nil || len(cfg.ExemptPaths) != 0 {
-			t.Errorf("expected empty exempt paths slice, got %v", cfg.ExemptPaths)
+		if cfg.ExcludedPaths == nil || len(cfg.ExcludedPaths) != 0 {
+			t.Errorf("expected empty excluded paths slice, got %v", cfg.ExcludedPaths)
 		}
 
 		cfg2 := RateLimitConfig{
-			ExemptPaths: nil,
+			ExcludedPaths: nil,
 		}
-		if cfg2.ExemptPaths != nil {
-			t.Error("expected exempt paths to remain nil when nil is passed")
+		if cfg2.ExcludedPaths != nil {
+			t.Error("expected excluded paths to remain nil when nil is passed")
+		}
+	})
+
+	t.Run("empty and nil included paths", func(t *testing.T) {
+		cfg := RateLimitConfig{
+			IncludedPaths: []string{},
+		}
+		if cfg.IncludedPaths == nil || len(cfg.IncludedPaths) != 0 {
+			t.Errorf("expected empty included paths slice, got %v", cfg.IncludedPaths)
+		}
+
+		cfg2 := RateLimitConfig{
+			IncludedPaths: nil,
+		}
+		if cfg2.IncludedPaths != nil {
+			t.Error("expected included paths to remain nil when nil is passed")
 		}
 	})
 
@@ -311,7 +351,7 @@ func TestRateLimitConfig_CustomKeyExtractors(t *testing.T) {
 }
 
 func TestRateLimitConfig_PathPatterns(t *testing.T) {
-	exemptPaths := []string{
+	excludedPaths := []string{
 		"/health",
 		"/metrics",
 		"/api/v1/health/*",
@@ -321,12 +361,12 @@ func TestRateLimitConfig_PathPatterns(t *testing.T) {
 		"/internal/status",
 	}
 	cfg := RateLimitConfig{
-		ExemptPaths: exemptPaths,
+		ExcludedPaths: excludedPaths,
 	}
-	if len(cfg.ExemptPaths) != len(exemptPaths) {
-		t.Errorf("expected %d exempt paths, got %d", len(exemptPaths), len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != len(excludedPaths) {
+		t.Errorf("expected %d excluded paths, got %d", len(excludedPaths), len(cfg.ExcludedPaths))
 	}
-	if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-		t.Errorf("expected exempt paths = %v, got %v", exemptPaths, cfg.ExemptPaths)
+	if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+		t.Errorf("expected excluded paths = %v, got %v", excludedPaths, cfg.ExcludedPaths)
 	}
 }

--- a/config/request_body_size.go
+++ b/config/request_body_size.go
@@ -5,12 +5,24 @@ type RequestBodySizeConfig struct {
 	// MaxBytes is the maximum request body size in bytes.
 	MaxBytes int64
 
-	// ExemptPaths contains paths that skip body size limiting.
-	ExemptPaths []string
+	// ExcludedPaths contains paths that skip body size limiting.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// Cannot be used with IncludedPaths - setting both will panic.
+	// Default: []
+	ExcludedPaths []string
+
+	// IncludedPaths contains paths where body size limiting is explicitly applied.
+	// If set, body size limiting will only occur for paths matching these patterns.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// If empty, body size limiting applies to all paths (subject to ExcludedPaths).
+	// Cannot be used with ExcludedPaths - setting both will panic.
+	// Default: []
+	IncludedPaths []string
 }
 
 // DefaultRequestBodySizeConfig contains the default values for request body size limiting.
 var DefaultRequestBodySizeConfig = RequestBodySizeConfig{
-	MaxBytes:    1 << 20, // 1MB default
-	ExemptPaths: []string{},
+	MaxBytes:      1 << 20, // 1MB default
+	ExcludedPaths: []string{},
+	IncludedPaths: []string{},
 }

--- a/config/request_body_size_test.go
+++ b/config/request_body_size_test.go
@@ -10,8 +10,11 @@ func TestRequestBodySizeConfig_DefaultValues(t *testing.T) {
 	if cfg.MaxBytes != 1<<20 {
 		t.Errorf("expected default max bytes = %d (1MB), got %d", 1<<20, cfg.MaxBytes)
 	}
-	if len(cfg.ExemptPaths) != 0 {
-		t.Errorf("expected default exempt paths to be empty, got %d paths", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 0 {
+		t.Errorf("expected default excluded paths to be empty, got %d paths", len(cfg.ExcludedPaths))
+	}
+	if len(cfg.IncludedPaths) != 0 {
+		t.Errorf("expected default included paths to be empty, got %d paths", len(cfg.IncludedPaths))
 	}
 
 	// Verify the 1MB calculation
@@ -40,8 +43,8 @@ func TestRequestBodySizeConfig_BoundaryValues(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := RequestBodySizeConfig{
-				MaxBytes:    tt.maxBytes,
-				ExemptPaths: []string{},
+				MaxBytes:      tt.maxBytes,
+				ExcludedPaths: []string{},
 			}
 			if cfg.MaxBytes != tt.maxBytes {
 				t.Errorf("expected max bytes = %d, got %d", tt.maxBytes, cfg.MaxBytes)
@@ -69,8 +72,8 @@ func TestRequestBodySizeConfig_CommonSizes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := RequestBodySizeConfig{
-				MaxBytes:    tt.maxBytes,
-				ExemptPaths: []string{},
+				MaxBytes:      tt.maxBytes,
+				ExcludedPaths: []string{},
 			}
 			if cfg.MaxBytes != tt.maxBytes {
 				t.Errorf("expected %s max bytes = %d, got %d", tt.name, tt.maxBytes, cfg.MaxBytes)
@@ -80,41 +83,41 @@ func TestRequestBodySizeConfig_CommonSizes(t *testing.T) {
 }
 
 func TestRequestBodySizeConfig_EdgeCases(t *testing.T) {
-	t.Run("empty exempt paths", func(t *testing.T) {
+	t.Run("empty excluded paths", func(t *testing.T) {
 		cfg := RequestBodySizeConfig{
-			MaxBytes:    1048576,
-			ExemptPaths: []string{},
+			MaxBytes:      1048576,
+			ExcludedPaths: []string{},
 		}
-		if cfg.ExemptPaths == nil {
-			t.Error("expected exempt paths slice to be initialized, not nil")
+		if cfg.ExcludedPaths == nil {
+			t.Error("expected excluded paths slice to be initialized, not nil")
 		}
-		if len(cfg.ExemptPaths) != 0 {
-			t.Errorf("expected empty exempt paths slice, got %d entries", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 0 {
+			t.Errorf("expected empty excluded paths slice, got %d entries", len(cfg.ExcludedPaths))
 		}
 	})
 
-	t.Run("nil exempt paths", func(t *testing.T) {
+	t.Run("nil excluded paths", func(t *testing.T) {
 		cfg := RequestBodySizeConfig{
-			MaxBytes:    1048576,
-			ExemptPaths: nil,
+			MaxBytes:      1048576,
+			ExcludedPaths: nil,
 		}
-		if cfg.ExemptPaths != nil {
-			t.Error("expected exempt paths to remain nil when nil is passed")
+		if cfg.ExcludedPaths != nil {
+			t.Error("expected excluded paths to remain nil when nil is passed")
 		}
 	})
 
 	t.Run("empty string paths", func(t *testing.T) {
-		exemptPaths := []string{"", "/upload", ""}
+		excludedPaths := []string{"", "/upload", ""}
 		cfg := RequestBodySizeConfig{
-			MaxBytes:    1048576,
-			ExemptPaths: exemptPaths,
+			MaxBytes:      1048576,
+			ExcludedPaths: excludedPaths,
 		}
-		if len(cfg.ExemptPaths) != 3 {
-			t.Errorf("expected 3 exempt paths, got %d", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 3 {
+			t.Errorf("expected 3 excluded paths, got %d", len(cfg.ExcludedPaths))
 		}
-		for i, expectedPath := range exemptPaths {
-			if cfg.ExemptPaths[i] != expectedPath {
-				t.Errorf("expected exempt path[%d] = %q, got %q", i, expectedPath, cfg.ExemptPaths[i])
+		for i, expectedPath := range excludedPaths {
+			if cfg.ExcludedPaths[i] != expectedPath {
+				t.Errorf("expected excluded path[%d] = %q, got %q", i, expectedPath, cfg.ExcludedPaths[i])
 			}
 		}
 	})
@@ -124,15 +127,55 @@ func TestRequestBodySizeConfig_EdgeCases(t *testing.T) {
 		if cfg.MaxBytes != 0 {
 			t.Errorf("expected zero max bytes = 0, got %d", cfg.MaxBytes)
 		}
-		if cfg.ExemptPaths != nil {
-			t.Errorf("expected zero exempt paths = nil, got %v", cfg.ExemptPaths)
+		if cfg.ExcludedPaths != nil {
+			t.Errorf("expected zero excluded paths = nil, got %v", cfg.ExcludedPaths)
+		}
+		if cfg.IncludedPaths != nil {
+			t.Errorf("expected zero included paths = nil, got %v", cfg.IncludedPaths)
+		}
+	})
+
+	t.Run("empty included paths", func(t *testing.T) {
+		cfg := RequestBodySizeConfig{
+			MaxBytes:      1048576,
+			IncludedPaths: []string{},
+		}
+		if cfg.IncludedPaths == nil {
+			t.Error("expected included paths slice to be initialized, not nil")
+		}
+		if len(cfg.IncludedPaths) != 0 {
+			t.Errorf("expected empty included paths slice, got %d entries", len(cfg.IncludedPaths))
+		}
+	})
+
+	t.Run("nil included paths", func(t *testing.T) {
+		cfg := RequestBodySizeConfig{
+			MaxBytes:      1048576,
+			IncludedPaths: nil,
+		}
+		if cfg.IncludedPaths != nil {
+			t.Error("expected included paths to remain nil when nil is passed")
+		}
+	})
+
+	t.Run("custom included paths", func(t *testing.T) {
+		includedPaths := []string{"/api/public", "/health"}
+		cfg := RequestBodySizeConfig{
+			MaxBytes:      1048576,
+			IncludedPaths: includedPaths,
+		}
+		if len(cfg.IncludedPaths) != 2 {
+			t.Errorf("expected 2 included paths, got %d", len(cfg.IncludedPaths))
+		}
+		if !reflect.DeepEqual(cfg.IncludedPaths, includedPaths) {
+			t.Errorf("expected included paths = %v, got %v", includedPaths, cfg.IncludedPaths)
 		}
 	})
 }
 
 func TestRequestBodySizeConfig_PathPatterns(t *testing.T) {
 	t.Run("path patterns", func(t *testing.T) {
-		exemptPaths := []string{
+		excludedPaths := []string{
 			"/api/v1/upload/*",
 			"/files/*",
 			"/media/upload",
@@ -142,19 +185,19 @@ func TestRequestBodySizeConfig_PathPatterns(t *testing.T) {
 			"/webhooks/large-payload",
 		}
 		cfg := RequestBodySizeConfig{
-			MaxBytes:    10485760, // 10MB
-			ExemptPaths: exemptPaths,
+			MaxBytes:      10485760, // 10MB
+			ExcludedPaths: excludedPaths,
 		}
-		if len(cfg.ExemptPaths) != len(exemptPaths) {
-			t.Errorf("expected %d exempt paths, got %d", len(exemptPaths), len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != len(excludedPaths) {
+			t.Errorf("expected %d excluded paths, got %d", len(excludedPaths), len(cfg.ExcludedPaths))
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Errorf("expected exempt paths = %v, got %v", exemptPaths, cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Errorf("expected excluded paths = %v, got %v", excludedPaths, cfg.ExcludedPaths)
 		}
 	})
 
 	t.Run("special character paths", func(t *testing.T) {
-		exemptPaths := []string{
+		excludedPaths := []string{
 			"/api-v1/upload",
 			"/files_large",
 			"/upload-service",
@@ -165,34 +208,34 @@ func TestRequestBodySizeConfig_PathPatterns(t *testing.T) {
 			"/files/test@example.com",
 		}
 		cfg := RequestBodySizeConfig{
-			MaxBytes:    5242880, // 5MB
-			ExemptPaths: exemptPaths,
+			MaxBytes:      5242880, // 5MB
+			ExcludedPaths: excludedPaths,
 		}
-		if len(cfg.ExemptPaths) != len(exemptPaths) {
-			t.Errorf("expected %d exempt paths, got %d", len(exemptPaths), len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != len(excludedPaths) {
+			t.Errorf("expected %d excluded paths, got %d", len(excludedPaths), len(cfg.ExcludedPaths))
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Errorf("expected exempt paths = %v, got %v", exemptPaths, cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Errorf("expected excluded paths = %v, got %v", excludedPaths, cfg.ExcludedPaths)
 		}
 	})
 }
 
 func TestRequestBodySizeConfig_StructAssignment(t *testing.T) {
 	t.Run("direct struct assignment", func(t *testing.T) {
-		exemptPaths := []string{"/upload", "/download"}
+		excludedPaths := []string{"/upload", "/download"}
 		cfg := RequestBodySizeConfig{
-			MaxBytes:    5242880, // 5MB
-			ExemptPaths: exemptPaths,
+			MaxBytes:      5242880, // 5MB
+			ExcludedPaths: excludedPaths,
 		}
 
 		if cfg.MaxBytes != 5242880 {
 			t.Errorf("expected max bytes = 5242880, got %d", cfg.MaxBytes)
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Error("expected exempt paths to be set correctly")
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Error("expected excluded paths to be set correctly")
 		}
-		if len(cfg.ExemptPaths) != 2 {
-			t.Errorf("expected 2 exempt paths, got %d", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 2 {
+			t.Errorf("expected 2 excluded paths, got %d", len(cfg.ExcludedPaths))
 		}
 	})
 
@@ -201,13 +244,13 @@ func TestRequestBodySizeConfig_StructAssignment(t *testing.T) {
 
 		// Modify fields directly
 		cfg.MaxBytes = 2097152 // 2MB
-		cfg.ExemptPaths = []string{"/api/upload", "/files"}
+		cfg.ExcludedPaths = []string{"/api/upload", "/files"}
 
 		if cfg.MaxBytes != 2097152 {
 			t.Errorf("expected modified max bytes = 2097152, got %d", cfg.MaxBytes)
 		}
-		if len(cfg.ExemptPaths) != 2 {
-			t.Errorf("expected 2 exempt paths, got %d", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 2 {
+			t.Errorf("expected 2 excluded paths, got %d", len(cfg.ExcludedPaths))
 		}
 	})
 }

--- a/config/request_logger.go
+++ b/config/request_logger.go
@@ -41,14 +41,18 @@ type RequestLoggerConfig struct {
 	// Fields to include in logs (defaults to all fields).
 	Fields []LogField
 
-	// ExemptPaths contains paths to skip logging (e.g., health checks).
-	ExemptPaths []string
+	// ExcludedPaths contains paths to skip logging (e.g., health checks).
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// Cannot be used with IncludedPaths - setting both will panic.
+	// Default: []
+	ExcludedPaths []string
 
-	// AllowedPaths contains paths where body logging is explicitly allowed.
+	// IncludedPaths contains paths where body logging is explicitly allowed.
 	// If set, body logging (LogRequestBody/LogResponseBody) will only occur
 	// for paths matching these patterns. Supports exact matches and prefixes (ending with /).
-	// If empty, body logging applies to all paths (subject to ExemptPaths).
-	AllowedPaths []string
+	// If empty, body logging applies to all paths (subject to ExcludedPaths).
+	// Default: []
+	IncludedPaths []string
 
 	// LogRequestBody enables logging of request bodies (defaults to false).
 	// This is opt-in due to performance and security considerations.
@@ -122,8 +126,8 @@ var DefaultRequestLoggerConfig = RequestLoggerConfig{
 		FieldClientIP,
 		FieldRequestID,
 	},
-	ExemptPaths:     []string{},
-	AllowedPaths:    []string{},
+	ExcludedPaths:   []string{},
+	IncludedPaths:   []string{},
 	MaxBodySize:     1024, // 1KB default
 	SensitiveFields: DefaultSensitiveFields,
 }

--- a/config/request_logger_test.go
+++ b/config/request_logger_test.go
@@ -17,8 +17,8 @@ func TestRequestLoggerConfig_DefaultValues(t *testing.T) {
 	if len(cfg.Fields) != 13 {
 		t.Errorf("expected 13 default fields, got %d", len(cfg.Fields))
 	}
-	if len(cfg.ExemptPaths) != 0 {
-		t.Errorf("expected default exempt paths to be empty, got %d paths", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 0 {
+		t.Errorf("expected default excluded paths to be empty, got %d paths", len(cfg.ExcludedPaths))
 	}
 
 	// Test default field values
@@ -62,9 +62,9 @@ func TestRequestLoggerConfig_FieldConstants(t *testing.T) {
 func TestRequestLoggerConfig_StructAssignment(t *testing.T) {
 	t.Run("log errors assignment", func(t *testing.T) {
 		cfg := RequestLoggerConfig{
-			LogErrors:   false,
-			Fields:      DefaultRequestLoggerConfig.Fields,
-			ExemptPaths: []string{},
+			LogErrors:     false,
+			Fields:        DefaultRequestLoggerConfig.Fields,
+			ExcludedPaths: []string{},
 		}
 		if cfg.LogErrors != false {
 			t.Errorf("expected log errors = false, got %t", cfg.LogErrors)
@@ -79,9 +79,9 @@ func TestRequestLoggerConfig_StructAssignment(t *testing.T) {
 	t.Run("fields assignment", func(t *testing.T) {
 		fields := []LogField{FieldMethod, FieldPath, FieldStatus, FieldDurationHuman}
 		cfg := RequestLoggerConfig{
-			LogErrors:   true,
-			Fields:      fields,
-			ExemptPaths: []string{},
+			LogErrors:     true,
+			Fields:        fields,
+			ExcludedPaths: []string{},
 		}
 		if len(cfg.Fields) != 4 {
 			t.Errorf("expected 4 fields, got %d", len(cfg.Fields))
@@ -91,28 +91,28 @@ func TestRequestLoggerConfig_StructAssignment(t *testing.T) {
 		}
 	})
 
-	t.Run("exempt paths assignment", func(t *testing.T) {
-		exemptPaths := []string{"/health", "/metrics", "/ping", "/status"}
+	t.Run("excluded paths assignment", func(t *testing.T) {
+		excludedPaths := []string{"/health", "/metrics", "/ping", "/status"}
 		cfg := RequestLoggerConfig{
-			LogErrors:   true,
-			Fields:      DefaultRequestLoggerConfig.Fields,
-			ExemptPaths: exemptPaths,
+			LogErrors:     true,
+			Fields:        DefaultRequestLoggerConfig.Fields,
+			ExcludedPaths: excludedPaths,
 		}
-		if len(cfg.ExemptPaths) != 4 {
-			t.Errorf("expected 4 exempt paths, got %d", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 4 {
+			t.Errorf("expected 4 excluded paths, got %d", len(cfg.ExcludedPaths))
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Errorf("expected exempt paths = %v, got %v", exemptPaths, cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Errorf("expected excluded paths = %v, got %v", excludedPaths, cfg.ExcludedPaths)
 		}
 	})
 
 	t.Run("multiple fields assignment", func(t *testing.T) {
 		fields := []LogField{FieldMethod, FieldStatus, FieldDurationHuman}
-		exemptPaths := []string{"/health", "/metrics"}
+		excludedPaths := []string{"/health", "/metrics"}
 		cfg := RequestLoggerConfig{
-			LogErrors:   false,
-			Fields:      fields,
-			ExemptPaths: exemptPaths,
+			LogErrors:     false,
+			Fields:        fields,
+			ExcludedPaths: excludedPaths,
 		}
 
 		if cfg.LogErrors != false {
@@ -121,8 +121,8 @@ func TestRequestLoggerConfig_StructAssignment(t *testing.T) {
 		if !reflect.DeepEqual(cfg.Fields, fields) {
 			t.Error("expected fields to be set correctly")
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Error("expected exempt paths to be set correctly")
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Error("expected excluded paths to be set correctly")
 		}
 	})
 }
@@ -131,9 +131,9 @@ func TestRequestLoggerConfig_FieldScenarios(t *testing.T) {
 	t.Run("minimal fields", func(t *testing.T) {
 		fields := []LogField{FieldMethod, FieldPath, FieldStatus}
 		cfg := RequestLoggerConfig{
-			LogErrors:   true,
-			Fields:      fields,
-			ExemptPaths: []string{},
+			LogErrors:     true,
+			Fields:        fields,
+			ExcludedPaths: []string{},
 		}
 		if len(cfg.Fields) != 3 {
 			t.Errorf("expected 3 minimal fields, got %d", len(cfg.Fields))
@@ -153,9 +153,9 @@ func TestRequestLoggerConfig_FieldScenarios(t *testing.T) {
 		for _, field := range allFields {
 			t.Run(string(field), func(t *testing.T) {
 				cfg := RequestLoggerConfig{
-					LogErrors:   true,
-					Fields:      []LogField{field},
-					ExemptPaths: []string{},
+					LogErrors:     true,
+					Fields:        []LogField{field},
+					ExcludedPaths: []string{},
 				}
 				if len(cfg.Fields) != 1 {
 					t.Errorf("expected 1 field, got %d", len(cfg.Fields))
@@ -170,9 +170,9 @@ func TestRequestLoggerConfig_FieldScenarios(t *testing.T) {
 	t.Run("duration fields", func(t *testing.T) {
 		durationFields := []LogField{FieldDurationNS, FieldDurationHuman}
 		cfg := RequestLoggerConfig{
-			LogErrors:   true,
-			Fields:      durationFields,
-			ExemptPaths: []string{},
+			LogErrors:     true,
+			Fields:        durationFields,
+			ExcludedPaths: []string{},
 		}
 		if len(cfg.Fields) != 2 {
 			t.Errorf("expected 2 duration fields, got %d", len(cfg.Fields))
@@ -185,9 +185,9 @@ func TestRequestLoggerConfig_FieldScenarios(t *testing.T) {
 	t.Run("security fields", func(t *testing.T) {
 		securityFields := []LogField{FieldRemoteAddr, FieldClientIP, FieldUserAgent, FieldReferer}
 		cfg := RequestLoggerConfig{
-			LogErrors:   true,
-			Fields:      securityFields,
-			ExemptPaths: []string{},
+			LogErrors:     true,
+			Fields:        securityFields,
+			ExcludedPaths: []string{},
 		}
 		if len(cfg.Fields) != 4 {
 			t.Errorf("expected 4 security fields, got %d", len(cfg.Fields))
@@ -201,9 +201,9 @@ func TestRequestLoggerConfig_FieldScenarios(t *testing.T) {
 func TestRequestLoggerConfig_EdgeCases(t *testing.T) {
 	t.Run("empty fields", func(t *testing.T) {
 		cfg := RequestLoggerConfig{
-			LogErrors:   true,
-			Fields:      []LogField{},
-			ExemptPaths: []string{},
+			LogErrors:     true,
+			Fields:        []LogField{},
+			ExcludedPaths: []string{},
 		}
 		if cfg.Fields == nil {
 			t.Error("expected fields slice to be initialized, not nil")
@@ -215,52 +215,52 @@ func TestRequestLoggerConfig_EdgeCases(t *testing.T) {
 
 	t.Run("nil fields", func(t *testing.T) {
 		cfg := RequestLoggerConfig{
-			LogErrors:   true,
-			Fields:      nil,
-			ExemptPaths: []string{},
+			LogErrors:     true,
+			Fields:        nil,
+			ExcludedPaths: []string{},
 		}
 		if cfg.Fields != nil {
 			t.Error("expected fields to remain nil when nil is passed")
 		}
 	})
 
-	t.Run("empty exempt paths", func(t *testing.T) {
+	t.Run("empty excluded paths", func(t *testing.T) {
 		cfg := RequestLoggerConfig{
-			LogErrors:   true,
-			Fields:      DefaultRequestLoggerConfig.Fields,
-			ExemptPaths: []string{},
+			LogErrors:     true,
+			Fields:        DefaultRequestLoggerConfig.Fields,
+			ExcludedPaths: []string{},
 		}
-		if cfg.ExemptPaths == nil {
-			t.Error("expected exempt paths slice to be initialized, not nil")
+		if cfg.ExcludedPaths == nil {
+			t.Error("expected excluded paths slice to be initialized, not nil")
 		}
-		if len(cfg.ExemptPaths) != 0 {
-			t.Errorf("expected empty exempt paths slice, got %d entries", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 0 {
+			t.Errorf("expected empty excluded paths slice, got %d entries", len(cfg.ExcludedPaths))
 		}
 	})
 
-	t.Run("nil exempt paths", func(t *testing.T) {
+	t.Run("nil excluded paths", func(t *testing.T) {
 		cfg := RequestLoggerConfig{
-			LogErrors:   true,
-			Fields:      DefaultRequestLoggerConfig.Fields,
-			ExemptPaths: nil,
+			LogErrors:     true,
+			Fields:        DefaultRequestLoggerConfig.Fields,
+			ExcludedPaths: nil,
 		}
-		if cfg.ExemptPaths != nil {
-			t.Error("expected exempt paths to remain nil when nil is passed")
+		if cfg.ExcludedPaths != nil {
+			t.Error("expected excluded paths to remain nil when nil is passed")
 		}
 	})
 
 	t.Run("empty string paths", func(t *testing.T) {
-		exemptPaths := []string{"", "/health", ""}
+		excludedPaths := []string{"", "/health", ""}
 		cfg := RequestLoggerConfig{
-			LogErrors:   true,
-			Fields:      DefaultRequestLoggerConfig.Fields,
-			ExemptPaths: exemptPaths,
+			LogErrors:     true,
+			Fields:        DefaultRequestLoggerConfig.Fields,
+			ExcludedPaths: excludedPaths,
 		}
-		if len(cfg.ExemptPaths) != 3 {
-			t.Errorf("expected 3 exempt paths, got %d", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 3 {
+			t.Errorf("expected 3 excluded paths, got %d", len(cfg.ExcludedPaths))
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Errorf("expected exempt paths = %v, got %v", exemptPaths, cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Errorf("expected excluded paths = %v, got %v", excludedPaths, cfg.ExcludedPaths)
 		}
 	})
 
@@ -272,46 +272,46 @@ func TestRequestLoggerConfig_EdgeCases(t *testing.T) {
 		if cfg.Fields != nil {
 			t.Errorf("expected zero fields = nil, got %v", cfg.Fields)
 		}
-		if cfg.ExemptPaths != nil {
-			t.Errorf("expected zero exempt paths = nil, got %v", cfg.ExemptPaths)
+		if cfg.ExcludedPaths != nil {
+			t.Errorf("expected zero excluded paths = nil, got %v", cfg.ExcludedPaths)
 		}
 	})
 }
 
 func TestRequestLoggerConfig_PathPatterns(t *testing.T) {
 	t.Run("pattern paths", func(t *testing.T) {
-		exemptPaths := []string{
+		excludedPaths := []string{
 			"/health", "/metrics", "/api/v1/health/*", "/monitoring/*",
 			"*.json", "/admin/debug/*", "/internal/status", "/ping",
 		}
 		cfg := RequestLoggerConfig{
-			LogErrors:   true,
-			Fields:      DefaultRequestLoggerConfig.Fields,
-			ExemptPaths: exemptPaths,
+			LogErrors:     true,
+			Fields:        DefaultRequestLoggerConfig.Fields,
+			ExcludedPaths: excludedPaths,
 		}
-		if len(cfg.ExemptPaths) != len(exemptPaths) {
-			t.Errorf("expected %d exempt paths, got %d", len(exemptPaths), len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != len(excludedPaths) {
+			t.Errorf("expected %d excluded paths, got %d", len(excludedPaths), len(cfg.ExcludedPaths))
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Errorf("expected exempt paths = %v, got %v", exemptPaths, cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Errorf("expected excluded paths = %v, got %v", excludedPaths, cfg.ExcludedPaths)
 		}
 	})
 
 	t.Run("special character paths", func(t *testing.T) {
-		exemptPaths := []string{
+		excludedPaths := []string{
 			"/api-v1/health", "/metrics_endpoint", "/health-check", "/status.json",
 			"/monitoring (internal)", "/path with spaces", "/path/with/unicode-ñ", "/endpoint@service.com",
 		}
 		cfg := RequestLoggerConfig{
-			LogErrors:   true,
-			Fields:      DefaultRequestLoggerConfig.Fields,
-			ExemptPaths: exemptPaths,
+			LogErrors:     true,
+			Fields:        DefaultRequestLoggerConfig.Fields,
+			ExcludedPaths: excludedPaths,
 		}
-		if len(cfg.ExemptPaths) != len(exemptPaths) {
-			t.Errorf("expected %d exempt paths, got %d", len(exemptPaths), len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != len(excludedPaths) {
+			t.Errorf("expected %d excluded paths, got %d", len(excludedPaths), len(cfg.ExcludedPaths))
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Errorf("expected exempt paths = %v, got %v", exemptPaths, cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Errorf("expected excluded paths = %v, got %v", excludedPaths, cfg.ExcludedPaths)
 		}
 	})
 }
@@ -319,9 +319,9 @@ func TestRequestLoggerConfig_PathPatterns(t *testing.T) {
 func TestRequestLoggerConfig_StructCreation(t *testing.T) {
 	t.Run("basic struct creation", func(t *testing.T) {
 		cfg := RequestLoggerConfig{
-			LogErrors:   false,
-			Fields:      []LogField{FieldMethod, FieldStatus},
-			ExemptPaths: []string{"/health", "/metrics"},
+			LogErrors:     false,
+			Fields:        []LogField{FieldMethod, FieldStatus},
+			ExcludedPaths: []string{"/health", "/metrics"},
 		}
 
 		if cfg.LogErrors != false {
@@ -330,8 +330,8 @@ func TestRequestLoggerConfig_StructCreation(t *testing.T) {
 		if !reflect.DeepEqual(cfg.Fields, []LogField{FieldMethod, FieldStatus}) {
 			t.Errorf("expected fields = [method status], got %v", cfg.Fields)
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, []string{"/health", "/metrics"}) {
-			t.Errorf("expected exempt paths = [/health /metrics], got %v", cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, []string{"/health", "/metrics"}) {
+			t.Errorf("expected excluded paths = [/health /metrics], got %v", cfg.ExcludedPaths)
 		}
 	})
 
@@ -344,17 +344,17 @@ func TestRequestLoggerConfig_StructCreation(t *testing.T) {
 		if !reflect.DeepEqual(cfg.Fields, DefaultRequestLoggerConfig.Fields) {
 			t.Errorf("expected fields to match default")
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, DefaultRequestLoggerConfig.ExemptPaths) {
-			t.Errorf("expected exempt paths to match default")
+		if !reflect.DeepEqual(cfg.ExcludedPaths, DefaultRequestLoggerConfig.ExcludedPaths) {
+			t.Errorf("expected excluded paths to match default")
 		}
 	})
 
 	t.Run("logging scenarios", func(t *testing.T) {
 		tests := []struct {
-			name        string
-			logErrors   bool
-			fields      []LogField
-			exemptPaths []string
+			name          string
+			logErrors     bool
+			fields        []LogField
+			excludedPaths []string
 		}{
 			{"minimal logging", false, []LogField{FieldMethod, FieldPath, FieldStatus}, []string{"/health"}},
 			{"verbose logging", true, DefaultRequestLoggerConfig.Fields, []string{}},
@@ -365,9 +365,9 @@ func TestRequestLoggerConfig_StructCreation(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				cfg := RequestLoggerConfig{
-					LogErrors:   tt.logErrors,
-					Fields:      tt.fields,
-					ExemptPaths: tt.exemptPaths,
+					LogErrors:     tt.logErrors,
+					Fields:        tt.fields,
+					ExcludedPaths: tt.excludedPaths,
 				}
 
 				if cfg.LogErrors != tt.logErrors {
@@ -376,8 +376,8 @@ func TestRequestLoggerConfig_StructCreation(t *testing.T) {
 				if !reflect.DeepEqual(cfg.Fields, tt.fields) {
 					t.Errorf("expected fields = %v, got %v", tt.fields, cfg.Fields)
 				}
-				if !reflect.DeepEqual(cfg.ExemptPaths, tt.exemptPaths) {
-					t.Errorf("expected exempt paths = %v, got %v", tt.exemptPaths, cfg.ExemptPaths)
+				if !reflect.DeepEqual(cfg.ExcludedPaths, tt.excludedPaths) {
+					t.Errorf("expected excluded paths = %v, got %v", tt.excludedPaths, cfg.ExcludedPaths)
 				}
 			})
 		}

--- a/config/reverse_proxy.go
+++ b/config/reverse_proxy.go
@@ -108,8 +108,19 @@ type ReverseProxyConfig struct {
 	// Return an error to trigger the error handler
 	ModifyResponse func(*http.Response) error
 
-	// ExemptPaths contains paths that skip reverse proxying
-	ExemptPaths []string
+	// ExcludedPaths contains paths that skip reverse proxying.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// Cannot be used with IncludedPaths - setting both will panic.
+	// Default: []
+	ExcludedPaths []string
+
+	// IncludedPaths contains paths where reverse proxying is explicitly applied.
+	// If set, reverse proxying will only occur for paths matching these patterns.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// If empty, reverse proxying applies to all paths (subject to ExcludedPaths).
+	// Cannot be used with ExcludedPaths - setting both will panic.
+	// Default: []
+	IncludedPaths []string
 }
 
 // DefaultReverseProxyConfig contains sensible defaults
@@ -122,5 +133,6 @@ var DefaultReverseProxyConfig = ReverseProxyConfig{
 	SetHeaders:      map[string]string{},
 	RemoveHeaders:   []string{},
 	ForwardHeaders:  true,
-	ExemptPaths:     []string{},
+	ExcludedPaths:   []string{},
+	IncludedPaths:   []string{},
 }

--- a/config/reverse_proxy_test.go
+++ b/config/reverse_proxy_test.go
@@ -32,8 +32,11 @@ func TestDefaultReverseProxyConfig(t *testing.T) {
 	if !cfg.ForwardHeaders {
 		t.Error("expected ForwardHeaders to be true")
 	}
-	if len(cfg.ExemptPaths) != 0 {
-		t.Errorf("expected ExemptPaths to be empty, got %d items", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 0 {
+		t.Errorf("expected ExcludedPaths to be empty, got %d items", len(cfg.ExcludedPaths))
+	}
+	if len(cfg.IncludedPaths) != 0 {
+		t.Errorf("expected IncludedPaths to be empty, got %d items", len(cfg.IncludedPaths))
 	}
 }
 
@@ -100,7 +103,8 @@ func TestReverseProxyConfig(t *testing.T) {
 		},
 		RemoveHeaders:  []string{"X-Internal"},
 		ForwardHeaders: true,
-		ExemptPaths:    []string{"/health", "/metrics"},
+		ExcludedPaths:  []string{"/health", "/metrics"},
+		IncludedPaths:  []string{"/api/public"},
 	}
 
 	if cfg.Target != "http://localhost:8081" {
@@ -142,9 +146,48 @@ func TestReverseProxyConfig(t *testing.T) {
 	if !cfg.ForwardHeaders {
 		t.Error("expected ForwardHeaders to be true")
 	}
-	if len(cfg.ExemptPaths) != 2 {
-		t.Errorf("expected 2 ExemptPaths, got %d", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 2 {
+		t.Errorf("expected 2 ExcludedPaths, got %d", len(cfg.ExcludedPaths))
 	}
+	if len(cfg.IncludedPaths) != 1 {
+		t.Errorf("expected 1 AllowedPath, got %d", len(cfg.IncludedPaths))
+	}
+}
+
+func TestReverseProxyConfig_IncludedPaths(t *testing.T) {
+	t.Run("custom included paths", func(t *testing.T) {
+		cfg := ReverseProxyConfig{
+			Target:        "http://localhost:8081",
+			IncludedPaths: []string{"/api/public", "/health"},
+		}
+		if len(cfg.IncludedPaths) != 2 {
+			t.Errorf("expected 2 included paths, got %d", len(cfg.IncludedPaths))
+		}
+		if cfg.IncludedPaths[0] != "/api/public" {
+			t.Errorf("expected first allowed path to be /api/public, got %s", cfg.IncludedPaths[0])
+		}
+	})
+
+	t.Run("empty included paths", func(t *testing.T) {
+		cfg := ReverseProxyConfig{
+			IncludedPaths: []string{},
+		}
+		if cfg.IncludedPaths == nil {
+			t.Error("expected included paths slice to be initialized, not nil")
+		}
+		if len(cfg.IncludedPaths) != 0 {
+			t.Errorf("expected empty included paths slice, got %d entries", len(cfg.IncludedPaths))
+		}
+	})
+
+	t.Run("nil included paths", func(t *testing.T) {
+		cfg := ReverseProxyConfig{
+			IncludedPaths: nil,
+		}
+		if cfg.IncludedPaths != nil {
+			t.Error("expected included paths to remain nil when nil is passed")
+		}
+	})
 }
 
 func TestReverseProxyConfigWithTargets(t *testing.T) {

--- a/config/security_headers.go
+++ b/config/security_headers.go
@@ -101,8 +101,19 @@ type SecurityHeadersConfig struct {
 	// XFrameOptions sets the `X-Frame-Options` header
 	XFrameOptions string
 
-	// ExemptPaths contains paths to skip security headers
-	ExemptPaths []string
+	// ExcludedPaths contains paths to skip security headers.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// Cannot be used with IncludedPaths - setting both will panic.
+	// Default: []
+	ExcludedPaths []string
+
+	// IncludedPaths contains paths where security headers are explicitly applied.
+	// If set, security headers will only be set for paths matching these patterns.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// If empty, security headers apply to all paths (subject to ExcludedPaths).
+	// Cannot be used with ExcludedPaths - setting both will panic.
+	// Default: []
+	IncludedPaths []string
 }
 
 // DefaultSecurityHeadersConfig contains the default values for security headers configuration.
@@ -116,5 +127,6 @@ var DefaultSecurityHeadersConfig = SecurityHeadersConfig{
 	StrictTransportSecurity:   DefaultStrictTransportSecurity,
 	XContentTypeOptions:       "nosniff",
 	XFrameOptions:             "DENY",
-	ExemptPaths:               []string{},
+	ExcludedPaths:             []string{},
+	IncludedPaths:             []string{},
 }

--- a/config/security_headers_test.go
+++ b/config/security_headers_test.go
@@ -39,8 +39,11 @@ func TestSecurityHeadersConfig_DefaultValues(t *testing.T) {
 	if cfg.XFrameOptions != "DENY" {
 		t.Errorf("expected default X-Frame-Options = 'DENY', got %s", cfg.XFrameOptions)
 	}
-	if len(cfg.ExemptPaths) != 0 {
-		t.Errorf("expected default exempt paths to be empty, got %d paths", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 0 {
+		t.Errorf("expected default excluded paths to be empty, got %d paths", len(cfg.ExcludedPaths))
+	}
+	if len(cfg.IncludedPaths) != 0 {
+		t.Errorf("expected default included paths to be empty, got %d paths", len(cfg.IncludedPaths))
 	}
 
 	// Test default HSTS values
@@ -117,7 +120,7 @@ func TestSecurityHeadersConfig_StructAssignment(t *testing.T) {
 			},
 			XContentTypeOptions: "nosniff",
 			XFrameOptions:       "SAMEORIGIN",
-			ExemptPaths:         []string{},
+			ExcludedPaths:       []string{},
 		}
 
 		if cfg.ContentSecurityPolicy != "default-src 'self'; script-src 'self' 'unsafe-inline'" {
@@ -150,7 +153,7 @@ func TestSecurityHeadersConfig_StructAssignment(t *testing.T) {
 			StrictTransportSecurity:         DefaultStrictTransportSecurity,
 			XContentTypeOptions:             "nosniff",
 			XFrameOptions:                   "SAMEORIGIN",
-			ExemptPaths:                     []string{},
+			ExcludedPaths:                   []string{},
 		}
 
 		if cfg.PermissionsPolicy != "camera=(), microphone=(), geolocation=()" {
@@ -187,7 +190,7 @@ func TestSecurityHeadersConfig_StructAssignment(t *testing.T) {
 			},
 			XContentTypeOptions: "nosniff",
 			XFrameOptions:       "DENY",
-			ExemptPaths:         []string{},
+			ExcludedPaths:       []string{},
 		}
 
 		if cfg.StrictTransportSecurity.MaxAge != 31536000 {
@@ -201,8 +204,8 @@ func TestSecurityHeadersConfig_StructAssignment(t *testing.T) {
 		}
 	})
 
-	t.Run("exempt paths field", func(t *testing.T) {
-		exemptPaths := []string{"/api/webhook", "/health", "/metrics"}
+	t.Run("excluded paths field", func(t *testing.T) {
+		excludedPaths := []string{"/api/webhook", "/health", "/metrics"}
 		cfg := SecurityHeadersConfig{
 			ContentSecurityPolicy:           DefaultSecurityHeadersConfig.ContentSecurityPolicy,
 			ContentSecurityPolicyReportOnly: false,
@@ -215,19 +218,44 @@ func TestSecurityHeadersConfig_StructAssignment(t *testing.T) {
 			StrictTransportSecurity:         DefaultStrictTransportSecurity,
 			XContentTypeOptions:             "nosniff",
 			XFrameOptions:                   "DENY",
-			ExemptPaths:                     exemptPaths,
+			ExcludedPaths:                   excludedPaths,
 		}
-		if len(cfg.ExemptPaths) != 3 {
-			t.Errorf("expected 3 exempt paths, got %d", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 3 {
+			t.Errorf("expected 3 excluded paths, got %d", len(cfg.ExcludedPaths))
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Errorf("expected exempt paths = %v, got %v", exemptPaths, cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Errorf("expected excluded paths = %v, got %v", excludedPaths, cfg.ExcludedPaths)
+		}
+	})
+
+	t.Run("included paths field", func(t *testing.T) {
+		includedPaths := []string{"/api/public", "/health"}
+		cfg := SecurityHeadersConfig{
+			ContentSecurityPolicy:           DefaultSecurityHeadersConfig.ContentSecurityPolicy,
+			ContentSecurityPolicyReportOnly: false,
+			CrossOriginEmbedderPolicy:       DefaultSecurityHeadersConfig.CrossOriginEmbedderPolicy,
+			CrossOriginOpenerPolicy:         DefaultSecurityHeadersConfig.CrossOriginOpenerPolicy,
+			CrossOriginResourcePolicy:       DefaultSecurityHeadersConfig.CrossOriginResourcePolicy,
+			PermissionsPolicy:               DefaultSecurityHeadersConfig.PermissionsPolicy,
+			ReferrerPolicy:                  DefaultSecurityHeadersConfig.ReferrerPolicy,
+			Server:                          "",
+			StrictTransportSecurity:         DefaultStrictTransportSecurity,
+			XContentTypeOptions:             "nosniff",
+			XFrameOptions:                   "DENY",
+			IncludedPaths:                   includedPaths,
+		}
+		if len(cfg.IncludedPaths) != 2 {
+			t.Errorf("expected 2 included paths, got %d", len(cfg.IncludedPaths))
+		}
+		if !reflect.DeepEqual(cfg.IncludedPaths, includedPaths) {
+			t.Errorf("expected included paths = %v, got %v", includedPaths, cfg.IncludedPaths)
 		}
 	})
 }
 
 func TestSecurityHeadersConfig_MultipleFields(t *testing.T) {
-	exemptPaths := []string{"/public", "/api/webhook"}
+	excludedPaths := []string{"/public", "/api/webhook"}
+	includedPaths := []string{"/api/public"}
 	cfg := SecurityHeadersConfig{
 		ContentSecurityPolicy:           "default-src 'self'",
 		ContentSecurityPolicyReportOnly: true,
@@ -240,7 +268,8 @@ func TestSecurityHeadersConfig_MultipleFields(t *testing.T) {
 		StrictTransportSecurity:         DefaultStrictTransportSecurity,
 		XContentTypeOptions:             "nosniff",
 		XFrameOptions:                   "SAMEORIGIN",
-		ExemptPaths:                     exemptPaths,
+		ExcludedPaths:                   excludedPaths,
+		IncludedPaths:                   includedPaths,
 	}
 
 	if cfg.ContentSecurityPolicy != "default-src 'self'" {
@@ -261,8 +290,11 @@ func TestSecurityHeadersConfig_MultipleFields(t *testing.T) {
 	if cfg.XFrameOptions != "SAMEORIGIN" {
 		t.Error("expected X-Frame-Options to be set correctly")
 	}
-	if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-		t.Error("expected exempt paths to be set correctly")
+	if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+		t.Error("expected excluded paths to be set correctly")
+	}
+	if !reflect.DeepEqual(cfg.IncludedPaths, includedPaths) {
+		t.Error("expected included paths to be set correctly")
 	}
 }
 
@@ -293,7 +325,7 @@ func TestSecurityHeadersConfig_PolicyVariations(t *testing.T) {
 					StrictTransportSecurity:         DefaultStrictTransportSecurity,
 					XContentTypeOptions:             "nosniff",
 					XFrameOptions:                   "DENY",
-					ExemptPaths:                     []string{},
+					ExcludedPaths:                   []string{},
 				}
 				if cfg.ContentSecurityPolicy != tt.csp {
 					t.Errorf("expected CSP = %s, got %s", tt.csp, cfg.ContentSecurityPolicy)
@@ -328,7 +360,7 @@ func TestSecurityHeadersConfig_PolicyVariations(t *testing.T) {
 					StrictTransportSecurity:         DefaultStrictTransportSecurity,
 					XContentTypeOptions:             "nosniff",
 					XFrameOptions:                   "DENY",
-					ExemptPaths:                     []string{},
+					ExcludedPaths:                   []string{},
 				}
 
 				if cfg.CrossOriginEmbedderPolicy != tt.coep {
@@ -364,7 +396,7 @@ func TestSecurityHeadersConfig_PolicyVariations(t *testing.T) {
 					StrictTransportSecurity:         DefaultStrictTransportSecurity,
 					XContentTypeOptions:             "nosniff",
 					XFrameOptions:                   "DENY",
-					ExemptPaths:                     []string{},
+					ExcludedPaths:                   []string{},
 				}
 				if cfg.ReferrerPolicy != policy {
 					t.Errorf("expected referrer policy = %s, got %s", policy, cfg.ReferrerPolicy)
@@ -390,7 +422,7 @@ func TestSecurityHeadersConfig_PolicyVariations(t *testing.T) {
 					StrictTransportSecurity:         DefaultStrictTransportSecurity,
 					XContentTypeOptions:             "nosniff",
 					XFrameOptions:                   option,
-					ExemptPaths:                     []string{},
+					ExcludedPaths:                   []string{},
 				}
 				if cfg.XFrameOptions != option {
 					t.Errorf("expected X-Frame-Options = %s, got %s", option, cfg.XFrameOptions)
@@ -401,7 +433,7 @@ func TestSecurityHeadersConfig_PolicyVariations(t *testing.T) {
 }
 
 func TestSecurityHeadersConfig_EdgeCases(t *testing.T) {
-	t.Run("empty exempt paths", func(t *testing.T) {
+	t.Run("empty excluded paths", func(t *testing.T) {
 		cfg := SecurityHeadersConfig{
 			ContentSecurityPolicy:           DefaultSecurityHeadersConfig.ContentSecurityPolicy,
 			ContentSecurityPolicyReportOnly: false,
@@ -414,17 +446,17 @@ func TestSecurityHeadersConfig_EdgeCases(t *testing.T) {
 			StrictTransportSecurity:         DefaultStrictTransportSecurity,
 			XContentTypeOptions:             "nosniff",
 			XFrameOptions:                   "DENY",
-			ExemptPaths:                     []string{},
+			ExcludedPaths:                   []string{},
 		}
-		if cfg.ExemptPaths == nil {
-			t.Error("expected exempt paths slice to be initialized, not nil")
+		if cfg.ExcludedPaths == nil {
+			t.Error("expected excluded paths slice to be initialized, not nil")
 		}
-		if len(cfg.ExemptPaths) != 0 {
-			t.Errorf("expected empty exempt paths slice, got %d entries", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 0 {
+			t.Errorf("expected empty excluded paths slice, got %d entries", len(cfg.ExcludedPaths))
 		}
 	})
 
-	t.Run("nil exempt paths", func(t *testing.T) {
+	t.Run("nil excluded paths", func(t *testing.T) {
 		cfg := SecurityHeadersConfig{
 			ContentSecurityPolicy:           DefaultSecurityHeadersConfig.ContentSecurityPolicy,
 			ContentSecurityPolicyReportOnly: false,
@@ -437,10 +469,53 @@ func TestSecurityHeadersConfig_EdgeCases(t *testing.T) {
 			StrictTransportSecurity:         DefaultStrictTransportSecurity,
 			XContentTypeOptions:             "nosniff",
 			XFrameOptions:                   "DENY",
-			ExemptPaths:                     nil,
+			ExcludedPaths:                   nil,
 		}
-		if cfg.ExemptPaths != nil {
-			t.Error("expected exempt paths to remain nil when nil is passed")
+		if cfg.ExcludedPaths != nil {
+			t.Error("expected excluded paths to remain nil when nil is passed")
+		}
+	})
+
+	t.Run("empty included paths", func(t *testing.T) {
+		cfg := SecurityHeadersConfig{
+			ContentSecurityPolicy:           DefaultSecurityHeadersConfig.ContentSecurityPolicy,
+			ContentSecurityPolicyReportOnly: false,
+			CrossOriginEmbedderPolicy:       DefaultSecurityHeadersConfig.CrossOriginEmbedderPolicy,
+			CrossOriginOpenerPolicy:         DefaultSecurityHeadersConfig.CrossOriginOpenerPolicy,
+			CrossOriginResourcePolicy:       DefaultSecurityHeadersConfig.CrossOriginResourcePolicy,
+			PermissionsPolicy:               DefaultSecurityHeadersConfig.PermissionsPolicy,
+			ReferrerPolicy:                  DefaultSecurityHeadersConfig.ReferrerPolicy,
+			Server:                          "",
+			StrictTransportSecurity:         DefaultStrictTransportSecurity,
+			XContentTypeOptions:             "nosniff",
+			XFrameOptions:                   "DENY",
+			IncludedPaths:                   []string{},
+		}
+		if cfg.IncludedPaths == nil {
+			t.Error("expected included paths slice to be initialized, not nil")
+		}
+		if len(cfg.IncludedPaths) != 0 {
+			t.Errorf("expected empty included paths slice, got %d entries", len(cfg.IncludedPaths))
+		}
+	})
+
+	t.Run("nil included paths", func(t *testing.T) {
+		cfg := SecurityHeadersConfig{
+			ContentSecurityPolicy:           DefaultSecurityHeadersConfig.ContentSecurityPolicy,
+			ContentSecurityPolicyReportOnly: false,
+			CrossOriginEmbedderPolicy:       DefaultSecurityHeadersConfig.CrossOriginEmbedderPolicy,
+			CrossOriginOpenerPolicy:         DefaultSecurityHeadersConfig.CrossOriginOpenerPolicy,
+			CrossOriginResourcePolicy:       DefaultSecurityHeadersConfig.CrossOriginResourcePolicy,
+			PermissionsPolicy:               DefaultSecurityHeadersConfig.PermissionsPolicy,
+			ReferrerPolicy:                  DefaultSecurityHeadersConfig.ReferrerPolicy,
+			Server:                          "",
+			StrictTransportSecurity:         DefaultStrictTransportSecurity,
+			XContentTypeOptions:             "nosniff",
+			XFrameOptions:                   "DENY",
+			IncludedPaths:                   nil,
+		}
+		if cfg.IncludedPaths != nil {
+			t.Error("expected included paths to remain nil when nil is passed")
 		}
 	})
 
@@ -455,8 +530,11 @@ func TestSecurityHeadersConfig_EdgeCases(t *testing.T) {
 		if cfg.StrictTransportSecurity.MaxAge != 0 {
 			t.Errorf("expected zero HSTS max age = 0, got %d", cfg.StrictTransportSecurity.MaxAge)
 		}
-		if cfg.ExemptPaths != nil {
-			t.Errorf("expected zero exempt paths = nil, got %v", cfg.ExemptPaths)
+		if cfg.ExcludedPaths != nil {
+			t.Errorf("expected zero excluded paths = nil, got %v", cfg.ExcludedPaths)
+		}
+		if cfg.IncludedPaths != nil {
+			t.Errorf("expected zero included paths = nil, got %v", cfg.IncludedPaths)
 		}
 	})
 }
@@ -478,7 +556,7 @@ func TestSecurityHeadersConfig_StructCreation(t *testing.T) {
 		},
 		XContentTypeOptions: "nosniff",
 		XFrameOptions:       "SAMEORIGIN",
-		ExemptPaths:         []string{"/public"},
+		ExcludedPaths:       []string{"/public"},
 	}
 
 	if cfg.ContentSecurityPolicy != "default-src 'self'" {
@@ -490,7 +568,7 @@ func TestSecurityHeadersConfig_StructCreation(t *testing.T) {
 	if cfg.StrictTransportSecurity.MaxAge != 31536000 {
 		t.Error("expected HSTS max age to be set correctly")
 	}
-	if !reflect.DeepEqual(cfg.ExemptPaths, []string{"/public"}) {
-		t.Error("expected exempt paths to be set correctly")
+	if !reflect.DeepEqual(cfg.ExcludedPaths, []string{"/public"}) {
+		t.Error("expected excluded paths to be set correctly")
 	}
 }

--- a/config/timeout.go
+++ b/config/timeout.go
@@ -16,14 +16,26 @@ type TimeoutConfig struct {
 	// Message to write on timeout (optional)
 	Message string
 
-	// ExemptPaths contains paths that skip timeout enforcement
-	ExemptPaths []string
+	// ExcludedPaths contains paths that skip timeout enforcement.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// Cannot be used with IncludedPaths - setting both will panic.
+	// Default: []
+	ExcludedPaths []string
+
+	// IncludedPaths contains paths where timeout is explicitly applied.
+	// If set, timeout will only be enforced for paths matching these patterns.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// If empty, timeout applies to all paths (subject to ExcludedPaths).
+	// Cannot be used with ExcludedPaths - setting both will panic.
+	// Default: []
+	IncludedPaths []string
 }
 
 // DefaultTimeoutConfig contains the default values for timeout configuration.
 var DefaultTimeoutConfig = TimeoutConfig{
-	Timeout:     30 * time.Second,
-	StatusCode:  http.StatusGatewayTimeout,
-	Message:     "",
-	ExemptPaths: []string{},
+	Timeout:       30 * time.Second,
+	StatusCode:    http.StatusGatewayTimeout,
+	Message:       "",
+	ExcludedPaths: []string{},
+	IncludedPaths: []string{},
 }

--- a/config/timeout_test.go
+++ b/config/timeout_test.go
@@ -18,8 +18,11 @@ func TestTimeoutConfig_DefaultValues(t *testing.T) {
 	if cfg.Message != "" {
 		t.Errorf("expected default message = '', got %s", cfg.Message)
 	}
-	if len(cfg.ExemptPaths) != 0 {
-		t.Errorf("expected default exempt paths to be empty, got %d paths", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 0 {
+		t.Errorf("expected default excluded paths to be empty, got %d paths", len(cfg.ExcludedPaths))
+	}
+	if len(cfg.IncludedPaths) != 0 {
+		t.Errorf("expected default included paths to be empty, got %d paths", len(cfg.IncludedPaths))
 	}
 
 	// Test default status code specifically
@@ -63,27 +66,43 @@ func TestTimeoutConfig_StructAssignment(t *testing.T) {
 		}
 	})
 
-	t.Run("exempt paths assignment", func(t *testing.T) {
-		exemptPaths := []string{"/api/long-running", "/upload", "/stream", "/websocket"}
+	t.Run("excluded paths assignment", func(t *testing.T) {
+		excludedPaths := []string{"/api/long-running", "/upload", "/stream", "/websocket"}
 		cfg := TimeoutConfig{
-			Timeout:     DefaultTimeoutConfig.Timeout,
-			ExemptPaths: exemptPaths,
+			Timeout:       DefaultTimeoutConfig.Timeout,
+			ExcludedPaths: excludedPaths,
 		}
-		if len(cfg.ExemptPaths) != 4 {
-			t.Errorf("expected 4 exempt paths, got %d", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 4 {
+			t.Errorf("expected 4 excluded paths, got %d", len(cfg.ExcludedPaths))
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Errorf("expected exempt paths = %v, got %v", exemptPaths, cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Errorf("expected excluded paths = %v, got %v", excludedPaths, cfg.ExcludedPaths)
+		}
+	})
+
+	t.Run("included paths assignment", func(t *testing.T) {
+		includedPaths := []string{"/api/public", "/health"}
+		cfg := TimeoutConfig{
+			Timeout:       DefaultTimeoutConfig.Timeout,
+			IncludedPaths: includedPaths,
+		}
+		if len(cfg.IncludedPaths) != 2 {
+			t.Errorf("expected 2 included paths, got %d", len(cfg.IncludedPaths))
+		}
+		if !reflect.DeepEqual(cfg.IncludedPaths, includedPaths) {
+			t.Errorf("expected included paths = %v, got %v", includedPaths, cfg.IncludedPaths)
 		}
 	})
 
 	t.Run("multiple fields", func(t *testing.T) {
-		exemptPaths := []string{"/long-process", "/upload"}
+		excludedPaths := []string{"/long-process", "/upload"}
+		includedPaths := []string{"/api/public"}
 		cfg := TimeoutConfig{
-			Timeout:     2 * time.Minute,
-			StatusCode:  http.StatusServiceUnavailable,
-			Message:     "Service unavailable due to timeout",
-			ExemptPaths: exemptPaths,
+			Timeout:       2 * time.Minute,
+			StatusCode:    http.StatusServiceUnavailable,
+			Message:       "Service unavailable due to timeout",
+			ExcludedPaths: excludedPaths,
+			IncludedPaths: includedPaths,
 		}
 
 		if cfg.Timeout != 2*time.Minute {
@@ -95,8 +114,14 @@ func TestTimeoutConfig_StructAssignment(t *testing.T) {
 		if cfg.Message != "Service unavailable due to timeout" {
 			t.Error("expected timeout message to be set correctly")
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Error("expected exempt paths to be set correctly")
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Error("expected excluded paths to be set correctly")
+		}
+		if len(cfg.IncludedPaths) != 1 {
+			t.Errorf("expected 1 allowed path, got %d", len(cfg.IncludedPaths))
+		}
+		if !reflect.DeepEqual(cfg.IncludedPaths, includedPaths) {
+			t.Error("expected included paths to be set correctly")
 		}
 	})
 }
@@ -191,76 +216,113 @@ func TestTimeoutConfig_MessageVariations(t *testing.T) {
 }
 
 func TestTimeoutConfig_EdgeCases(t *testing.T) {
-	t.Run("empty exempt paths", func(t *testing.T) {
+	t.Run("empty excluded paths", func(t *testing.T) {
 		cfg := TimeoutConfig{
-			Timeout:     DefaultTimeoutConfig.Timeout,
-			ExemptPaths: []string{},
+			Timeout:       DefaultTimeoutConfig.Timeout,
+			ExcludedPaths: []string{},
 		}
-		if cfg.ExemptPaths == nil {
-			t.Error("expected exempt paths slice to be initialized, not nil")
+		if cfg.ExcludedPaths == nil {
+			t.Error("expected excluded paths slice to be initialized, not nil")
 		}
-		if len(cfg.ExemptPaths) != 0 {
-			t.Errorf("expected empty exempt paths slice, got %d entries", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 0 {
+			t.Errorf("expected empty excluded paths slice, got %d entries", len(cfg.ExcludedPaths))
 		}
 	})
 
-	t.Run("nil exempt paths", func(t *testing.T) {
+	t.Run("nil excluded paths", func(t *testing.T) {
 		cfg := TimeoutConfig{
-			Timeout:     DefaultTimeoutConfig.Timeout,
-			ExemptPaths: nil,
+			Timeout:       DefaultTimeoutConfig.Timeout,
+			ExcludedPaths: nil,
 		}
-		if cfg.ExemptPaths != nil {
-			t.Error("expected exempt paths to remain nil when nil is passed")
+		if cfg.ExcludedPaths != nil {
+			t.Error("expected excluded paths to remain nil when nil is passed")
 		}
 	})
 
 	t.Run("empty string paths", func(t *testing.T) {
-		exemptPaths := []string{"", "/upload", ""}
+		excludedPaths := []string{"", "/upload", ""}
 		cfg := TimeoutConfig{
-			Timeout:     DefaultTimeoutConfig.Timeout,
-			ExemptPaths: exemptPaths,
+			Timeout:       DefaultTimeoutConfig.Timeout,
+			ExcludedPaths: excludedPaths,
 		}
-		if len(cfg.ExemptPaths) != 3 {
-			t.Errorf("expected 3 exempt paths, got %d", len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != 3 {
+			t.Errorf("expected 3 excluded paths, got %d", len(cfg.ExcludedPaths))
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Errorf("expected exempt paths = %v, got %v", exemptPaths, cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Errorf("expected excluded paths = %v, got %v", excludedPaths, cfg.ExcludedPaths)
+		}
+	})
+
+	t.Run("empty included paths", func(t *testing.T) {
+		cfg := TimeoutConfig{
+			Timeout:       DefaultTimeoutConfig.Timeout,
+			IncludedPaths: []string{},
+		}
+		if cfg.IncludedPaths == nil {
+			t.Error("expected included paths slice to be initialized, not nil")
+		}
+		if len(cfg.IncludedPaths) != 0 {
+			t.Errorf("expected empty included paths slice, got %d entries", len(cfg.IncludedPaths))
+		}
+	})
+
+	t.Run("nil included paths", func(t *testing.T) {
+		cfg := TimeoutConfig{
+			Timeout:       DefaultTimeoutConfig.Timeout,
+			IncludedPaths: nil,
+		}
+		if cfg.IncludedPaths != nil {
+			t.Error("expected included paths to remain nil when nil is passed")
+		}
+	})
+
+	t.Run("custom included paths", func(t *testing.T) {
+		includedPaths := []string{"/api/public", "/health"}
+		cfg := TimeoutConfig{
+			Timeout:       DefaultTimeoutConfig.Timeout,
+			IncludedPaths: includedPaths,
+		}
+		if len(cfg.IncludedPaths) != 2 {
+			t.Errorf("expected 2 included paths, got %d", len(cfg.IncludedPaths))
+		}
+		if !reflect.DeepEqual(cfg.IncludedPaths, includedPaths) {
+			t.Errorf("expected included paths = %v, got %v", includedPaths, cfg.IncludedPaths)
 		}
 	})
 }
 
 func TestTimeoutConfig_PathPatterns(t *testing.T) {
 	t.Run("pattern paths", func(t *testing.T) {
-		exemptPaths := []string{
+		excludedPaths := []string{
 			"/api/v1/upload/*", "/streaming/*", "/websocket", "/long-poll",
 			"*.upload", "/admin/backup/*", "/reports/generate", "/sse/*",
 		}
 		cfg := TimeoutConfig{
-			Timeout:     DefaultTimeoutConfig.Timeout,
-			ExemptPaths: exemptPaths,
+			Timeout:       DefaultTimeoutConfig.Timeout,
+			ExcludedPaths: excludedPaths,
 		}
-		if len(cfg.ExemptPaths) != len(exemptPaths) {
-			t.Errorf("expected %d exempt paths, got %d", len(exemptPaths), len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != len(excludedPaths) {
+			t.Errorf("expected %d excluded paths, got %d", len(excludedPaths), len(cfg.ExcludedPaths))
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Errorf("expected exempt paths = %v, got %v", exemptPaths, cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Errorf("expected excluded paths = %v, got %v", excludedPaths, cfg.ExcludedPaths)
 		}
 	})
 
 	t.Run("special character paths", func(t *testing.T) {
-		exemptPaths := []string{
+		excludedPaths := []string{
 			"/api-v1/upload", "/long_running_task", "/upload-service", "/stream.data",
 			"/process (background)", "/path with spaces", "/path/with/unicode-ñ", "/files/test@example.com",
 		}
 		cfg := TimeoutConfig{
-			Timeout:     DefaultTimeoutConfig.Timeout,
-			ExemptPaths: exemptPaths,
+			Timeout:       DefaultTimeoutConfig.Timeout,
+			ExcludedPaths: excludedPaths,
 		}
-		if len(cfg.ExemptPaths) != len(exemptPaths) {
-			t.Errorf("expected %d exempt paths, got %d", len(exemptPaths), len(cfg.ExemptPaths))
+		if len(cfg.ExcludedPaths) != len(excludedPaths) {
+			t.Errorf("expected %d excluded paths, got %d", len(excludedPaths), len(cfg.ExcludedPaths))
 		}
-		if !reflect.DeepEqual(cfg.ExemptPaths, exemptPaths) {
-			t.Errorf("expected exempt paths = %v, got %v", exemptPaths, cfg.ExemptPaths)
+		if !reflect.DeepEqual(cfg.ExcludedPaths, excludedPaths) {
+			t.Errorf("expected excluded paths = %v, got %v", excludedPaths, cfg.ExcludedPaths)
 		}
 	})
 }

--- a/config/tracer.go
+++ b/config/tracer.go
@@ -11,10 +11,20 @@ import (
 type TracerConfig struct {
 	TracerField trace.Tracer
 
-	// ExemptPaths is a list of paths that should not be traced.
+	// ExcludedPaths is a list of paths that should not be traced.
 	// Requests to these paths will not create spans.
-	// Default: nil (all paths are traced)
-	ExemptPaths []string
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// Cannot be used with IncludedPaths - setting both will panic.
+	// Default: []
+	ExcludedPaths []string
+
+	// IncludedPaths contains paths where tracing is explicitly applied.
+	// If set, tracing will only occur for paths matching these patterns.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// If empty, tracing applies to all paths (subject to ExcludedPaths).
+	// Cannot be used with ExcludedPaths - setting both will panic.
+	// Default: []
+	IncludedPaths []string
 
 	// SpanNameFormatter is a custom function to generate span names.
 	// If nil, the default formatter is used (returns "{method} {path}").
@@ -24,7 +34,8 @@ type TracerConfig struct {
 
 // DefaultTracerConfig contains the default values for TracerConfig.
 var DefaultTracerConfig = TracerConfig{
-	ExemptPaths:       nil,
+	ExcludedPaths:     []string{},
+	IncludedPaths:     []string{},
 	SpanNameFormatter: nil,
 }
 
@@ -44,9 +55,9 @@ func (c TracerConfig) Wrap() *TracerConfigWrapper {
 	return &TracerConfigWrapper{Config: c}
 }
 
-// IsExempt checks if a path is exempt from tracing.
-func (w *TracerConfigWrapper) IsExempt(path string) bool {
-	return slices.Contains(w.Config.ExemptPaths, path)
+// IsExcluded checks if a path is excluded from tracing.
+func (w *TracerConfigWrapper) IsExcluded(path string) bool {
+	return slices.Contains(w.Config.ExcludedPaths, path)
 }
 
 // GetSpanName returns the span name for a request.

--- a/config/tracer_test.go
+++ b/config/tracer_test.go
@@ -6,27 +6,27 @@ import (
 	"testing"
 )
 
-func TestTracerConfigWrapper_IsExempt(t *testing.T) {
+func TestTracerConfigWrapper_IsExcluded(t *testing.T) {
 	tests := []struct {
-		name        string
-		exemptPaths []string
-		path        string
-		want        bool
+		name          string
+		excludedPaths []string
+		path          string
+		want          bool
 	}{
 		{"exact match", []string{"/health", "/metrics"}, "/health", true},
-		{"not exempt", []string{"/health", "/metrics"}, "/api/users", false},
-		{"empty exempt list", []string{}, "/health", false},
-		{"nil exempt list", nil, "/health", false},
+		{"not excluded", []string{"/health", "/metrics"}, "/api/users", false},
+		{"empty excluded list", []string{}, "/health", false},
+		{"nil excluded list", nil, "/health", false},
 		{"partial match should not work", []string{"/health"}, "/healthz", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := TracerConfig{ExemptPaths: tt.exemptPaths}
+			cfg := TracerConfig{ExcludedPaths: tt.excludedPaths}
 			wrapper := cfg.Wrap()
-			got := wrapper.IsExempt(tt.path)
+			got := wrapper.IsExcluded(tt.path)
 			if got != tt.want {
-				t.Errorf("IsExempt(%q) = %v, want %v", tt.path, got, tt.want)
+				t.Errorf("IsExcluded(%q) = %v, want %v", tt.path, got, tt.want)
 			}
 		})
 	}
@@ -81,8 +81,17 @@ func TestDefaultSpanNameFormatter(t *testing.T) {
 }
 
 func TestDefaultTracerConfig(t *testing.T) {
-	if DefaultTracerConfig.ExemptPaths != nil {
-		t.Error("DefaultTracerConfig.ExemptPaths should be nil")
+	if DefaultTracerConfig.ExcludedPaths == nil {
+		t.Error("DefaultTracerConfig.ExcludedPaths should not be nil")
+	}
+	if len(DefaultTracerConfig.ExcludedPaths) != 0 {
+		t.Errorf("DefaultTracerConfig.ExcludedPaths should be empty, got %d", len(DefaultTracerConfig.ExcludedPaths))
+	}
+	if DefaultTracerConfig.IncludedPaths == nil {
+		t.Error("DefaultTracerConfig.IncludedPaths should not be nil")
+	}
+	if len(DefaultTracerConfig.IncludedPaths) != 0 {
+		t.Errorf("DefaultTracerConfig.IncludedPaths should be empty, got %d", len(DefaultTracerConfig.IncludedPaths))
 	}
 	if DefaultTracerConfig.SpanNameFormatter != nil {
 		t.Error("DefaultTracerConfig.SpanNameFormatter should be nil")

--- a/examples/core/metrics/main.go
+++ b/examples/core/metrics/main.go
@@ -23,9 +23,9 @@ func main() {
 	// for security. This prevents exposing metrics to the public internet.
 	app := zh.New(config.Config{
 		Metrics: config.MetricsConfig{
-			Enabled:      config.Bool(true),
-			Endpoint:     "/metrics",
-			ExcludePaths: []string{"/health", "/metrics"},
+			Enabled:       config.Bool(true),
+			Endpoint:      "/metrics",
+			ExcludedPaths: []string{"/health", "/metrics"},
 			PathLabelFunc: func(p string) string {
 				// Normalize dynamic paths - replace numeric IDs with placeholders
 				// e.g., /users/123 -> /users/{id}

--- a/examples/middleware/cache/main.go
+++ b/examples/middleware/cache/main.go
@@ -54,7 +54,7 @@ func main() {
 	)
 
 	// Live/health endpoint - never cached
-	// Demonstrates exempt paths (or you could just not apply the middleware)
+	// Demonstrates excluded paths (or you could just not apply the middleware)
 	app.GET("/api/live", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 		return zh.R.JSON(w, http.StatusOK, map[string]string{
 			"status":    "ok",
@@ -99,7 +99,6 @@ func main() {
 	)
 
 	// Stats endpoint - demonstrates custom store usage (in-memory here)
-	// This also shows how to exempt specific paths from caching
 	app.GET("/api/stats", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 		return zh.R.JSON(w, http.StatusOK, map[string]any{
 			"requests":    12345,

--- a/examples/middleware/cache_redis/main.go
+++ b/examples/middleware/cache_redis/main.go
@@ -153,7 +153,7 @@ func main() {
 	)
 
 	// Live/health endpoint - never cached
-	// Demonstrates exempt paths (or you could just not apply the middleware)
+	// Demonstrates excluded paths (or you could just not apply the middleware)
 	app.GET("/api/live", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 		return zh.R.JSON(w, http.StatusOK, map[string]string{
 			"status":    "ok",

--- a/examples/middleware/csrf/main.go
+++ b/examples/middleware/csrf/main.go
@@ -108,7 +108,7 @@ curl -X POST http://localhost:8080/submit \
     CookieMaxAge:   86400,
     CookieSecure:   config.Bool(true),
     CookieSameSite: http.SameSiteStrictMode,
-    ExemptPaths:    []string{"/api/webhook"},
+    ExcludedPaths:    []string{"/api/webhook"},
 }))</pre>
 
     <h2>Token Lookup Methods</h2>

--- a/examples/middleware/host_validation/README.md
+++ b/examples/middleware/host_validation/README.md
@@ -7,7 +7,7 @@ This example demonstrates zerohttp's host validation middleware for protecting a
 - Exact host matching
 - Subdomain allowlisting
 - Strict port validation
-- Exempt paths
+- Excluded paths
 - Custom error responses
 
 ## Running the Example
@@ -26,7 +26,7 @@ The server starts on `http://localhost:8080`.
 | `GET /api/subdomains`  | `*.example.com`      | Subdomains allowed     |
 | `GET /api/multi`       | Multiple hosts       | Multiple allowed hosts |
 | `GET /api/strict-port` | `localhost:8080`     | Requires port in Host  |
-| `GET /health`          | Any (exempt)         | Bypasses validation    |
+| `GET /health`          | Any (excluded)       | Bypasses validation    |
 | `GET /api/custom`      | `secure.example.com` | Custom error response  |
 
 ## Test Commands
@@ -49,7 +49,7 @@ curl -H "Host: localhost:8080" http://localhost:8080/api/strict-port
 curl -H "Host: localhost" http://localhost:8080/api/strict-port  # rejected
 ```
 
-### Exempt path (no validation)
+### Excluded path (no validation)
 ```bash
 curl -H "Host: anything.com" http://localhost:8080/health
 ```

--- a/examples/middleware/host_validation/main.go
+++ b/examples/middleware/host_validation/main.go
@@ -56,7 +56,7 @@ func main() {
 		Port:         8080, // Server port - Host must include :8080
 	}))
 
-	// Example 5: Exempt paths (health check bypasses validation)
+	// Example 5: Excluded paths (health check bypasses validation)
 	app.GET("/health", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 		return zh.R.JSON(w, http.StatusOK, zh.M{
 			"status": "healthy",
@@ -64,8 +64,8 @@ func main() {
 			"note":   "This endpoint bypasses host validation",
 		})
 	}), middleware.HostValidation(config.HostValidationConfig{
-		AllowedHosts: []string{"api.example.com"},
-		ExemptPaths:  []string{"/health"},
+		AllowedHosts:  []string{"api.example.com"},
+		ExcludedPaths: []string{"/health"},
 	}))
 
 	// Example 6: Custom error response

--- a/examples/middleware/idempotency/README.md
+++ b/examples/middleware/idempotency/README.md
@@ -6,7 +6,7 @@ This example demonstrates zerohttp's idempotency middleware for safe request ret
 
 - In-memory response caching by idempotency key
 - Required vs optional idempotency keys
-- Exempt paths for webhooks
+- Excluded paths for webhooks
 - Body size limits for caching
 - Idempotency-Replay header for cached responses
 
@@ -24,7 +24,7 @@ The server starts on `http://localhost:8080`.
 |-------------------------|-------------|----------------------------------|
 | `POST /api/payments`    | Optional    | Basic idempotency with caching   |
 | `POST /api/transfers`   | Required    | Fails without idempotency key    |
-| `POST /api/webhooks`    | Exempt      | Skips idempotency check          |
+| `POST /api/webhooks`    | Excluded    | Skips idempotency check          |
 | `POST /api/bulk-import` | Optional    | Max body size limit (1KB)        |
 | `GET /api/status`       | N/A         | GET requests bypass idempotency  |
 
@@ -70,7 +70,7 @@ curl -i -X POST http://localhost:8080/api/transfers \
   -d '{"amount":500}'
 ```
 
-### Exempt path (webhook - no idempotency check)
+### Excluded path (webhook - no idempotency check)
 ```bash
 curl -i -X POST http://localhost:8080/api/webhooks \
   -H 'Content-Type: application/json' \

--- a/examples/middleware/idempotency/main.go
+++ b/examples/middleware/idempotency/main.go
@@ -55,7 +55,7 @@ func main() {
 		}),
 	)
 
-	// Webhook endpoint - exempt from idempotency
+	// Webhook endpoint - excluded from idempotency
 	// External systems may retry webhooks with same payload
 	app.POST("/api/webhooks", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 		return zh.R.JSON(w, http.StatusOK, map[string]string{
@@ -64,9 +64,9 @@ func main() {
 		})
 	}),
 		middleware.Idempotency(config.IdempotencyConfig{
-			TTL:         1 * time.Hour,
-			MaxBodySize: 1024 * 1024,
-			ExemptPaths: []string{"/api/webhooks"}, // Skip idempotency for webhooks
+			TTL:           1 * time.Hour,
+			MaxBodySize:   1024 * 1024,
+			ExcludedPaths: []string{"/api/webhooks"}, // Skip idempotency for webhooks
 		}),
 	)
 

--- a/examples/middleware/jwt_auth/README.md
+++ b/examples/middleware/jwt_auth/README.md
@@ -7,7 +7,7 @@ This example demonstrates zerohttp's JWT authentication middleware using HS256.
 - HS256 JWT token signing
 - Access token generation with configurable TTL
 - Required claims validation
-- Exempt paths for public endpoints
+- Exclude paths for public endpoints
 - Scope-based access control
 
 ## Running the Example

--- a/examples/middleware/jwt_auth/main.go
+++ b/examples/middleware/jwt_auth/main.go
@@ -24,7 +24,7 @@ func main() {
 	jwtCfg := config.JWTAuthConfig{
 		TokenStore:     middleware.NewHS256TokenStore(jwtSecret, hp),
 		RequiredClaims: []string{"sub"},
-		ExemptPaths:    []string{"/login", "/register"},
+		ExcludedPaths:  []string{"/login", "/register"},
 		// Long expiry - 30 days (or use 0 for no expiry)
 		AccessTokenTTL: 30 * 24 * time.Hour,
 	}

--- a/examples/middleware/jwt_auth_golang_jwt/main.go
+++ b/examples/middleware/jwt_auth_golang_jwt/main.go
@@ -126,7 +126,7 @@ func main() {
 	jwtCfg := config.JWTAuthConfig{
 		TokenStore:      tokenStore,
 		RequiredClaims:  []string{"sub"},
-		ExemptPaths:     []string{"/login"},
+		ExcludedPaths:   []string{"/login"},
 		AccessTokenTTL:  15 * time.Minute,
 		RefreshTokenTTL: 7 * 24 * time.Hour,
 	}

--- a/examples/middleware/jwt_auth_lestrrat_jwx/main.go
+++ b/examples/middleware/jwt_auth_lestrrat_jwx/main.go
@@ -237,7 +237,7 @@ func main() {
 	jwtCfg := config.JWTAuthConfig{
 		TokenStore:      tokenStore,
 		RequiredClaims:  []string{"sub"},
-		ExemptPaths:     []string{"/login"},
+		ExcludedPaths:   []string{"/login"},
 		AccessTokenTTL:  15 * time.Minute,
 		RefreshTokenTTL: 7 * 24 * time.Hour,
 	}

--- a/examples/middleware/jwt_auth_refresh/main.go
+++ b/examples/middleware/jwt_auth_refresh/main.go
@@ -98,7 +98,7 @@ func main() {
 	jwtCfg := config.JWTAuthConfig{
 		TokenStore:      tokenStore,
 		RequiredClaims:  []string{"sub"},
-		ExemptPaths:     []string{"/login", "/register"},
+		ExcludedPaths:   []string{"/login", "/register"},
 		AccessTokenTTL:  15 * time.Minute,
 		RefreshTokenTTL: 7 * 24 * time.Hour,
 	}

--- a/examples/middleware/rate_limit/README.md
+++ b/examples/middleware/rate_limit/README.md
@@ -7,7 +7,7 @@ This example demonstrates zerohttp's rate limiting middleware with various confi
 - Token bucket and sliding window algorithms
 - Per-client rate limiting with custom key extractors
 - Rate limit headers (X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset)
-- Path exemptions for health checks
+- Path exclusions for health checks
 - Configurable in-memory store
 
 ## Running the Example
@@ -20,13 +20,13 @@ The server starts on `http://localhost:8080`.
 
 ## Endpoints
 
-| Endpoint               | Rate Limit          | Description                     |
-|------------------------|---------------------|---------------------------------|
-| `GET /api/default`     | 100 req/min         | Default token bucket limiter    |
-| `GET /api/strict`      | 10 req/second       | Strict sliding window limiter   |
-| `GET /api/user`        | 5 req/min per user  | Per-user rate limiting          |
-| `GET /api/high-volume` | 1000 req/min        | High-volume endpoint            |
-| `GET /health`          | Exempt              | Health check (no rate limit)    |
+| Endpoint               | Rate Limit         | Description                     |
+|------------------------|--------------------|---------------------------------|
+| `GET /api/default`     | 100 req/min        | Default token bucket limiter    |
+| `GET /api/strict`      | 10 req/second      | Strict sliding window limiter   |
+| `GET /api/user`        | 5 req/min per user | Per-user rate limiting          |
+| `GET /api/high-volume` | 1000 req/min       | High-volume endpoint            |
+| `GET /health`          | Excluded           | Health check (no rate limit)    |
 
 ## Test Commands
 
@@ -64,7 +64,7 @@ X-RateLimit-Remaining: 95
 X-RateLimit-Reset: 1704067200
 ```
 
-### Health check (exempt from rate limiting)
+### Health check (excluded from rate limiting)
 ```bash
 curl -i http://localhost:8080/health
 ```

--- a/examples/middleware/rate_limit/main.go
+++ b/examples/middleware/rate_limit/main.go
@@ -55,13 +55,13 @@ func main() {
 		IncludeHeaders: true,
 	}))
 
-	// Example 5: Exempt health check from rate limiting
+	// Example 5: Exclude health check from rate limiting
 	app.GET("/health", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 		return zh.R.JSON(w, http.StatusOK, zh.M{"status": "healthy"})
 	}), middleware.RateLimit(config.RateLimitConfig{
 		Rate:           10,
 		Window:         time.Second,
-		ExemptPaths:    []string{"/health", "/metrics"},
+		ExcludedPaths:  []string{"/health", "/metrics"},
 		IncludeHeaders: true,
 	}))
 

--- a/examples/middleware/request_body_size/README.md
+++ b/examples/middleware/request_body_size/README.md
@@ -66,13 +66,13 @@ app := zh.New(config.Config{
 })
 ```
 
-### Exempting Paths
+### Excluding Paths
 
 ```go
 app := zh.New(config.Config{
     RequestBodySize: config.RequestBodySizeConfig{
         MaxBytes:    1 * 1024 * 1024, // 1MB
-        ExemptPaths: []string{"/api/webhook", "/health"},
+        ExcludedPaths: []string{"/api/webhook", "/health"},
     },
 })
 ```

--- a/metrics/doc.go
+++ b/metrics/doc.go
@@ -45,7 +45,7 @@
 //	    Metrics: config.MetricsConfig{
 //	        Enabled:      true,
 //	        Endpoint:     "/metrics",
-//	        ExcludePaths: []string{"/health", "/readyz"},
+//	        ExcludedPaths: []string{"/health", "/readyz"},
 //	        CustomLabels: func(r *http.Request) map[string]string {
 //	            return map[string]string{
 //	                "tenant": r.Header.Get("X-Tenant-ID"),

--- a/metrics/middleware.go
+++ b/metrics/middleware.go
@@ -59,7 +59,7 @@ type Middleware struct {
 
 	DurationBuckets []float64
 	SizeBuckets     []float64
-	ExcludePaths    map[string]struct{}
+	ExcludedPaths   map[string]struct{}
 	PathLabelFunc   func(string) string
 	CustomLabels    func(r *http.Request) map[string]string
 	customLabelKeys []string
@@ -82,7 +82,7 @@ func NewMiddleware(reg Registry, cfg ...config.MetricsConfig) func(http.Handler)
 	}
 
 	excludePaths := make(map[string]struct{})
-	for _, p := range c.ExcludePaths {
+	for _, p := range c.ExcludedPaths {
 		excludePaths[p] = struct{}{}
 	}
 
@@ -90,7 +90,7 @@ func NewMiddleware(reg Registry, cfg ...config.MetricsConfig) func(http.Handler)
 		reg:             reg,
 		DurationBuckets: c.DurationBuckets,
 		SizeBuckets:     c.SizeBuckets,
-		ExcludePaths:    excludePaths,
+		ExcludedPaths:   excludePaths,
 		PathLabelFunc:   c.PathLabelFunc,
 		CustomLabels:    c.CustomLabels,
 	}
@@ -107,7 +107,7 @@ func NewMiddleware(reg Registry, cfg ...config.MetricsConfig) func(http.Handler)
 			// Add registry to context so other middleware can access it
 			r = r.WithContext(WithRegistry(r.Context(), reg))
 
-			if _, excluded := mm.ExcludePaths[r.URL.Path]; excluded {
+			if _, excluded := mm.ExcludedPaths[r.URL.Path]; excluded {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/metrics/middleware_test.go
+++ b/metrics/middleware_test.go
@@ -132,7 +132,7 @@ func TestMiddleware_BasicRequest(t *testing.T) {
 func TestMiddleware_ExcludedPath(t *testing.T) {
 	reg := NewRegistry()
 	cfg := config.MetricsConfig{
-		ExcludePaths:  []string{"/health", "/metrics"},
+		ExcludedPaths: []string{"/health", "/metrics"},
 		PathLabelFunc: func(p string) string { return p },
 	}
 

--- a/middleware/basic_auth.go
+++ b/middleware/basic_auth.go
@@ -18,15 +18,15 @@ func BasicAuth(cfg ...config.BasicAuthConfig) func(http.Handler) http.Handler {
 		zconfig.Merge(&c, cfg[0])
 	}
 
+	validatePathConfig(c.ExcludedPaths, c.IncludedPaths, "BasicAuth")
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			reg := metrics.SafeRegistry(metrics.GetRegistry(r.Context()))
 
-			for _, exemptPath := range c.ExemptPaths {
-				if pathMatches(r.URL.Path, exemptPath) {
-					next.ServeHTTP(w, r)
-					return
-				}
+			if !shouldProcessMiddleware(r.URL.Path, c.IncludedPaths, c.ExcludedPaths) {
+				next.ServeHTTP(w, r)
+				return
 			}
 
 			user, pass, ok := r.BasicAuth()

--- a/middleware/basic_auth_test.go
+++ b/middleware/basic_auth_test.go
@@ -103,10 +103,10 @@ func TestBasicAuth(t *testing.T) {
 			expectedStatus: http.StatusUnauthorized,
 		},
 		{
-			name: "exempt path allows access",
+			name: "excluded path allows access",
 			middleware: BasicAuth(config.BasicAuthConfig{
-				Credentials: map[string]string{"admin": "secret"},
-				ExemptPaths: []string{"/health"},
+				Credentials:   map[string]string{"admin": "secret"},
+				ExcludedPaths: []string{"/health"},
 			}),
 			path:           "/health",
 			authHeader:     "",
@@ -114,10 +114,10 @@ func TestBasicAuth(t *testing.T) {
 			expectedStatus: http.StatusOK,
 		},
 		{
-			name: "non-exempt path requires auth",
+			name: "non-excluded path requires auth",
 			middleware: BasicAuth(config.BasicAuthConfig{
-				Credentials: map[string]string{"admin": "secret"},
-				ExemptPaths: []string{"/health"},
+				Credentials:   map[string]string{"admin": "secret"},
+				ExcludedPaths: []string{"/health"},
 			}),
 			path:           "/admin",
 			authHeader:     "",
@@ -204,15 +204,15 @@ func TestBasicAuthMalformedHeaders(t *testing.T) {
 	}
 }
 
-func TestBasicAuthExemptPaths(t *testing.T) {
+func TestBasicAuthExcludedPaths(t *testing.T) {
 	middleware := BasicAuth(config.BasicAuthConfig{
-		Credentials: map[string]string{"admin": "secret"},
-		ExemptPaths: []string{"/health", "/metrics", "/api/public/"},
+		Credentials:   map[string]string{"admin": "secret"},
+		ExcludedPaths: []string{"/health", "/metrics", "/api/public/"},
 	})
 
 	pathTests := []struct {
-		path   string
-		exempt bool
+		path     string
+		excluded bool
 	}{
 		{"/health", true},
 		{"/metrics", true},
@@ -226,12 +226,80 @@ func TestBasicAuthExemptPaths(t *testing.T) {
 		t.Run(tt.path, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
 			expectedStatus := http.StatusUnauthorized
-			if tt.exempt {
+			if tt.excluded {
 				expectedStatus = http.StatusOK
 			}
-			testMiddleware(t, middleware, req, tt.exempt, expectedStatus)
+			testMiddleware(t, middleware, req, tt.excluded, expectedStatus)
 		})
 	}
+}
+
+func TestBasicAuthIncludedPaths(t *testing.T) {
+	middleware := BasicAuth(config.BasicAuthConfig{
+		Credentials:   map[string]string{"admin": "secret"},
+		IncludedPaths: []string{"/admin", "/api/private/"},
+	})
+
+	pathTests := []struct {
+		path       string
+		shouldAuth bool
+	}{
+		{"/admin", true},
+		{"/api/private/", true},
+		{"/api/private/data", true},
+		{"/health", false},
+		{"/metrics", false},
+		{"/public", false},
+	}
+
+	for _, tt := range pathTests {
+		t.Run(tt.path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			expectedStatus := http.StatusOK
+			if tt.shouldAuth {
+				expectedStatus = http.StatusUnauthorized
+			}
+			testMiddleware(t, middleware, req, !tt.shouldAuth, expectedStatus)
+		})
+	}
+}
+
+func TestBasicAuthIncludedPathsWithAuth(t *testing.T) {
+	middleware := BasicAuth(config.BasicAuthConfig{
+		Credentials:   map[string]string{"admin": "secret"},
+		IncludedPaths: []string{"/admin"},
+	})
+
+	t.Run("allowed path with valid auth", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/admin", nil)
+		req.Header.Set(httpx.HeaderAuthorization, createAuthHeader("admin", "secret"))
+		testMiddleware(t, middleware, req, true, http.StatusOK)
+	})
+
+	t.Run("allowed path with invalid auth", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/admin", nil)
+		req.Header.Set(httpx.HeaderAuthorization, createAuthHeader("admin", "wrong"))
+		testMiddleware(t, middleware, req, false, http.StatusUnauthorized)
+	})
+
+	t.Run("non-allowed path without auth", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/public", nil)
+		testMiddleware(t, middleware, req, true, http.StatusOK)
+	})
+}
+
+func TestBasicAuthBothExcludedAndIncludedPathsPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when both ExcludedPaths and IncludedPaths are set")
+		}
+	}()
+
+	_ = BasicAuth(config.BasicAuthConfig{
+		Credentials:   map[string]string{"admin": "secret"},
+		ExcludedPaths: []string{"/health"},
+		IncludedPaths: []string{"/admin"},
+	})
 }
 
 func TestBasicAuthNoAuthConfigured(t *testing.T) {
@@ -254,10 +322,10 @@ func TestBasicAuthNoAuthConfigured(t *testing.T) {
 	zhtest.AssertWith(t, w).Status(http.StatusUnauthorized)
 }
 
-func TestBasicAuthNilExemptPathsFallback(t *testing.T) {
+func TestBasicAuthNilExcludedPathsFallback(t *testing.T) {
 	middleware := BasicAuth(config.BasicAuthConfig{
-		Credentials: map[string]string{"admin": "secret"},
-		ExemptPaths: nil,
+		Credentials:   map[string]string{"admin": "secret"},
+		ExcludedPaths: nil,
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)

--- a/middleware/cache.go
+++ b/middleware/cache.go
@@ -26,6 +26,8 @@ func Cache(cfg ...config.CacheConfig) func(http.Handler) http.Handler {
 		zconfig.Merge(&c, cfg[0])
 	}
 
+	validatePathConfig(c.ExcludedPaths, c.IncludedPaths, "Cache")
+
 	statusCodeMap := make(map[int]bool)
 	for _, code := range c.StatusCodes {
 		statusCodeMap[code] = true
@@ -50,11 +52,9 @@ func Cache(cfg ...config.CacheConfig) func(http.Handler) http.Handler {
 				return
 			}
 
-			for _, exemptPath := range c.ExemptPaths {
-				if pathMatches(r.URL.Path, exemptPath) {
-					next.ServeHTTP(w, r)
-					return
-				}
+			if !shouldProcessMiddleware(r.URL.Path, c.IncludedPaths, c.ExcludedPaths) {
+				next.ServeHTTP(w, r)
+				return
 			}
 
 			// Note: Per RFC 9111, no-cache means revalidate, not bypass. We treat it as

--- a/middleware/cache_test.go
+++ b/middleware/cache_test.go
@@ -109,7 +109,7 @@ func TestCache_Basic(t *testing.T) {
 		}
 	})
 
-	t.Run("respects exempt paths", func(t *testing.T) {
+	t.Run("respects excluded paths", func(t *testing.T) {
 		callCount := 0
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			callCount++
@@ -117,8 +117,8 @@ func TestCache_Basic(t *testing.T) {
 		})
 
 		cacheMiddleware := Cache(config.CacheConfig{
-			DefaultTTL:  time.Minute,
-			ExemptPaths: []string{"/api/live*"},
+			DefaultTTL:    time.Minute,
+			ExcludedPaths: []string{"/api/live*"},
 		})
 
 		req1 := httptest.NewRequest(http.MethodGet, "/api/live", nil)
@@ -130,7 +130,7 @@ func TestCache_Basic(t *testing.T) {
 		cacheMiddleware(handler).ServeHTTP(w2, req2)
 
 		if callCount != 2 {
-			t.Errorf("Expected 2 handler calls for exempt path, got %d", callCount)
+			t.Errorf("Expected 2 handler calls for excluded path, got %d", callCount)
 		}
 	})
 }
@@ -814,5 +814,89 @@ func TestCache_BodyOverflow(t *testing.T) {
 		cacheMiddleware(handler).ServeHTTP(w, req)
 
 		zhtest.AssertWith(t, w).Status(http.StatusPartialContent)
+	})
+}
+
+func TestCache_IncludedPaths(t *testing.T) {
+	t.Run("only caches included paths", func(t *testing.T) {
+		callCount := 0
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("response"))
+		})
+
+		cacheMiddleware := Cache(config.CacheConfig{
+			DefaultTTL:    time.Minute,
+			IncludedPaths: []string{"/api/", "/cache/*"},
+		})
+
+		// First request to allowed path - should hit handler
+		req1 := httptest.NewRequest(http.MethodGet, "/api/data", nil)
+		w1 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w1, req1)
+
+		// Second request to same allowed path - should be cached
+		req2 := httptest.NewRequest(http.MethodGet, "/api/data", nil)
+		w2 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w2, req2)
+
+		if callCount != 1 {
+			t.Errorf("Expected 1 handler call for cached path, got %d", callCount)
+		}
+
+		// Request to non-allowed path - should not be cached
+		callCount = 0
+		req3 := httptest.NewRequest(http.MethodGet, "/other", nil)
+		w3 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w3, req3)
+
+		req4 := httptest.NewRequest(http.MethodGet, "/other", nil)
+		w4 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w4, req4)
+
+		if callCount != 2 {
+			t.Errorf("Expected 2 handler calls for non-allowed path, got %d", callCount)
+		}
+	})
+
+	t.Run("wildcard included paths", func(t *testing.T) {
+		callCount := 0
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.WriteHeader(http.StatusOK)
+		})
+
+		cacheMiddleware := Cache(config.CacheConfig{
+			DefaultTTL:    time.Minute,
+			IncludedPaths: []string{"/cache/*"},
+		})
+
+		// Request to wildcard path
+		req1 := httptest.NewRequest(http.MethodGet, "/cache/anything", nil)
+		w1 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w1, req1)
+
+		req2 := httptest.NewRequest(http.MethodGet, "/cache/anything", nil)
+		w2 := httptest.NewRecorder()
+		cacheMiddleware(handler).ServeHTTP(w2, req2)
+
+		if callCount != 1 {
+			t.Errorf("Expected 1 handler call for wildcard path, got %d", callCount)
+		}
+	})
+}
+
+func TestCache_BothExcludedAndIncludedPathsPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when both ExcludedPaths and IncludedPaths are set")
+		}
+	}()
+
+	_ = Cache(config.CacheConfig{
+		DefaultTTL:    time.Minute,
+		ExcludedPaths: []string{"/health"},
+		IncludedPaths: []string{"/api"},
 	})
 }

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -31,7 +31,8 @@ type Compressor struct {
 	encodingPrecedence []string
 	level              int                                  // The compression level.
 	algorithms         map[config.CompressionAlgorithm]bool // Allowed algorithms
-	exemptPaths        []string                             // Paths to skip compression
+	excludedPaths      []string                             // Paths to skip compression
+	includedPaths      []string                             // Paths to allow compression (if set, only these paths)
 }
 
 // NewCompressor creates a new Compressor that will handle encoding responses.
@@ -61,7 +62,8 @@ func NewCompressor(level int, types ...string) *Compressor {
 		allowedTypes:     allowedTypes,
 		allowedWildcards: allowedWildcards,
 		algorithms:       make(map[config.CompressionAlgorithm]bool),
-		exemptPaths:      []string{},
+		excludedPaths:    []string{},
+		includedPaths:    []string{},
 	}
 
 	// Set default algorithms
@@ -108,21 +110,16 @@ func (c *Compressor) SetEncoder(encoding string, fn EncoderFunc) {
 	c.encodingPrecedence = append([]string{encoding}, c.encodingPrecedence...)
 }
 
-// isExemptPath checks if a path should be exempted from compression
-func (c *Compressor) isExemptPath(path string) bool {
-	for _, exemptPath := range c.exemptPaths {
-		if pathMatches(path, exemptPath) {
-			return true
-		}
-	}
-	return false
+// isExcludedPath checks if a path should be excluded from compression
+func (c *Compressor) isExcludedPath(path string) bool {
+	return !shouldProcessMiddleware(path, c.includedPaths, c.excludedPaths)
 }
 
 // Handler returns a new middleware that will compress the response.
 func (c *Compressor) Handler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Check exempt paths first
-		if c.isExemptPath(r.URL.Path) {
+		// Check excluded paths first
+		if c.isExcludedPath(r.URL.Path) {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -353,8 +350,11 @@ func Compress(cfg ...config.CompressConfig) func(http.Handler) http.Handler {
 		zconfig.Merge(&c, cfg[0])
 	}
 
+	validatePathConfig(c.ExcludedPaths, c.IncludedPaths, "Compress")
+
 	compressor := NewCompressor(c.Level, c.Types...)
-	compressor.exemptPaths = c.ExemptPaths
+	compressor.excludedPaths = c.ExcludedPaths
+	compressor.includedPaths = c.IncludedPaths
 
 	// Set allowed algorithms
 	compressor.algorithms = make(map[config.CompressionAlgorithm]bool)

--- a/middleware/compress_bench_test.go
+++ b/middleware/compress_bench_test.go
@@ -307,26 +307,26 @@ func BenchmarkCompress_NoCompressionFallback(b *testing.B) {
 	})
 }
 
-// BenchmarkCompress_ExemptPaths measures path exemption checking overhead
-func BenchmarkCompress_ExemptPaths(b *testing.B) {
+// BenchmarkCompress_ExcludedPaths measures path exclusion checking overhead
+func BenchmarkCompress_ExcludedPaths(b *testing.B) {
 	content := []byte(strings.Repeat("Test content. ", 20))
 
 	testCases := []struct {
-		name        string
-		exemptPaths []string
-		path        string
+		name          string
+		excludedPaths []string
+		path          string
 	}{
-		{"NoExemptions", nil, "/test"},
-		{"OneExemption", []string{"/health"}, "/test"},
-		{"ManyExemptions", []string{"/health", "/metrics", "/api/internal/", "/debug/", "/admin/"}, "/test"},
-		{"ExemptPathMatch", []string{"/health", "/metrics", "/api/internal/"}, "/api/internal/data"},
+		{"NoExcluded", nil, "/test"},
+		{"OneExcluded", []string{"/health"}, "/test"},
+		{"ManyExcluded", []string{"/health", "/metrics", "/api/internal/", "/debug/", "/admin/"}, "/test"},
+		{"ExcludedPathMatch", []string{"/health", "/metrics", "/api/internal/"}, "/api/internal/data"},
 	}
 
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
 			mw := Compress(config.CompressConfig{
-				Types:       []string{"text/plain"},
-				ExemptPaths: tc.exemptPaths,
+				Types:         []string{"text/plain"},
+				ExcludedPaths: tc.excludedPaths,
 			})
 
 			handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -111,9 +111,9 @@ func TestCompress(t *testing.T) {
 	}
 }
 
-func TestCompressExemptPaths(t *testing.T) {
+func TestCompressExcludedPaths(t *testing.T) {
 	middleware := Compress(config.CompressConfig{
-		ExemptPaths: []string{"/health", "/metrics", "/api/internal/"},
+		ExcludedPaths: []string{"/health", "/metrics", "/api/internal/"},
 	})
 
 	tests := []struct {
@@ -213,10 +213,10 @@ func TestCompressAlgorithms(t *testing.T) {
 func TestCompressAllOptions(t *testing.T) {
 	// Test all options working together
 	middleware := Compress(config.CompressConfig{
-		Level:       9,
-		Types:       []string{"text/html", "application/json"},
-		Algorithms:  []config.CompressionAlgorithm{config.Gzip},
-		ExemptPaths: []string{"/health"},
+		Level:         9,
+		Types:         []string{"text/html", "application/json"},
+		Algorithms:    []config.CompressionAlgorithm{config.Gzip},
+		ExcludedPaths: []string{"/health"},
 	})
 
 	tests := []struct {
@@ -236,7 +236,7 @@ func TestCompressAllOptions(t *testing.T) {
 			expectedEncoding: "gzip",
 		},
 		{
-			name:             "exempt path not compressed",
+			name:             "excluded path not compressed",
 			path:             "/health",
 			contentType:      "text/html",
 			content:          strings.Repeat("health check ", 10),
@@ -495,7 +495,7 @@ func TestCompressConfigDefaults(t *testing.T) {
 		{
 			name:           "no config - use all defaults",
 			config:         config.CompressConfig{},
-			description:    "Should use default level, types, algorithms, and exempt paths",
+			description:    "Should use default level, types, algorithms, and excluded paths",
 			shouldCompress: true,
 		},
 		{
@@ -523,9 +523,9 @@ func TestCompressConfigDefaults(t *testing.T) {
 			shouldCompress: true,
 		},
 		{
-			name:           "nil exempt paths - use defaults",
-			config:         config.CompressConfig{ExemptPaths: nil},
-			description:    "Nil exempt paths should use default (empty list)",
+			name:           "nil excluded paths - use defaults",
+			config:         config.CompressConfig{ExcludedPaths: nil},
+			description:    "Nil excluded paths should use default (empty list)",
 			shouldCompress: true,
 		},
 	}
@@ -569,9 +569,9 @@ func TestCompressConfigExplicitEmptyValues(t *testing.T) {
 			expectCompression: false,
 		},
 		{
-			name:              "empty exempt paths - allow compression",
-			config:            config.CompressConfig{ExemptPaths: []string{}},
-			description:       "Empty exempt paths should allow compression on all paths",
+			name:              "empty excluded paths - allow compression",
+			config:            config.CompressConfig{ExcludedPaths: []string{}},
+			description:       "Empty excluded paths should allow compression on all paths",
 			expectCompression: true,
 		},
 	}
@@ -604,10 +604,10 @@ func TestCompressConfigExplicitEmptyValues(t *testing.T) {
 func TestCompressConfigDefaultsVsOverrides(t *testing.T) {
 	t.Run("defaults used when config values are nil or invalid", func(t *testing.T) {
 		mw := Compress(config.CompressConfig{
-			Level:       0,   // Should fallback to default (6)
-			Types:       nil, // Should use defaults
-			Algorithms:  nil, // Should use defaults
-			ExemptPaths: nil, // Should use defaults
+			Level:         0,   // Should fallback to default (6)
+			Types:         nil, // Should use defaults
+			Algorithms:    nil, // Should use defaults
+			ExcludedPaths: nil, // Should use defaults
 		})
 
 		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -799,6 +799,59 @@ func TestCompress_WriteHeader_MultipleCalls(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Errorf("expected status 200, got %d (subsequent WriteHeader calls should be ignored)", rr.Code)
 	}
+}
+
+func TestCompress_IncludedPaths(t *testing.T) {
+	middleware := Compress(config.CompressConfig{
+		IncludedPaths: []string{"/api/", "/compress/*"},
+	})
+
+	tests := []struct {
+		path           string
+		shouldCompress bool
+	}{
+		{"/api/data", true},
+		{"/api/users", true},
+		{"/compress/anything", true},
+		{"/other", false},
+		{"/health", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set(httpx.HeaderContentType, httpx.MIMETextPlain)
+				_, err := w.Write([]byte(strings.Repeat("test content ", 10)))
+				if err != nil {
+					t.Fatalf("failed to write response: %v", err)
+				}
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			req.Header.Set(httpx.HeaderAcceptEncoding, httpx.ContentEncodingGzip)
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			hasCompression := rr.Header().Get(httpx.HeaderContentEncoding) != ""
+			if hasCompression != tt.shouldCompress {
+				t.Errorf("path %s: expected compression=%v, got compression=%v", tt.path, tt.shouldCompress, hasCompression)
+			}
+		})
+	}
+}
+
+func TestCompress_BothExcludedAndIncludedPathsPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when both ExcludedPaths and IncludedPaths are set")
+		}
+	}()
+
+	_ = Compress(config.CompressConfig{
+		ExcludedPaths: []string{"/health"},
+		IncludedPaths: []string{"/api"},
+	})
 }
 
 // TestCompressionProvider tests the pluggable CompressionProvider interface

--- a/middleware/content_encoding.go
+++ b/middleware/content_encoding.go
@@ -17,6 +17,8 @@ func ContentEncoding(cfg ...config.ContentEncodingConfig) func(http.Handler) htt
 		zconfig.Merge(&c, cfg[0])
 	}
 
+	validatePathConfig(c.ExcludedPaths, c.IncludedPaths, "ContentEncoding")
+
 	allowedEncodings := make(map[string]struct{}, len(c.Encodings))
 	for _, encoding := range c.Encodings {
 		allowedEncodings[strings.TrimSpace(strings.ToLower(encoding))] = struct{}{}
@@ -24,12 +26,9 @@ func ContentEncoding(cfg ...config.ContentEncodingConfig) func(http.Handler) htt
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Check exempt paths
-			for _, exemptPath := range c.ExemptPaths {
-				if pathMatches(r.URL.Path, exemptPath) {
-					next.ServeHTTP(w, r)
-					return
-				}
+			if !shouldProcessMiddleware(r.URL.Path, c.IncludedPaths, c.ExcludedPaths) {
+				next.ServeHTTP(w, r)
+				return
 			}
 
 			// Skip validation for empty content body (like Chi does)

--- a/middleware/content_encoding_test.go
+++ b/middleware/content_encoding_test.go
@@ -128,7 +128,7 @@ func TestContentEncodingCustomConfig(t *testing.T) {
 	}
 }
 
-func TestContentEncodingExemptPaths(t *testing.T) {
+func TestContentEncodingExcludedPaths(t *testing.T) {
 	tests := []struct {
 		name       string
 		path       string
@@ -136,14 +136,14 @@ func TestContentEncodingExemptPaths(t *testing.T) {
 		expectNext bool
 		expectCode int
 	}{
-		{"exempt exact", "/health", "br", true, http.StatusOK},
-		{"exempt prefix", "/api/webhooks/github", "br", true, http.StatusOK},
-		{"not exempt", "/api/users", "br", false, http.StatusUnsupportedMediaType},
+		{"excluded exact", "/health", "br", true, http.StatusOK},
+		{"excluded prefix", "/api/webhooks/github", "br", true, http.StatusOK},
+		{"not excluded", "/api/users", "br", false, http.StatusUnsupportedMediaType},
 	}
 
 	middleware := ContentEncoding(config.ContentEncodingConfig{
-		Encodings:   []string{"gzip"},
-		ExemptPaths: []string{"/health", "/api/webhooks/"},
+		Encodings:     []string{"gzip"},
+		ExcludedPaths: []string{"/health", "/api/webhooks/"},
 	})
 
 	for _, tt := range tests {
@@ -207,10 +207,10 @@ func TestContentEncodingNilEncodingsFallback(t *testing.T) {
 	zhtest.AssertWith(t, rr).Status(http.StatusOK)
 }
 
-func TestContentEncodingNilExemptPathsFallback(t *testing.T) {
+func TestContentEncodingNilExcludedPathsFallback(t *testing.T) {
 	middleware := ContentEncoding(config.ContentEncodingConfig{
-		Encodings:   []string{"gzip"},
-		ExemptPaths: nil,
+		Encodings:     []string{"gzip"},
+		ExcludedPaths: nil,
 	})
 	req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader("test"))
 	req.Header.Set(httpx.HeaderContentEncoding, "br")
@@ -226,4 +226,56 @@ func TestContentEncodingNilExemptPathsFallback(t *testing.T) {
 		t.Error("handler should not be called with disallowed encoding")
 	}
 	zhtest.AssertWith(t, rr).Status(http.StatusUnsupportedMediaType)
+}
+
+func TestContentEncodingIncludedPaths(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		encoding   string
+		expectNext bool
+		expectCode int
+	}{
+		{"allowed prefix", "/api/users", "br", false, http.StatusUnsupportedMediaType},
+		{"allowed exact", "/upload", "br", false, http.StatusUnsupportedMediaType},
+		{"not allowed", "/other", "br", true, http.StatusOK},
+	}
+
+	middleware := ContentEncoding(config.ContentEncodingConfig{
+		Encodings:     []string{"gzip"},
+		IncludedPaths: []string{"/api/", "/upload"},
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tt.path, strings.NewReader("test"))
+			req.Header.Set(httpx.HeaderContentEncoding, tt.encoding)
+			rr := httptest.NewRecorder()
+			nextCalled := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+			middleware(next).ServeHTTP(rr, req)
+
+			if nextCalled != tt.expectNext {
+				t.Errorf("expected nextCalled=%v, got %v", tt.expectNext, nextCalled)
+			}
+			zhtest.AssertWith(t, rr).Status(tt.expectCode)
+		})
+	}
+}
+
+func TestContentEncodingBothExcludedAndIncludedPathsPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when both ExcludedPaths and IncludedPaths are set")
+		}
+	}()
+
+	_ = ContentEncoding(config.ContentEncodingConfig{
+		Encodings:     []string{"gzip"},
+		ExcludedPaths: []string{"/health"},
+		IncludedPaths: []string{"/api"},
+	})
 }

--- a/middleware/content_type.go
+++ b/middleware/content_type.go
@@ -18,6 +18,8 @@ func ContentType(cfg ...config.ContentTypeConfig) func(http.Handler) http.Handle
 		zconfig.Merge(&c, cfg[0])
 	}
 
+	validatePathConfig(c.ExcludedPaths, c.IncludedPaths, "ContentType")
+
 	allowedContentTypes := make(map[string]struct{}, len(c.ContentTypes))
 	for _, ctype := range c.ContentTypes {
 		allowedContentTypes[strings.TrimSpace(strings.ToLower(ctype))] = struct{}{}
@@ -25,11 +27,9 @@ func ContentType(cfg ...config.ContentTypeConfig) func(http.Handler) http.Handle
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			for _, exemptPath := range c.ExemptPaths {
-				if pathMatches(r.URL.Path, exemptPath) {
-					next.ServeHTTP(w, r)
-					return
-				}
+			if !shouldProcessMiddleware(r.URL.Path, c.IncludedPaths, c.ExcludedPaths) {
+				next.ServeHTTP(w, r)
+				return
 			}
 
 			if r.ContentLength == 0 {

--- a/middleware/content_type_test.go
+++ b/middleware/content_type_test.go
@@ -97,23 +97,23 @@ func TestContentTypeCustomConfig(t *testing.T) {
 	}
 }
 
-func TestContentTypeExemptPaths(t *testing.T) {
+func TestContentTypeExcludedPaths(t *testing.T) {
 	tests := []struct {
 		name       string
 		path       string
 		expectNext bool
 		expectCode int
 	}{
-		{"exempt exact path /health", "/health", true, http.StatusOK},
-		{"exempt exact path /api/upload", "/api/upload", true, http.StatusOK},
-		{"exempt prefix /webhooks/", "/webhooks/", true, http.StatusOK},
-		{"exempt prefix /webhooks/github", "/webhooks/github", true, http.StatusOK},
-		{"not exempt /api/users", "/api/users", false, http.StatusUnsupportedMediaType},
+		{"excluded exact path /health", "/health", true, http.StatusOK},
+		{"excluded exact path /api/upload", "/api/upload", true, http.StatusOK},
+		{"excluded prefix /webhooks/", "/webhooks/", true, http.StatusOK},
+		{"excluded prefix /webhooks/github", "/webhooks/github", true, http.StatusOK},
+		{"not excluded /api/users", "/api/users", false, http.StatusUnsupportedMediaType},
 	}
 
 	middleware := ContentType(config.ContentTypeConfig{
-		ContentTypes: []string{"application/json"},
-		ExemptPaths:  []string{"/health", "/webhooks/", "/api/upload"},
+		ContentTypes:  []string{"application/json"},
+		ExcludedPaths: []string{"/health", "/webhooks/", "/api/upload"},
 	})
 
 	for _, tt := range tests {
@@ -213,10 +213,10 @@ func TestContentTypeConfigFallbacks(t *testing.T) {
 		zhtest.AssertWith(t, rr).Status(http.StatusOK)
 	})
 
-	t.Run("nil exempt paths fallback", func(t *testing.T) {
+	t.Run("nil excluded paths fallback", func(t *testing.T) {
 		middleware := ContentType(config.ContentTypeConfig{
-			ContentTypes: []string{httpx.MIMEApplicationJSON},
-			ExemptPaths:  nil,
+			ContentTypes:  []string{httpx.MIMEApplicationJSON},
+			ExcludedPaths: nil,
 		})
 		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader("test"))
 		req.Header.Set(httpx.HeaderContentType, httpx.MIMETextPlain)
@@ -227,7 +227,60 @@ func TestContentTypeConfigFallbacks(t *testing.T) {
 		})).ServeHTTP(rr, req)
 
 		if called || rr.Code != http.StatusUnsupportedMediaType {
-			t.Error("should fallback to default exempt paths and reject text/plain")
+			t.Error("should fallback to default excluded paths and reject text/plain")
 		}
+	})
+}
+
+func TestContentTypeIncludedPaths(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		expectNext bool
+		expectCode int
+	}{
+		{"allowed exact /api", "/api", false, http.StatusUnsupportedMediaType},
+		{"allowed prefix /api/", "/api/users", false, http.StatusUnsupportedMediaType},
+		{"allowed exact /upload", "/upload", false, http.StatusUnsupportedMediaType},
+		{"not allowed /other", "/other", true, http.StatusOK},
+		{"not allowed /health", "/health", true, http.StatusOK},
+	}
+
+	middleware := ContentType(config.ContentTypeConfig{
+		ContentTypes:  []string{httpx.MIMEApplicationJSON},
+		IncludedPaths: []string{"/api/", "/api", "/upload"},
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tt.path, strings.NewReader("test data"))
+			req.Header.Set(httpx.HeaderContentType, httpx.MIMETextPlain)
+			rr := httptest.NewRecorder()
+			nextCalled := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+			middleware(next).ServeHTTP(rr, req)
+
+			if nextCalled != tt.expectNext {
+				t.Errorf("expected nextCalled=%v, got %v", tt.expectNext, nextCalled)
+			}
+			zhtest.AssertWith(t, rr).Status(tt.expectCode)
+		})
+	}
+}
+
+func TestContentTypeBothExcludedAndIncludedPathsPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when both ExcludedPaths and IncludedPaths are set")
+		}
+	}()
+
+	_ = ContentType(config.ContentTypeConfig{
+		ContentTypes:  []string{httpx.MIMEApplicationJSON},
+		ExcludedPaths: []string{"/health"},
+		IncludedPaths: []string{"/api"},
 	})
 }

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -19,6 +19,8 @@ func CORS(cfg ...config.CORSConfig) func(http.Handler) http.Handler {
 		zconfig.Merge(&c, cfg[0])
 	}
 
+	validatePathConfig(c.ExcludedPaths, c.IncludedPaths, "CORS")
+
 	allowedOriginMap := make(map[string]bool)
 	allowAllOrigins := false
 	for _, origin := range c.AllowedOrigins {
@@ -48,11 +50,9 @@ func CORS(cfg ...config.CORSConfig) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			reg := metrics.SafeRegistry(metrics.GetRegistry(r.Context()))
 
-			for _, exemptPath := range c.ExemptPaths {
-				if pathMatches(r.URL.Path, exemptPath) {
-					next.ServeHTTP(w, r)
-					return
-				}
+			if !shouldProcessMiddleware(r.URL.Path, c.IncludedPaths, c.ExcludedPaths) {
+				next.ServeHTTP(w, r)
+				return
 			}
 
 			origin := r.Header.Get(httpx.HeaderOrigin)

--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -200,7 +200,7 @@ func TestCORSOptionsPassthrough(t *testing.T) {
 	zhtest.AssertWith(t, rr).Status(http.StatusOK)
 }
 
-func TestCORSExemptPaths(t *testing.T) {
+func TestCORSExcludedPaths(t *testing.T) {
 	tests := []struct {
 		path       string
 		expectCORS bool
@@ -209,7 +209,7 @@ func TestCORSExemptPaths(t *testing.T) {
 		{"/no-cors", false},
 		{"/api/users", true},
 	}
-	mw := CORS(config.CORSConfig{ExemptPaths: []string{"/skip-cors", "/no-cors"}})
+	mw := CORS(config.CORSConfig{ExcludedPaths: []string{"/skip-cors", "/no-cors"}})
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
@@ -223,7 +223,7 @@ func TestCORSExemptPaths(t *testing.T) {
 			if tt.expectCORS && corsOrigin == "" {
 				t.Error("expected CORS headers")
 			} else if !tt.expectCORS && corsOrigin != "" {
-				t.Error("expected no CORS headers for exempt path")
+				t.Error("expected no CORS headers for excluded path")
 			}
 		})
 	}
@@ -271,8 +271,8 @@ func TestCORSNilConfig(t *testing.T) {
 	}
 }
 
-func TestCORSNilExemptPathsFallback(t *testing.T) {
-	mw := CORS(config.CORSConfig{ExemptPaths: nil})
+func TestCORSNilExcludedPathsFallback(t *testing.T) {
+	mw := CORS(config.CORSConfig{ExcludedPaths: nil})
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set(httpx.HeaderOrigin, "https://example.com")
 	rr := httptest.NewRecorder()
@@ -283,7 +283,7 @@ func TestCORSNilExemptPathsFallback(t *testing.T) {
 	})).ServeHTTP(rr, req)
 
 	if !called {
-		t.Error("should fallback to default exempt paths and process CORS")
+		t.Error("should fallback to default excluded paths and process CORS")
 	}
 	zhtest.AssertWith(t, rr).Header(httpx.HeaderAccessControlAllowOrigin, "*")
 }
@@ -547,4 +547,50 @@ func TestCORSCustomOriginFuncWithCredentials(t *testing.T) {
 	if got := rr.Header().Get("Vary"); got != "Origin" {
 		t.Errorf("expected Vary: Origin, got %s", got)
 	}
+}
+
+func TestCORSIncludedPaths(t *testing.T) {
+	tests := []struct {
+		path       string
+		expectCORS bool
+	}{
+		{"/api/users", true},
+		{"/api/data", true},
+		{"/admin", true},
+		{"/health", false},
+		{"/metrics", false},
+	}
+	mw := CORS(config.CORSConfig{
+		IncludedPaths: []string{"/api/", "/admin"},
+	})
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			req.Header.Set(httpx.HeaderOrigin, "https://example.com")
+			rr := httptest.NewRecorder()
+			mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})).ServeHTTP(rr, req)
+
+			corsOrigin := rr.Header().Get(httpx.HeaderAccessControlAllowOrigin)
+			if tt.expectCORS && corsOrigin == "" {
+				t.Error("expected CORS headers")
+			} else if !tt.expectCORS && corsOrigin != "" {
+				t.Error("expected no CORS headers for non-allowed path")
+			}
+		})
+	}
+}
+
+func TestCORSBothExcludedAndIncludedPathsPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when both ExcludedPaths and IncludedPaths are set")
+		}
+	}()
+
+	_ = CORS(config.CORSConfig{
+		ExcludedPaths: []string{"/health"},
+		IncludedPaths: []string{"/api"},
+	})
 }

--- a/middleware/csrf.go
+++ b/middleware/csrf.go
@@ -52,9 +52,9 @@ func CSRF(cfg ...config.CSRFConfig) func(http.Handler) http.Handler {
 		tokenGenerator = generateToken
 	}
 
-	exemptMethodMap := make(map[string]bool)
-	for _, method := range c.ExemptMethods {
-		exemptMethodMap[strings.ToUpper(method)] = true
+	excludedMethodMap := make(map[string]bool)
+	for _, method := range c.ExcludedMethods {
+		excludedMethodMap[strings.ToUpper(method)] = true
 	}
 
 	lookupSource, lookupName := parseTokenLookup(c.TokenLookup)
@@ -64,18 +64,18 @@ func CSRF(cfg ...config.CSRFConfig) func(http.Handler) http.Handler {
 		errorHandler = defaultCSRFErrorHandler
 	}
 
+	validatePathConfig(c.ExcludedPaths, c.IncludedPaths, "CSRF")
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			reg := metrics.SafeRegistry(metrics.GetRegistry(r.Context()))
 
-			for _, exemptPath := range c.ExemptPaths {
-				if pathMatches(r.URL.Path, exemptPath) {
-					next.ServeHTTP(w, r)
-					return
-				}
+			if !shouldProcessMiddleware(r.URL.Path, c.IncludedPaths, c.ExcludedPaths) {
+				next.ServeHTTP(w, r)
+				return
 			}
 
-			if exemptMethodMap[strings.ToUpper(r.Method)] {
+			if excludedMethodMap[strings.ToUpper(r.Method)] {
 				cookie, err := r.Cookie(c.CookieName)
 				var token string
 				if err != nil || cookie.Value == "" || !validateTokenFormat(cookie.Value) {

--- a/middleware/csrf_bench_test.go
+++ b/middleware/csrf_bench_test.go
@@ -120,10 +120,10 @@ func BenchmarkCSRF_ExtractToken(b *testing.B) {
 func BenchmarkCSRF_Middleware(b *testing.B) {
 	key := []byte("test-key-32-bytes-long-for-hmac!!")
 
-	b.Run("GET_ExemptMethod", func(b *testing.B) {
+	b.Run("GET_ExcludedMethod", func(b *testing.B) {
 		handler := CSRF(config.CSRFConfig{
-			HMACKey:       key,
-			ExemptMethods: []string{http.MethodGet},
+			HMACKey:         key,
+			ExcludedMethods: []string{http.MethodGet},
 		})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -140,8 +140,8 @@ func BenchmarkCSRF_Middleware(b *testing.B) {
 
 	b.Run("GET_NewToken", func(b *testing.B) {
 		handler := CSRF(config.CSRFConfig{
-			HMACKey:       key,
-			ExemptMethods: []string{}, // GET is not exempt, will generate token
+			HMACKey:         key,
+			ExcludedMethods: []string{}, // GET is not excluded, will generate token
 		})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -282,19 +282,19 @@ func BenchmarkCSRF_SetCookie(b *testing.B) {
 	}
 }
 
-// BenchmarkCSRF_ExemptPaths measures exempt path checking
-func BenchmarkCSRF_ExemptPaths(b *testing.B) {
+// BenchmarkCSRF_ExcludedPaths measures excluded path checking
+func BenchmarkCSRF_ExcludedPaths(b *testing.B) {
 	key := []byte("test-key-32-bytes-long-for-hmac!!")
-	exemptPaths := []string{"/api/*", "/health", "/static/*"}
+	excludedPaths := []string{"/api/*", "/health", "/static/*"}
 
 	handler := CSRF(config.CSRFConfig{
-		HMACKey:     key,
-		ExemptPaths: exemptPaths,
+		HMACKey:       key,
+		ExcludedPaths: excludedPaths,
 	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	b.Run("ExemptPath", func(b *testing.B) {
+	b.Run("ExcludedPath", func(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 
@@ -305,7 +305,7 @@ func BenchmarkCSRF_ExemptPaths(b *testing.B) {
 		}
 	})
 
-	b.Run("NonExemptPath", func(b *testing.B) {
+	b.Run("NonExcludedPath", func(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 
@@ -347,8 +347,8 @@ func BenchmarkCSRF_Concurrent(b *testing.B) {
 
 	b.Run("Middleware_GET", func(b *testing.B) {
 		handler := CSRF(config.CSRFConfig{
-			HMACKey:       key,
-			ExemptMethods: []string{http.MethodGet},
+			HMACKey:         key,
+			ExcludedMethods: []string{http.MethodGet},
 		})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))

--- a/middleware/csrf_test.go
+++ b/middleware/csrf_test.go
@@ -86,13 +86,13 @@ func TestCSRF_DefaultValues(t *testing.T) {
 
 	// Test with explicit zero values to trigger default code paths
 	csrf := CSRF(config.CSRFConfig{
-		HMACKey:       testHMACKey,
-		CookieName:    "",
-		CookieMaxAge:  0,
-		CookiePath:    "",
-		TokenLookup:   "",
-		ExemptMethods: nil,
-		ExemptPaths:   nil,
+		HMACKey:         testHMACKey,
+		CookieName:      "",
+		CookieMaxAge:    0,
+		CookiePath:      "",
+		TokenLookup:     "",
+		ExcludedMethods: nil,
+		ExcludedPaths:   nil,
 	})(handler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -294,16 +294,16 @@ func TestCSRF_MismatchedTokens(t *testing.T) {
 	zhtest.AssertWith(t, rr2).Status(http.StatusForbidden)
 }
 
-func TestCSRF_ExemptMethods(t *testing.T) {
+func TestCSRF_ExcludedMethods(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 
 	csrf := CSRF(config.CSRFConfig{HMACKey: testHMACKey})(handler)
 
-	exemptMethods := []string{http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace}
+	excludedMethods := []string{http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace}
 
-	for _, method := range exemptMethods {
+	for _, method := range excludedMethods {
 		req := httptest.NewRequest(method, "/", nil)
 		rr := httptest.NewRecorder()
 
@@ -313,14 +313,14 @@ func TestCSRF_ExemptMethods(t *testing.T) {
 	}
 }
 
-func TestCSRF_ExemptPaths(t *testing.T) {
+func TestCSRF_ExcludedPaths(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 
 	csrf := CSRF(config.CSRFConfig{
-		HMACKey:     testHMACKey,
-		ExemptPaths: []string{"/api/webhook", "/public/"},
+		HMACKey:       testHMACKey,
+		ExcludedPaths: []string{"/api/webhook", "/public/"},
 	})(handler)
 
 	// Test exact path match
@@ -337,7 +337,7 @@ func TestCSRF_ExemptPaths(t *testing.T) {
 
 	zhtest.AssertWith(t, rr2).Status(http.StatusOK)
 
-	// Test non-exempt path (should require token)
+	// Test non-excluded path (should require token)
 	req3 := httptest.NewRequest(http.MethodPost, "/api/other", nil)
 	rr3 := httptest.NewRecorder()
 	csrf.ServeHTTP(rr3, req3)
@@ -685,25 +685,25 @@ func TestCSRF_TokenWithWrongSignature(t *testing.T) {
 	zhtest.AssertWith(t, rr2).Status(http.StatusForbidden)
 }
 
-func TestCSRF_CustomExemptMethods(t *testing.T) {
+func TestCSRF_CustomExcludedMethods(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	// Only exempt PUT, not GET
+	// Only exclude PUT, not GET
 	csrf := CSRF(config.CSRFConfig{
-		HMACKey:       testHMACKey,
-		ExemptMethods: []string{http.MethodPut},
+		HMACKey:         testHMACKey,
+		ExcludedMethods: []string{http.MethodPut},
 	})(handler)
 
-	// GET without token should return 403 (not exempt)
+	// GET without token should return 403 (not excluded)
 	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
 	rr1 := httptest.NewRecorder()
 	csrf.ServeHTTP(rr1, req1)
 
 	zhtest.AssertWith(t, rr1).Status(http.StatusForbidden)
 
-	// PUT should be exempt and work without token
+	// PUT should be excluded and work without token
 	req2 := httptest.NewRequest(http.MethodPut, "/", nil)
 	rr2 := httptest.NewRecorder()
 	csrf.ServeHTTP(rr2, req2)
@@ -948,7 +948,7 @@ func TestCSRF_TokenGenerationFailsClosed(t *testing.T) {
 		t.Error("handler should not be called when token generation fails")
 	})))
 
-	// Test GET request (exempt method) with failing token generation
+	// Test GET request (excluded method) with failing token generation
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rr := httptest.NewRecorder()
 	wrapped.ServeHTTP(rr, req)
@@ -1074,4 +1074,68 @@ func TestCSRF_DefaultTokenGenerator(t *testing.T) {
 	if !found {
 		t.Error("expected csrf_token cookie to be set")
 	}
+}
+
+func TestCSRF_IncludedPaths(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	csrf := CSRF(config.CSRFConfig{
+		HMACKey:       testHMACKey,
+		IncludedPaths: []string{"/api/", "/admin"},
+	})(handler)
+
+	// Test allowed path - should require token
+	req1 := httptest.NewRequest(http.MethodPost, "/api/users", nil)
+	rr1 := httptest.NewRecorder()
+	csrf.ServeHTTP(rr1, req1)
+
+	zhtest.AssertWith(t, rr1).Status(http.StatusForbidden)
+
+	// Test non-allowed path - should skip CSRF
+	req2 := httptest.NewRequest(http.MethodPost, "/public", nil)
+	rr2 := httptest.NewRecorder()
+	csrf.ServeHTTP(rr2, req2)
+
+	zhtest.AssertWith(t, rr2).Status(http.StatusOK)
+}
+
+func TestCSRF_IncludedPathsWithWildcard(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	csrf := CSRF(config.CSRFConfig{
+		HMACKey:       testHMACKey,
+		IncludedPaths: []string{"/api/*"},
+	})(handler)
+
+	// Test wildcard path - should require token
+	req1 := httptest.NewRequest(http.MethodPost, "/api/anything", nil)
+	rr1 := httptest.NewRecorder()
+	csrf.ServeHTTP(rr1, req1)
+
+	zhtest.AssertWith(t, rr1).Status(http.StatusForbidden)
+
+	// Test non-matching path - should skip CSRF
+	req2 := httptest.NewRequest(http.MethodPost, "/other", nil)
+	rr2 := httptest.NewRecorder()
+	csrf.ServeHTTP(rr2, req2)
+
+	zhtest.AssertWith(t, rr2).Status(http.StatusOK)
+}
+
+func TestCSRF_BothExcludedAndIncludedPathsPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when both ExcludedPaths and IncludedPaths are set")
+		}
+	}()
+
+	_ = CSRF(config.CSRFConfig{
+		HMACKey:       testHMACKey,
+		ExcludedPaths: []string{"/health"},
+		IncludedPaths: []string{"/api"},
+	})
 }

--- a/middleware/etag.go
+++ b/middleware/etag.go
@@ -415,6 +415,8 @@ func ETag(cfg ...config.ETagConfig) func(http.Handler) http.Handler {
 		zconfig.Merge(&c, cfg[0])
 	}
 
+	validatePathConfig(c.ExcludedPaths, c.IncludedPaths, "ETag")
+
 	if c.Algorithm != config.FNV && c.Algorithm != config.MD5 {
 		c.Algorithm = config.DefaultETagConfig.Algorithm
 	}
@@ -423,14 +425,12 @@ func ETag(cfg ...config.ETagConfig) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			reg := metrics.SafeRegistry(metrics.GetRegistry(r.Context()))
 
-			for _, exemptPath := range c.ExemptPaths {
-				if pathMatches(r.URL.Path, exemptPath) {
-					next.ServeHTTP(w, r)
-					return
-				}
+			if !shouldProcessMiddleware(r.URL.Path, c.IncludedPaths, c.ExcludedPaths) {
+				next.ServeHTTP(w, r)
+				return
 			}
 
-			if c.ExemptFunc != nil && c.ExemptFunc(r) {
+			if c.ExcludedFunc != nil && c.ExcludedFunc(r) {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/middleware/etag_test.go
+++ b/middleware/etag_test.go
@@ -237,36 +237,36 @@ func TestETag_MD5Algorithm(t *testing.T) {
 	}
 }
 
-func TestETag_ExemptPaths(t *testing.T) {
-	handler := ETag(config.ETagConfig{ExemptPaths: []string{"/skip"}})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func TestETag_ExcludedPaths(t *testing.T) {
+	handler := ETag(config.ETagConfig{ExcludedPaths: []string{"/skip"}})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("hello"))
 	}))
 
-	// Request to exempt path
+	// Request to excluded path
 	req1 := httptest.NewRequest(http.MethodGet, "/skip", nil)
 	rec1 := httptest.NewRecorder()
 	handler.ServeHTTP(rec1, req1)
 
 	if rec1.Header().Get("ETag") != "" {
-		t.Error("expected no ETag header for exempt path")
+		t.Error("expected no ETag header for excluded path")
 	}
 
-	// Request to non-exempt path
+	// Request to non-excluded path
 	req2 := httptest.NewRequest(http.MethodGet, "/other", nil)
 	rec2 := httptest.NewRecorder()
 	handler.ServeHTTP(rec2, req2)
 
 	if rec2.Header().Get("ETag") == "" {
-		t.Error("expected ETag header for non-exempt path")
+		t.Error("expected ETag header for non-excluded path")
 	}
 }
 
-func TestETag_ExemptFunc(t *testing.T) {
-	exemptFunc := func(r *http.Request) bool {
+func TestETag_ExcludedFunc(t *testing.T) {
+	excludedFunc := func(r *http.Request) bool {
 		return r.Header.Get("X-Skip-ETag") == "true"
 	}
 
-	handler := ETag(config.ETagConfig{ExemptFunc: exemptFunc})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := ETag(config.ETagConfig{ExcludedFunc: excludedFunc})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("hello"))
 	}))
 
@@ -277,7 +277,7 @@ func TestETag_ExemptFunc(t *testing.T) {
 	handler.ServeHTTP(rec1, req1)
 
 	if rec1.Header().Get("ETag") != "" {
-		t.Error("expected no ETag header when exempt func returns true")
+		t.Error("expected no ETag header when excluded func returns true")
 	}
 
 	// Request without skip header
@@ -286,7 +286,7 @@ func TestETag_ExemptFunc(t *testing.T) {
 	handler.ServeHTTP(rec2, req2)
 
 	if rec2.Header().Get("ETag") == "" {
-		t.Error("expected ETag header when exempt func returns false")
+		t.Error("expected ETag header when excluded func returns false")
 	}
 }
 
@@ -1033,8 +1033,8 @@ func TestETagMatches_ExactMatches(t *testing.T) {
 	}
 }
 
-func TestETag_ExemptPaths_PrefixMatch(t *testing.T) {
-	handler := ETag(config.ETagConfig{ExemptPaths: []string{"/api/"}})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func TestETag_ExcludedPaths_PrefixMatch(t *testing.T) {
+	handler := ETag(config.ETagConfig{ExcludedPaths: []string{"/api/"}})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("hello"))
 	}))
 
@@ -1044,7 +1044,7 @@ func TestETag_ExemptPaths_PrefixMatch(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	if rec.Header().Get("ETag") != "" {
-		t.Error("expected no ETag header for exempt path prefix")
+		t.Error("expected no ETag header for excluded path prefix")
 	}
 }
 
@@ -1072,7 +1072,7 @@ func TestETag_NilConfigMaps(t *testing.T) {
 		Weak:            config.Bool(true),
 		MaxBufferSize:   1024,
 		SkipStatusCodes: nil,
-		ExemptPaths:     []string{},
+		ExcludedPaths:   []string{},
 	}
 
 	handler := func(next http.Handler) http.Handler {
@@ -1185,7 +1185,7 @@ func TestETag_NilSkipContentTypes(t *testing.T) {
 		MaxBufferSize:    1024,
 		SkipStatusCodes:  map[int]struct{}{},
 		SkipContentTypes: nil, // nil
-		ExemptPaths:      []string{},
+		ExcludedPaths:    []string{},
 	}
 
 	handler := func(next http.Handler) http.Handler {
@@ -1369,4 +1369,43 @@ func TestETag_ConcurrentWriteAndFlush(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
+}
+
+func TestETag_IncludedPaths(t *testing.T) {
+	handler := ETag(config.ETagConfig{
+		IncludedPaths: []string{"/api/", "/admin"},
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("hello"))
+	}))
+
+	// Request to allowed path - should generate ETag
+	req1 := httptest.NewRequest(http.MethodGet, "/api/users", nil)
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+
+	if rec1.Header().Get("ETag") == "" {
+		t.Error("expected ETag header for allowed path")
+	}
+
+	// Request to non-allowed path - should skip ETag
+	req2 := httptest.NewRequest(http.MethodGet, "/other", nil)
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+
+	if rec2.Header().Get("ETag") != "" {
+		t.Error("expected no ETag header for non-allowed path")
+	}
+}
+
+func TestETag_BothExcludedAndIncludedPathsPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when both ExcludedPaths and IncludedPaths are set")
+		}
+	}()
+
+	_ = ETag(config.ETagConfig{
+		ExcludedPaths: []string{"/health"},
+		IncludedPaths: []string{"/api"},
+	})
 }

--- a/middleware/hmac_auth.go
+++ b/middleware/hmac_auth.go
@@ -123,6 +123,8 @@ func HMACAuth(cfg ...config.HMACAuthConfig) func(http.Handler) http.Handler {
 		c.Algorithm = config.HMACSHA256
 	}
 
+	validatePathConfig(c.ExcludedPaths, c.IncludedPaths, "HMACAuth")
+
 	errorHandler := c.ErrorHandler
 	if errorHandler == nil {
 		errorHandler = defaultHMACErrorHandler
@@ -143,11 +145,9 @@ func HMACAuth(cfg ...config.HMACAuthConfig) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			reg := metrics.SafeRegistry(metrics.GetRegistry(r.Context()))
 
-			for _, exemptPath := range c.ExemptPaths {
-				if pathMatches(r.URL.Path, exemptPath) {
-					next.ServeHTTP(w, r)
-					return
-				}
+			if !shouldProcessMiddleware(r.URL.Path, c.IncludedPaths, c.ExcludedPaths) {
+				next.ServeHTTP(w, r)
+				return
 			}
 
 			var parsed *parsedAuth

--- a/middleware/hmac_auth_test.go
+++ b/middleware/hmac_auth_test.go
@@ -294,7 +294,7 @@ func TestHMACAuth_FutureTimestamp(t *testing.T) {
 	}
 }
 
-func TestHMACAuth_ExemptPath(t *testing.T) {
+func TestHMACAuth_ExcludedPath(t *testing.T) {
 	creds := map[string]string{"test-key": "test-secret-key-that-is-32-bytes-long!"}
 	mw := HMACAuth(config.HMACAuthConfig{
 		CredentialStore: func(id string) []string {
@@ -303,7 +303,7 @@ func TestHMACAuth_ExemptPath(t *testing.T) {
 			}
 			return nil
 		},
-		ExemptPaths: []string{"/health", "/metrics"},
+		ExcludedPaths: []string{"/health", "/metrics"},
 	})
 
 	var handlerCalled bool
@@ -317,10 +317,10 @@ func TestHMACAuth_ExemptPath(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	if !handlerCalled {
-		t.Error("handler was not called for exempt path")
+		t.Error("handler was not called for excluded path")
 	}
 	if rr.Code != http.StatusOK {
-		t.Errorf("expected 200 for exempt path, got %d", rr.Code)
+		t.Errorf("expected 200 for excluded path, got %d", rr.Code)
 	}
 }
 
@@ -1920,4 +1920,67 @@ func TestHMACAuth_PresignedURL_NoHeaderModification(t *testing.T) {
 		t.Errorf("X-Timestamp header was modified by middleware: original=%q, final=%q",
 			originalTimestampHeader, finalTimestampHeader)
 	}
+}
+
+func TestHMACAuth_IncludedPaths(t *testing.T) {
+	creds := map[string]string{"test-key": "test-secret-key-that-is-32-bytes-long!"}
+	mw := HMACAuth(config.HMACAuthConfig{
+		CredentialStore: func(id string) []string {
+			if secret, ok := creds[id]; ok {
+				return []string{secret}
+			}
+			return nil
+		},
+		IncludedPaths: []string{"/api/", "/admin"},
+	})
+
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	signer := NewHMACSigner("test-key", "test-secret-key-that-is-32-bytes-long!")
+
+	// Test allowed path - should require auth
+	req1 := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	if err := signer.SignRequest(req1); err != nil {
+		t.Fatalf("failed to sign request: %v", err)
+	}
+	rr1 := httptest.NewRecorder()
+	handler.ServeHTTP(rr1, req1)
+
+	if rr1.Code != http.StatusOK {
+		t.Errorf("expected 200 for allowed path with valid auth, got %d", rr1.Code)
+	}
+
+	// Test non-allowed path - should skip auth
+	req2 := httptest.NewRequest(http.MethodGet, "/public", nil)
+	rr2 := httptest.NewRecorder()
+	handler.ServeHTTP(rr2, req2)
+
+	if rr2.Code != http.StatusOK {
+		t.Errorf("expected 200 for non-allowed path, got %d", rr2.Code)
+	}
+
+	// Test non-allowed path with missing auth - should still pass
+	req3 := httptest.NewRequest(http.MethodGet, "/other", nil)
+	rr3 := httptest.NewRecorder()
+	handler.ServeHTTP(rr3, req3)
+
+	if rr3.Code != http.StatusOK {
+		t.Errorf("expected 200 for non-allowed path without auth, got %d", rr3.Code)
+	}
+}
+
+func TestHMACAuth_BothExcludedAndIncludedPathsPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when both ExcludedPaths and IncludedPaths are set")
+		}
+	}()
+
+	_ = HMACAuth(config.HMACAuthConfig{
+		CredentialStore: func(id string) []string { return nil },
+		ExcludedPaths:   []string{"/health"},
+		IncludedPaths:   []string{"/api"},
+	})
 }

--- a/middleware/host_validation.go
+++ b/middleware/host_validation.go
@@ -48,6 +48,8 @@ func HostValidation(cfg ...config.HostValidationConfig) func(http.Handler) http.
 		}
 	}
 
+	validatePathConfig(c.ExcludedPaths, c.IncludedPaths, "HostValidation")
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if len(allowedHosts) == 0 {
@@ -55,11 +57,9 @@ func HostValidation(cfg ...config.HostValidationConfig) func(http.Handler) http.
 				return
 			}
 
-			for _, exemptPath := range c.ExemptPaths {
-				if pathMatches(r.URL.Path, exemptPath) {
-					next.ServeHTTP(w, r)
-					return
-				}
+			if !shouldProcessMiddleware(r.URL.Path, c.IncludedPaths, c.ExcludedPaths) {
+				next.ServeHTTP(w, r)
+				return
 			}
 
 			if r.Host == "" {

--- a/middleware/host_validation_test.go
+++ b/middleware/host_validation_test.go
@@ -149,10 +149,10 @@ func TestHostValidation_WithPort(t *testing.T) {
 	}
 }
 
-func TestHostValidation_ExemptPaths(t *testing.T) {
+func TestHostValidation_ExcludedPaths(t *testing.T) {
 	mw := HostValidation(config.HostValidationConfig{
-		AllowedHosts: []string{"example.com"},
-		ExemptPaths:  []string{"/health", "/metrics"},
+		AllowedHosts:  []string{"example.com"},
+		ExcludedPaths: []string{"/health", "/metrics"},
 	})
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -164,10 +164,10 @@ func TestHostValidation_ExemptPaths(t *testing.T) {
 		host       string
 		wantStatus int
 	}{
-		{"exempt path with bad host", "/health", "evil.com", http.StatusOK},
-		{"exempt path 2", "/metrics", "evil.com", http.StatusOK},
-		{"non-exempt path with bad host", "/api", "evil.com", http.StatusBadRequest},
-		{"non-exempt path with good host", "/api", "example.com", http.StatusOK},
+		{"excluded path with bad host", "/health", "evil.com", http.StatusOK},
+		{"excluded path 2", "/metrics", "evil.com", http.StatusOK},
+		{"non-excluded path with bad host", "/api", "evil.com", http.StatusBadRequest},
+		{"non-excluded path with good host", "/api", "example.com", http.StatusOK},
 	}
 
 	for _, tt := range tests {
@@ -563,4 +563,50 @@ func TestIsValidHost(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHostValidation_IncludedPaths(t *testing.T) {
+	mw := HostValidation(config.HostValidationConfig{
+		AllowedHosts:  []string{"example.com"},
+		IncludedPaths: []string{"/api/", "/admin"},
+	})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	tests := []struct {
+		name       string
+		path       string
+		host       string
+		wantStatus int
+	}{
+		{"allowed path with good host", "/api/users", "example.com", http.StatusOK},
+		{"allowed path with bad host", "/api/users", "evil.com", http.StatusBadRequest},
+		{"non-allowed path with good host", "/other", "example.com", http.StatusOK},
+		{"non-allowed path with bad host", "/other", "evil.com", http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := zhtest.NewRequest(http.MethodGet, tt.path).Build()
+			req.Host = tt.host
+			w := zhtest.Serve(handler, req)
+
+			zhtest.AssertWith(t, w).Status(tt.wantStatus)
+		})
+	}
+}
+
+func TestHostValidation_BothExcludedAndIncludedPathsPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when both ExcludedPaths and IncludedPaths are set")
+		}
+	}()
+
+	_ = HostValidation(config.HostValidationConfig{
+		AllowedHosts:  []string{"example.com"},
+		ExcludedPaths: []string{"/health"},
+		IncludedPaths: []string{"/api"},
+	})
 }

--- a/middleware/idempotency.go
+++ b/middleware/idempotency.go
@@ -40,6 +40,8 @@ func Idempotency(cfg ...config.IdempotencyConfig) func(http.Handler) http.Handle
 		http.MethodDelete: true,
 	}
 
+	validatePathConfig(c.ExcludedPaths, c.IncludedPaths, "Idempotency")
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if !stateChangingMethods[r.Method] {
@@ -47,11 +49,9 @@ func Idempotency(cfg ...config.IdempotencyConfig) func(http.Handler) http.Handle
 				return
 			}
 
-			for _, exemptPath := range c.ExemptPaths {
-				if pathMatches(r.URL.Path, exemptPath) {
-					next.ServeHTTP(w, r)
-					return
-				}
+			if !shouldProcessMiddleware(r.URL.Path, c.IncludedPaths, c.ExcludedPaths) {
+				next.ServeHTTP(w, r)
+				return
 			}
 
 			idempotencyKey := r.Header.Get(c.HeaderName)

--- a/middleware/idempotency_test.go
+++ b/middleware/idempotency_test.go
@@ -234,8 +234,8 @@ func TestIdempotency_Required(t *testing.T) {
 	})
 }
 
-func TestIdempotency_ExemptPaths(t *testing.T) {
-	t.Run("skips idempotency for exempt paths", func(t *testing.T) {
+func TestIdempotency_ExcludedPaths(t *testing.T) {
+	t.Run("skips idempotency for excluded paths", func(t *testing.T) {
 		callCount := 0
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			callCount++
@@ -243,24 +243,24 @@ func TestIdempotency_ExemptPaths(t *testing.T) {
 		})
 
 		idempotencyMiddleware := Idempotency(config.IdempotencyConfig{
-			TTL:         time.Hour,
-			ExemptPaths: []string{"/webhook*"},
+			TTL:           time.Hour,
+			ExcludedPaths: []string{"/webhook*"},
 		})
 
-		// First request to exempt path
+		// First request to excluded path
 		req1 := httptest.NewRequest(http.MethodPost, "/webhook/stripe", bytes.NewReader([]byte(`{}`)))
 		req1.Header.Set(httpx.HeaderIdempotencyKey, "key-webhook")
 		w1 := httptest.NewRecorder()
 		idempotencyMiddleware(handler).ServeHTTP(w1, req1)
 
-		// Second request to exempt path
+		// Second request to excluded path
 		req2 := httptest.NewRequest(http.MethodPost, "/webhook/stripe", bytes.NewReader([]byte(`{}`)))
 		req2.Header.Set(httpx.HeaderIdempotencyKey, "key-webhook")
 		w2 := httptest.NewRecorder()
 		idempotencyMiddleware(handler).ServeHTTP(w2, req2)
 
 		if callCount != 2 {
-			t.Errorf("Expected 2 handler calls for exempt path, got %d", callCount)
+			t.Errorf("Expected 2 handler calls for excluded path, got %d", callCount)
 		}
 	})
 }
@@ -1015,5 +1015,114 @@ func TestIdempotency_WriteHeaderIdempotent(t *testing.T) {
 		if w.Code != http.StatusCreated {
 			t.Errorf("Expected 201 (first WriteHeader), got %d", w.Code)
 		}
+	})
+}
+
+func TestIdempotency_IncludedPaths(t *testing.T) {
+	t.Run("only applies idempotency to included paths", func(t *testing.T) {
+		callCount := 0
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"123"}`))
+		})
+
+		idempotencyMiddleware := Idempotency(config.IdempotencyConfig{
+			TTL:           time.Hour,
+			IncludedPaths: []string{"/api/payments", "/api/transfers/"},
+		})
+
+		// First request to allowed path
+		req1 := httptest.NewRequest(http.MethodPost, "/api/payments", bytes.NewReader([]byte(`{"amount":100}`)))
+		req1.Header.Set(httpx.HeaderIdempotencyKey, "key-allowed")
+		w1 := httptest.NewRecorder()
+		idempotencyMiddleware(handler).ServeHTTP(w1, req1)
+
+		// Second request to same allowed path - should be cached
+		req2 := httptest.NewRequest(http.MethodPost, "/api/payments", bytes.NewReader([]byte(`{"amount":100}`)))
+		req2.Header.Set(httpx.HeaderIdempotencyKey, "key-allowed")
+		w2 := httptest.NewRecorder()
+		idempotencyMiddleware(handler).ServeHTTP(w2, req2)
+
+		if callCount != 1 {
+			t.Errorf("Expected 1 handler call for allowed path (cached), got %d", callCount)
+		}
+		if w2.Header().Get("X-Idempotency-Replay") != "true" {
+			t.Error("Replayed request should have X-Idempotency-Replay header")
+		}
+
+		// Request to non-allowed path - should not be cached
+		req3 := httptest.NewRequest(http.MethodPost, "/api/other", bytes.NewReader([]byte(`{"data":"test"}`)))
+		req3.Header.Set(httpx.HeaderIdempotencyKey, "key-other")
+		w3 := httptest.NewRecorder()
+		idempotencyMiddleware(handler).ServeHTTP(w3, req3)
+
+		// Second request to non-allowed path - should hit handler again
+		req4 := httptest.NewRequest(http.MethodPost, "/api/other", bytes.NewReader([]byte(`{"data":"test"}`)))
+		req4.Header.Set(httpx.HeaderIdempotencyKey, "key-other")
+		w4 := httptest.NewRecorder()
+		idempotencyMiddleware(handler).ServeHTTP(w4, req4)
+
+		if callCount != 3 {
+			t.Errorf("Expected 3 handler calls (non-allowed path not cached), got %d", callCount)
+		}
+	})
+
+	t.Run("included paths with prefix match", func(t *testing.T) {
+		callCount := 0
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.WriteHeader(http.StatusOK)
+		})
+
+		idempotencyMiddleware := Idempotency(config.IdempotencyConfig{
+			TTL:           time.Hour,
+			IncludedPaths: []string{"/api/"},
+		})
+
+		// Request to path under prefix
+		req1 := httptest.NewRequest(http.MethodPost, "/api/users", bytes.NewReader([]byte(`{}`)))
+		req1.Header.Set(httpx.HeaderIdempotencyKey, "key-prefix")
+		w1 := httptest.NewRecorder()
+		idempotencyMiddleware(handler).ServeHTTP(w1, req1)
+
+		// Second request - should be cached
+		req2 := httptest.NewRequest(http.MethodPost, "/api/users", bytes.NewReader([]byte(`{}`)))
+		req2.Header.Set(httpx.HeaderIdempotencyKey, "key-prefix")
+		w2 := httptest.NewRecorder()
+		idempotencyMiddleware(handler).ServeHTTP(w2, req2)
+
+		if callCount != 1 {
+			t.Errorf("Expected 1 handler call for prefix match, got %d", callCount)
+		}
+
+		// Request outside prefix - should not be cached
+		req3 := httptest.NewRequest(http.MethodPost, "/health", bytes.NewReader([]byte(`{}`)))
+		req3.Header.Set(httpx.HeaderIdempotencyKey, "key-health")
+		w3 := httptest.NewRecorder()
+		idempotencyMiddleware(handler).ServeHTTP(w3, req3)
+
+		req4 := httptest.NewRequest(http.MethodPost, "/health", bytes.NewReader([]byte(`{}`)))
+		req4.Header.Set(httpx.HeaderIdempotencyKey, "key-health")
+		w4 := httptest.NewRecorder()
+		idempotencyMiddleware(handler).ServeHTTP(w4, req4)
+
+		if callCount != 3 {
+			t.Errorf("Expected 3 handler calls (outside prefix not cached), got %d", callCount)
+		}
+	})
+}
+
+func TestIdempotency_BothExcludedAndIncludedPathsPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when both ExcludedPaths and IncludedPaths are set")
+		}
+	}()
+
+	_ = Idempotency(config.IdempotencyConfig{
+		TTL:           time.Hour,
+		ExcludedPaths: []string{"/webhook"},
+		IncludedPaths: []string{"/api"},
 	})
 }

--- a/middleware/jwt_auth.go
+++ b/middleware/jwt_auth.go
@@ -15,7 +15,7 @@
 // The middleware supports:
 //   - Custom token extraction (Bearer header, cookies, custom headers)
 //   - Required claims validation
-//   - Exempt paths and methods
+//   - Excluded paths and methods
 //   - Custom error handling
 //   - Token refresh handling
 //
@@ -115,6 +115,8 @@ func JWTAuth(cfg ...config.JWTAuthConfig) func(http.Handler) http.Handler {
 		c.TokenExtractor = extractBearerToken
 	}
 
+	validatePathConfig(c.ExcludedPaths, c.IncludedPaths, "JWTAuth")
+
 	errorHandler := c.ErrorHandler
 	if errorHandler == nil {
 		errorHandler = defaultJWTErrorHandler
@@ -131,16 +133,14 @@ func JWTAuth(cfg ...config.JWTAuthConfig) func(http.Handler) http.Handler {
 				return
 			}
 
-			if slices.Contains(c.ExemptMethods, r.Method) {
+			if slices.Contains(c.ExcludedMethods, r.Method) {
 				next.ServeHTTP(w, r)
 				return
 			}
 
-			for _, exemptPath := range c.ExemptPaths {
-				if pathMatches(r.URL.Path, exemptPath) {
-					next.ServeHTTP(w, r)
-					return
-				}
+			if !shouldProcessMiddleware(r.URL.Path, c.IncludedPaths, c.ExcludedPaths) {
+				next.ServeHTTP(w, r)
+				return
 			}
 
 			if c.TokenStore == nil {

--- a/middleware/jwt_auth_test.go
+++ b/middleware/jwt_auth_test.go
@@ -210,9 +210,9 @@ func TestJWTAuth_Success(t *testing.T) {
 	}
 }
 
-func TestJWTAuth_ExemptPath(t *testing.T) {
+func TestJWTAuth_ExcludedPath(t *testing.T) {
 	middleware := JWTAuth(config.JWTAuthConfig{
-		ExemptPaths: []string{"/health"},
+		ExcludedPaths: []string{"/health"},
 	})
 
 	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -239,9 +239,9 @@ func TestJWTAuth_ExemptPath(t *testing.T) {
 	}
 }
 
-func TestJWTAuth_ExemptMethod(t *testing.T) {
+func TestJWTAuth_ExcludedMethod(t *testing.T) {
 	middleware := JWTAuth(config.JWTAuthConfig{
-		ExemptMethods: []string{http.MethodHead},
+		ExcludedMethods: []string{http.MethodHead},
 	})
 
 	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2357,4 +2357,62 @@ func TestRefreshTokenHandler_GenerateRefreshTokenError(t *testing.T) {
 	if rr.Code != http.StatusInternalServerError {
 		t.Errorf("expected status %d, got %d", http.StatusInternalServerError, rr.Code)
 	}
+}
+
+func TestJWTAuth_IncludedPaths(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(ctx context.Context, token string) (config.JWTClaims, error) {
+			return map[string]any{"sub": "user123"}, nil
+		},
+	}
+
+	mw := JWTAuth(config.JWTAuthConfig{
+		TokenStore:    store,
+		IncludedPaths: []string{"/api/admin", "/api/private/"},
+	})
+
+	tests := []struct {
+		name       string
+		path       string
+		token      string
+		wantStatus int
+	}{
+		{"allowed path with token", "/api/admin", "valid-token", http.StatusOK},
+		{"allowed path without token", "/api/admin", "", http.StatusUnauthorized},
+		{"allowed prefix path with token", "/api/private/data", "valid-token", http.StatusOK},
+		{"allowed prefix path without token", "/api/private/data", "", http.StatusUnauthorized},
+		{"non-allowed path with token", "/public", "valid-token", http.StatusOK},
+		{"non-allowed path without token", "/public", "", http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			if tt.token != "" {
+				req.Header.Set(httpx.HeaderAuthorization, "Bearer "+tt.token)
+			}
+			rr := httptest.NewRecorder()
+			mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})).ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantStatus {
+				t.Errorf("expected status %d, got %d", tt.wantStatus, rr.Code)
+			}
+		})
+	}
+}
+
+func TestJWTAuth_BothExcludedAndIncludedPathsPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when both ExcludedPaths and IncludedPaths are set")
+		}
+	}()
+
+	_ = JWTAuth(config.JWTAuthConfig{
+		TokenStore:    &mockTokenStore{},
+		ExcludedPaths: []string{"/health"},
+		IncludedPaths: []string{"/api"},
+	})
 }

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -22,7 +23,7 @@ func DefaultMiddlewares(cfg config.Config, logger log.Logger) []func(http.Handle
 	}
 }
 
-// pathMatches checks if a request path matches an exempt path.
+// pathMatches checks if a request path matches an excluded path.
 // Supports:
 //   - Exact matches
 //   - Prefix matches (paths ending with /)
@@ -31,24 +32,60 @@ func DefaultMiddlewares(cfg config.Config, logger log.Logger) []func(http.Handle
 // For example:
 //   - "/api/public/" matches "/api/public", "/api/public/users", "/api/public/status"
 //   - "/api/live*" matches "/api/live", "/api/livez", "/api/health/live"
-func pathMatches(requestPath, exemptPath string) bool {
-	if exemptPath == requestPath {
+func pathMatches(requestPath, excludedPath string) bool {
+	if excludedPath == requestPath {
 		return true
 	}
 
 	// Support wildcard suffix matching for paths ending with *
-	if base, hasSuffix := strings.CutSuffix(exemptPath, "*"); hasSuffix {
+	if base, hasSuffix := strings.CutSuffix(excludedPath, "*"); hasSuffix {
 		return strings.HasPrefix(requestPath, base)
 	}
 
 	// Support prefix matching for paths ending with /
-	if base, hasSuffix := strings.CutSuffix(exemptPath, "/"); hasSuffix {
+	if base, hasSuffix := strings.CutSuffix(excludedPath, "/"); hasSuffix {
 		// Also match the path without the trailing slash (e.g., "/api/public" matches "/api/public/")
 		if requestPath == base {
 			return true
 		}
-		return strings.HasPrefix(requestPath, exemptPath)
+		return strings.HasPrefix(requestPath, excludedPath)
 	}
 
 	return false
+}
+
+// shouldProcessMiddleware checks if a path should be processed by middleware based on
+// IncludedPaths and ExcludedPaths configuration. Returns true if the middleware should run.
+//
+// Rules:
+//   - If IncludedPaths is set, the path must match one of the allowed patterns
+//   - If ExcludedPaths is set, the path must NOT match any of the excluded patterns
+//   - If both are empty, the middleware runs for all paths
+func shouldProcessMiddleware(path string, includedPaths, excludedPaths []string) bool {
+	// If IncludedPaths is set, only process matching paths
+	if len(includedPaths) > 0 {
+		for _, allowedPath := range includedPaths {
+			if pathMatches(path, allowedPath) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Check excluded paths
+	for _, excludedPath := range excludedPaths {
+		if pathMatches(path, excludedPath) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// validatePathConfig checks that ExcludedPaths and IncludedPaths are not both set,
+// which would be a configuration error. The middleware name is used for the panic message.
+func validatePathConfig(excludedPaths, includedPaths []string, middlewareName string) {
+	if len(excludedPaths) > 0 && len(includedPaths) > 0 {
+		panic(fmt.Sprintf("%s: cannot set both ExcludedPaths and IncludedPaths", middlewareName))
+	}
 }

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -73,9 +73,9 @@ func TestDefaultMiddlewares_NilInputs(t *testing.T) {
 
 func TestPathMatches(t *testing.T) {
 	tests := []struct {
-		requestPath string
-		exemptPath  string
-		expected    bool
+		requestPath  string
+		excludedPath string
+		expected     bool
 	}{
 		{"/health", "/health", true},
 		{"/health", "/metrics", false},
@@ -92,11 +92,11 @@ func TestPathMatches(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.requestPath+"_vs_"+tt.exemptPath, func(t *testing.T) {
-			result := pathMatches(tt.requestPath, tt.exemptPath)
+		t.Run(tt.requestPath+"_vs_"+tt.excludedPath, func(t *testing.T) {
+			result := pathMatches(tt.requestPath, tt.excludedPath)
 			if result != tt.expected {
 				t.Errorf("pathMatches(%q, %q) = %v, expected %v",
-					tt.requestPath, tt.exemptPath, result, tt.expected)
+					tt.requestPath, tt.excludedPath, result, tt.expected)
 			}
 		})
 	}

--- a/middleware/rate_limit.go
+++ b/middleware/rate_limit.go
@@ -28,6 +28,8 @@ func RateLimit(cfg ...config.RateLimitConfig) func(http.Handler) http.Handler {
 		c.KeyExtractor = IPKeyExtractor()
 	}
 
+	validatePathConfig(c.ExcludedPaths, c.IncludedPaths, "RateLimit")
+
 	var store RateLimitStore
 	if c.Store != nil {
 		store = c.Store
@@ -43,11 +45,9 @@ func RateLimit(cfg ...config.RateLimitConfig) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			reg := metrics.SafeRegistry(metrics.GetRegistry(r.Context()))
 
-			for _, exemptPath := range c.ExemptPaths {
-				if pathMatches(r.URL.Path, exemptPath) {
-					next.ServeHTTP(w, r)
-					return
-				}
+			if !shouldProcessMiddleware(r.URL.Path, c.IncludedPaths, c.ExcludedPaths) {
+				next.ServeHTTP(w, r)
+				return
 			}
 
 			key := c.KeyExtractor(r)

--- a/middleware/rate_limit_test.go
+++ b/middleware/rate_limit_test.go
@@ -232,12 +232,12 @@ func TestRateLimitCustomKeyExtractor(t *testing.T) {
 	zhtest.AssertWith(t, w).Status(http.StatusOK)
 }
 
-func TestRateLimitExemptPaths(t *testing.T) {
+func TestRateLimitExcludedPaths(t *testing.T) {
 	middleware := RateLimit(config.RateLimitConfig{
-		Rate:        1,
-		Window:      time.Second,
-		Algorithm:   config.TokenBucket,
-		ExemptPaths: []string{"/health", "/metrics"},
+		Rate:          1,
+		Window:        time.Second,
+		Algorithm:     config.TokenBucket,
+		ExcludedPaths: []string{"/health", "/metrics"},
 	})
 	count := 0
 	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -250,11 +250,11 @@ func TestRateLimitExemptPaths(t *testing.T) {
 		w := zhtest.Serve(handler, req)
 
 		if w.Code != http.StatusOK {
-			t.Errorf("exempt path request %d: expected status 200, got %d", i+1, w.Code)
+			t.Errorf("excluded path request %d: expected status 200, got %d", i+1, w.Code)
 		}
 	}
 	if count != 3 {
-		t.Errorf("expected 3 requests to exempt path, got %d", count)
+		t.Errorf("expected 3 requests to excluded path, got %d", count)
 	}
 	req := zhtest.NewRequest(http.MethodGet, "/api").Build()
 	req.RemoteAddr = "127.0.0.1:12345"
@@ -643,4 +643,60 @@ func TestIPKeyExtractor_IPv6(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRateLimit_IncludedPaths(t *testing.T) {
+	middleware := RateLimit(config.RateLimitConfig{
+		Rate:          1,
+		Window:        time.Second,
+		Algorithm:     config.TokenBucket,
+		IncludedPaths: []string{"/api/", "/admin"},
+	})
+	count := 0
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count++
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	tests := []struct {
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{"allowed path - first request", "/api/users", http.StatusOK},
+		{"allowed path - rate limited", "/api/users", http.StatusTooManyRequests},
+		// Note: /admin shares the same rate limit (same IP), so it's also rate limited
+		{"allowed exact path - also rate limited", "/admin", http.StatusTooManyRequests},
+		{"non-allowed path - not rate limited 1", "/health", http.StatusOK},
+		{"non-allowed path - not rate limited 2", "/health", http.StatusOK},
+		{"non-allowed path - not rate limited 3", "/metrics", http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := zhtest.NewRequest(http.MethodGet, tt.path).Build()
+			req.RemoteAddr = "127.0.0.1:12345"
+			w := zhtest.Serve(handler, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("expected status %d, got %d", tt.wantStatus, w.Code)
+			}
+		})
+	}
+}
+
+func TestRateLimit_BothExcludedAndIncludedPathsPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when both ExcludedPaths and IncludedPaths are set")
+		}
+	}()
+
+	_ = RateLimit(config.RateLimitConfig{
+		Rate:          1,
+		Window:        time.Second,
+		Algorithm:     config.TokenBucket,
+		ExcludedPaths: []string{"/health"},
+		IncludedPaths: []string{"/api"},
+	})
 }

--- a/middleware/request_body_size.go
+++ b/middleware/request_body_size.go
@@ -20,15 +20,15 @@ func RequestBodySize(cfg ...config.RequestBodySizeConfig) func(http.Handler) htt
 		c.MaxBytes = config.DefaultRequestBodySizeConfig.MaxBytes
 	}
 
+	validatePathConfig(c.ExcludedPaths, c.IncludedPaths, "RequestBodySize")
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			reg := metrics.SafeRegistry(metrics.GetRegistry(r.Context()))
 
-			for _, exemptPath := range c.ExemptPaths {
-				if pathMatches(r.URL.Path, exemptPath) {
-					next.ServeHTTP(w, r)
-					return
-				}
+			if !shouldProcessMiddleware(r.URL.Path, c.IncludedPaths, c.ExcludedPaths) {
+				next.ServeHTTP(w, r)
+				return
 			}
 
 			// Wrap the response writer to detect 413 status

--- a/middleware/request_body_size_test.go
+++ b/middleware/request_body_size_test.go
@@ -65,7 +65,7 @@ func TestRequestBodySize_Limits(t *testing.T) {
 	}
 }
 
-func TestRequestBodySize_ExemptPaths(t *testing.T) {
+func TestRequestBodySize_ExcludedPaths(t *testing.T) {
 	tests := []struct {
 		path        string
 		expectError bool
@@ -81,8 +81,8 @@ func TestRequestBodySize_ExemptPaths(t *testing.T) {
 		t.Run(tt.path, func(t *testing.T) {
 			handler := &requestBodySizeTestHandler{}
 			middleware := RequestBodySize(config.RequestBodySizeConfig{
-				MaxBytes:    5,
-				ExemptPaths: []string{"/upload", "/webhook", "/api/large"},
+				MaxBytes:      5,
+				ExcludedPaths: []string{"/upload", "/webhook", "/api/large"},
 			})(handler)
 			largeBody := bytes.NewReader([]byte("this is a long body"))
 			req := zhtest.NewRequest(http.MethodPost, tt.path).WithBody(largeBody).Build()
@@ -93,20 +93,20 @@ func TestRequestBodySize_ExemptPaths(t *testing.T) {
 			}
 			hasError := handler.bodyError != nil
 			if !tt.expectError && hasError {
-				t.Errorf("Expected no error for exempt path %s, got %v", tt.path, handler.bodyError)
+				t.Errorf("Expected no error for excluded path %s, got %v", tt.path, handler.bodyError)
 			}
 			if tt.expectError && !hasError {
-				t.Errorf("Expected error for non-exempt path %s, got none", tt.path)
+				t.Errorf("Expected error for non-excluded path %s, got none", tt.path)
 			}
 		})
 	}
 }
 
-func TestRequestBodySize_EmptyExemptPaths(t *testing.T) {
+func TestRequestBodySize_EmptyExcludedPaths(t *testing.T) {
 	handler := &requestBodySizeTestHandler{}
 	middleware := RequestBodySize(config.RequestBodySizeConfig{
-		MaxBytes:    10,
-		ExemptPaths: []string{},
+		MaxBytes:      10,
+		ExcludedPaths: []string{},
 	})(handler)
 	largeBody := bytes.NewReader([]byte("this body is longer than 10 bytes"))
 	req := zhtest.NewRequest(http.MethodPost, "/any-path").WithBody(largeBody).Build()
@@ -116,7 +116,7 @@ func TestRequestBodySize_EmptyExemptPaths(t *testing.T) {
 		t.Error("Expected handler to be called")
 	}
 	if handler.bodyError == nil {
-		t.Error("Expected error when no paths are exempt")
+		t.Error("Expected error when no paths are excluded")
 	}
 }
 
@@ -147,11 +147,11 @@ func TestRequestBodySize_ConfigFallbacks(t *testing.T) {
 	}
 }
 
-func TestRequestBodySize_NilExemptPaths(t *testing.T) {
+func TestRequestBodySize_NilExcludedPaths(t *testing.T) {
 	handler := &requestBodySizeTestHandler{}
 	middleware := RequestBodySize(config.RequestBodySizeConfig{
-		MaxBytes:    100,
-		ExemptPaths: nil,
+		MaxBytes:      100,
+		ExcludedPaths: nil,
 	})(handler)
 	smallBody := bytes.NewReader([]byte("small body"))
 	req := zhtest.NewRequest(http.MethodPost, "/").WithBody(smallBody).Build()
@@ -161,15 +161,15 @@ func TestRequestBodySize_NilExemptPaths(t *testing.T) {
 		t.Error("Expected handler to be called")
 	}
 	if handler.bodyError != nil {
-		t.Errorf("Expected no error with nil exempt paths, got %v", handler.bodyError)
+		t.Errorf("Expected no error with nil excluded paths, got %v", handler.bodyError)
 	}
 }
 
 func TestRequestBodySize_MultipleOptions(t *testing.T) {
 	handler := &requestBodySizeTestHandler{}
 	middleware := RequestBodySize(config.RequestBodySizeConfig{
-		MaxBytes:    10,
-		ExemptPaths: []string{"/test"},
+		MaxBytes:      10,
+		ExcludedPaths: []string{"/test"},
 	})(handler)
 	largeBody := bytes.NewReader([]byte("this body is longer than 10 bytes but less than 100"))
 	req := zhtest.NewRequest(http.MethodPost, "/").WithBody(largeBody).Build()
@@ -189,11 +189,11 @@ func TestDefaultRequestBodySizeConfig(t *testing.T) {
 	if cfg.MaxBytes != expectedMaxBytes {
 		t.Errorf("Expected default max bytes %d, got %d", expectedMaxBytes, cfg.MaxBytes)
 	}
-	if cfg.ExemptPaths == nil {
-		t.Error("Expected default exempt paths to be empty slice, got nil")
+	if cfg.ExcludedPaths == nil {
+		t.Error("Expected default excluded paths to be empty slice, got nil")
 	}
-	if len(cfg.ExemptPaths) != 0 {
-		t.Errorf("Expected default exempt paths to be empty, got %d items", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 0 {
+		t.Errorf("Expected default excluded paths to be empty, got %d items", len(cfg.ExcludedPaths))
 	}
 }
 
@@ -340,4 +340,56 @@ func TestRequestBodySize_Flush_SupportsSSE(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
 	}
+}
+
+func TestRequestBodySize_IncludedPaths(t *testing.T) {
+	tests := []struct {
+		path        string
+		expectError bool
+	}{
+		{"/api/upload", true},
+		{"/api/data", true},
+		{"/admin", true},
+		{"/health", false},
+		{"/metrics", false},
+		{"/public", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			handler := &requestBodySizeTestHandler{}
+			middleware := RequestBodySize(config.RequestBodySizeConfig{
+				MaxBytes:      5,
+				IncludedPaths: []string{"/api/", "/admin"},
+			})(handler)
+			largeBody := bytes.NewReader([]byte("this is a long body"))
+			req := zhtest.NewRequest(http.MethodPost, tt.path).WithBody(largeBody).Build()
+			zhtest.Serve(middleware, req)
+
+			if !handler.called {
+				t.Errorf("Expected handler to be called for path %s", tt.path)
+			}
+			hasError := handler.bodyError != nil
+			if !tt.expectError && hasError {
+				t.Errorf("Expected no error for non-allowed path %s, got %v", tt.path, handler.bodyError)
+			}
+			if tt.expectError && !hasError {
+				t.Errorf("Expected error for allowed path %s, got none", tt.path)
+			}
+		})
+	}
+}
+
+func TestRequestBodySize_BothExcludedAndIncludedPathsPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when both ExcludedPaths and IncludedPaths are set")
+		}
+	}()
+
+	_ = RequestBodySize(config.RequestBodySizeConfig{
+		MaxBytes:      1024,
+		ExcludedPaths: []string{"/health"},
+		IncludedPaths: []string{"/api"},
+	})
 }

--- a/middleware/request_logger.go
+++ b/middleware/request_logger.go
@@ -22,8 +22,8 @@ func RequestLogger(logger log.Logger, cfg ...config.RequestLoggerConfig) func(ht
 		zconfig.Merge(&c, cfg[0])
 	}
 
-	if len(c.ExemptPaths) > 0 && len(c.AllowedPaths) > 0 {
-		logger.Panic("RequestLogger: cannot set both ExemptPaths and AllowedPaths")
+	if len(c.ExcludedPaths) > 0 && len(c.IncludedPaths) > 0 {
+		logger.Panic("RequestLogger: cannot set both ExcludedPaths and IncludedPaths")
 	}
 
 	fieldMap := make(map[config.LogField]bool)
@@ -33,8 +33,8 @@ func RequestLogger(logger log.Logger, cfg ...config.RequestLoggerConfig) func(ht
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			for _, exemptPath := range c.ExemptPaths {
-				if pathMatches(r.URL.Path, exemptPath) {
+			for _, excludedPath := range c.ExcludedPaths {
+				if pathMatches(r.URL.Path, excludedPath) {
 					next.ServeHTTP(w, r)
 					return
 				}
@@ -42,7 +42,7 @@ func RequestLogger(logger log.Logger, cfg ...config.RequestLoggerConfig) func(ht
 
 			start := time.Now()
 
-			bodyLoggingAllowed := isBodyLoggingAllowed(r.URL.Path, c.AllowedPaths)
+			bodyLoggingAllowed := isBodyLoggingAllowed(r.URL.Path, c.IncludedPaths)
 
 			var requestBody string
 			if c.LogRequestBody && bodyLoggingAllowed {
@@ -333,13 +333,13 @@ func isSensitiveField(field string, sensitiveFields []string) bool {
 }
 
 // isBodyLoggingAllowed checks if body logging is allowed for the given path.
-// If allowedPaths is empty, body logging is allowed for all paths.
-// If allowedPaths is set, body logging is only allowed for matching paths.
-func isBodyLoggingAllowed(path string, allowedPaths []string) bool {
-	if len(allowedPaths) == 0 {
+// If includedPaths is empty, body logging is allowed for all paths.
+// If includedPaths is set, body logging is only allowed for matching paths.
+func isBodyLoggingAllowed(path string, includedPaths []string) bool {
+	if len(includedPaths) == 0 {
 		return true
 	}
-	for _, allowedPath := range allowedPaths {
+	for _, allowedPath := range includedPaths {
 		if pathMatches(path, allowedPath) {
 			return true
 		}

--- a/middleware/request_logger_bench_test.go
+++ b/middleware/request_logger_bench_test.go
@@ -205,25 +205,25 @@ func BenchmarkRequestLogger_LogLevelRouting(b *testing.B) {
 	}
 }
 
-// BenchmarkRequestLogger_ExemptPaths measures exempt path checking overhead
-func BenchmarkRequestLogger_ExemptPaths(b *testing.B) {
+// BenchmarkRequestLogger_ExcludedPaths measures excluded path checking overhead
+func BenchmarkRequestLogger_ExcludedPaths(b *testing.B) {
 	testCases := []struct {
-		name        string
-		exemptPaths []string
-		path        string
+		name          string
+		excludedPaths []string
+		path          string
 	}{
-		{"NoExemptions", nil, "/api/users"},
-		{"OneExemption", []string{"/health"}, "/api/users"},
-		{"ManyExemptions", []string{"/health", "/metrics", "/ready", "/live"}, "/api/users"},
-		{"ExemptMatch", []string{"/health"}, "/health"},
+		{"NoExcluded", nil, "/api/users"},
+		{"OneExcluded", []string{"/health"}, "/api/users"},
+		{"ManyExcluded", []string{"/health", "/metrics", "/ready", "/live"}, "/api/users"},
+		{"ExcludedMatch", []string{"/health"}, "/health"},
 	}
 
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
 			logger := &noopLogger{}
 			mw := RequestLogger(logger, config.RequestLoggerConfig{
-				Fields:      []config.LogField{config.FieldMethod, config.FieldPath},
-				ExemptPaths: tc.exemptPaths,
+				Fields:        []config.LogField{config.FieldMethod, config.FieldPath},
+				ExcludedPaths: tc.excludedPaths,
 			})
 
 			handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/middleware/request_logger_test.go
+++ b/middleware/request_logger_test.go
@@ -240,23 +240,23 @@ func TestRequestLogger_CustomFields(t *testing.T) {
 	}
 }
 
-func TestRequestLogger_ExemptPaths(t *testing.T) {
+func TestRequestLogger_ExcludedPaths(t *testing.T) {
 	logger := &requestLoggerMockLogger{}
 	handler := &statusTestHandler{statusCode: http.StatusOK}
-	middleware := RequestLogger(logger, config.RequestLoggerConfig{ExemptPaths: []string{"/health", "/metrics"}})(handler)
+	middleware := RequestLogger(logger, config.RequestLoggerConfig{ExcludedPaths: []string{"/health", "/metrics"}})(handler)
 
 	req1 := zhtest.NewRequest(http.MethodGet, "/health").Build()
 	zhtest.Serve(middleware, req1)
 
 	if len(logger.infoLogs) != 0 {
-		t.Errorf("Expected no logs for exempt path, got %d", len(logger.infoLogs))
+		t.Errorf("Expected no logs for excluded path, got %d", len(logger.infoLogs))
 	}
 
 	req2 := zhtest.NewRequest(http.MethodGet, "/api").Build()
 	zhtest.Serve(middleware, req2)
 
 	if len(logger.infoLogs) != 1 {
-		t.Errorf("Expected 1 log for non-exempt path, got %d", len(logger.infoLogs))
+		t.Errorf("Expected 1 log for non-excluded path, got %d", len(logger.infoLogs))
 	}
 }
 
@@ -322,8 +322,8 @@ func TestDefaultRequestLoggerConfig(t *testing.T) {
 			t.Errorf("Expected field %s to be in default cfg", expected)
 		}
 	}
-	if len(cfg.ExemptPaths) != 0 {
-		t.Errorf("Expected default exempt paths to be empty, got %d", len(cfg.ExemptPaths))
+	if len(cfg.ExcludedPaths) != 0 {
+		t.Errorf("Expected default excluded paths to be empty, got %d", len(cfg.ExcludedPaths))
 	}
 	if cfg.MaxBodySize != 1024 {
 		t.Errorf("Expected default MaxBodySize to be 1024, got %d", cfg.MaxBodySize)
@@ -764,24 +764,24 @@ func (p *panicLogger) Fatal(msg string, fields ...log.Field)      {}
 func (p *panicLogger) WithFields(fields ...log.Field) log.Logger  { return p }
 func (p *panicLogger) WithContext(ctx context.Context) log.Logger { return p }
 
-func TestRequestLogger_ExemptPathsAndAllowedPathsPanic(t *testing.T) {
+func TestRequestLogger_ExcludedPathsAndIncludedPathsPanic(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {
-			t.Error("Expected panic when both ExemptPaths and AllowedPaths are set")
-		} else if !strings.Contains(r.(string), "cannot set both ExemptPaths and AllowedPaths") {
-			t.Errorf("Expected panic message about ExemptPaths and AllowedPaths, got: %v", r)
+			t.Error("Expected panic when both ExcludedPaths and IncludedPaths are set")
+		} else if !strings.Contains(r.(string), "cannot set both ExcludedPaths and IncludedPaths") {
+			t.Errorf("Expected panic message about ExcludedPaths and IncludedPaths, got: %v", r)
 		}
 	}()
 
 	logger := &panicLogger{}
 	_ = RequestLogger(logger, config.RequestLoggerConfig{
-		ExemptPaths:  []string{"/health"},
-		AllowedPaths: []string{"/api/debug"},
+		ExcludedPaths: []string{"/health"},
+		IncludedPaths: []string{"/api/debug"},
 	})
 }
 
-func TestRequestLogger_AllowedPaths(t *testing.T) {
-	t.Run("body logging only for allowed paths", func(t *testing.T) {
+func TestRequestLogger_IncludedPaths(t *testing.T) {
+	t.Run("body logging only for included paths", func(t *testing.T) {
 		logger := &requestLoggerMockLogger{}
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write([]byte(`{"status":"ok"}`))
@@ -790,7 +790,7 @@ func TestRequestLogger_AllowedPaths(t *testing.T) {
 			Fields:          []config.LogField{config.FieldPath, config.FieldRequestBody, config.FieldResponseBody},
 			LogRequestBody:  true,
 			LogResponseBody: true,
-			AllowedPaths:    []string{"/api/debug"},
+			IncludedPaths:   []string{"/api/debug"},
 		})(handler)
 
 		// Request to allowed path - bodies should be logged
@@ -815,7 +815,7 @@ func TestRequestLogger_AllowedPaths(t *testing.T) {
 			Fields:          []config.LogField{config.FieldPath, config.FieldRequestBody, config.FieldResponseBody},
 			LogRequestBody:  true,
 			LogResponseBody: true,
-			AllowedPaths:    []string{"/api/debug"},
+			IncludedPaths:   []string{"/api/debug"},
 		})(handler)
 
 		req2 := zhtest.NewRequest(http.MethodPost, "/api/other").
@@ -834,7 +834,7 @@ func TestRequestLogger_AllowedPaths(t *testing.T) {
 		}
 	})
 
-	t.Run("prefix matching for allowed paths", func(t *testing.T) {
+	t.Run("prefix matching for included paths", func(t *testing.T) {
 		logger := &requestLoggerMockLogger{}
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write([]byte(`{"status":"ok"}`))
@@ -843,7 +843,7 @@ func TestRequestLogger_AllowedPaths(t *testing.T) {
 			Fields:          []config.LogField{config.FieldPath, config.FieldRequestBody, config.FieldResponseBody},
 			LogRequestBody:  true,
 			LogResponseBody: true,
-			AllowedPaths:    []string{"/api/debug/"},
+			IncludedPaths:   []string{"/api/debug/"},
 		})(handler)
 
 		// Request to path under allowed prefix
@@ -860,7 +860,7 @@ func TestRequestLogger_AllowedPaths(t *testing.T) {
 		}
 	})
 
-	t.Run("empty allowed paths allows all", func(t *testing.T) {
+	t.Run("empty included paths allows all", func(t *testing.T) {
 		logger := &requestLoggerMockLogger{}
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write([]byte(`{"status":"ok"}`))
@@ -869,7 +869,7 @@ func TestRequestLogger_AllowedPaths(t *testing.T) {
 			Fields:          []config.LogField{config.FieldPath, config.FieldRequestBody, config.FieldResponseBody},
 			LogRequestBody:  true,
 			LogResponseBody: true,
-			AllowedPaths:    []string{}, // Empty - should allow all
+			IncludedPaths:   []string{}, // Empty - should allow all
 		})(handler)
 
 		req := zhtest.NewRequest(http.MethodPost, "/api/anything").
@@ -881,7 +881,7 @@ func TestRequestLogger_AllowedPaths(t *testing.T) {
 			t.Fatalf("Expected 1 info log, got %d", len(logger.infoLogs))
 		}
 		if _, found := findFieldValue(logger.infoLogs[0].fields, "request_body"); !found {
-			t.Error("Expected request_body to be present when AllowedPaths is empty")
+			t.Error("Expected request_body to be present when IncludedPaths is empty")
 		}
 	})
 }

--- a/middleware/reverse_proxy.go
+++ b/middleware/reverse_proxy.go
@@ -94,15 +94,15 @@ func ReverseProxy(cfg config.ReverseProxyConfig) (func(http.Handler) http.Handle
 		}
 	}
 
+	validatePathConfig(cfg.ExcludedPaths, cfg.IncludedPaths, "ReverseProxy")
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			reg := metrics.SafeRegistry(metrics.GetRegistry(r.Context()))
 
-			for _, exempt := range cfg.ExemptPaths {
-				if pathMatches(r.URL.Path, exempt) {
-					next.ServeHTTP(w, r)
-					return
-				}
+			if !shouldProcessMiddleware(r.URL.Path, cfg.IncludedPaths, cfg.ExcludedPaths) {
+				next.ServeHTTP(w, r)
+				return
 			}
 
 			b := rp.selectBackend()

--- a/middleware/reverse_proxy_bench_test.go
+++ b/middleware/reverse_proxy_bench_test.go
@@ -242,8 +242,8 @@ func BenchmarkReverseProxy_Rewrites(b *testing.B) {
 	})
 }
 
-// BenchmarkReverseProxy_ExemptPaths measures exempt path checking overhead
-func BenchmarkReverseProxy_ExemptPaths(b *testing.B) {
+// BenchmarkReverseProxy_ExcludedPaths measures excluded path checking overhead
+func BenchmarkReverseProxy_ExcludedPaths(b *testing.B) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -254,21 +254,21 @@ func BenchmarkReverseProxy_ExemptPaths(b *testing.B) {
 	})
 
 	testCases := []struct {
-		name        string
-		exemptPaths []string
-		path        string
+		name          string
+		excludedPaths []string
+		path          string
 	}{
-		{"NoExemptions", nil, "/api/users"},
-		{"OneExemption_NoMatch", []string{"/health"}, "/api/users"},
-		{"ManyExemptions_NoMatch", []string{"/health", "/metrics", "/ready", "/live"}, "/api/users"},
-		{"ExemptMatch", []string{"/health"}, "/health"},
+		{"NoExcluded", nil, "/api/users"},
+		{"OneExcluded_NoMatch", []string{"/health"}, "/api/users"},
+		{"ManyExcluded_NoMatch", []string{"/health", "/metrics", "/ready", "/live"}, "/api/users"},
+		{"ExcludedMatch", []string{"/health"}, "/health"},
 	}
 
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
 			mw, cleanup := ReverseProxy(config.ReverseProxyConfig{
-				Target:      upstream.URL,
-				ExemptPaths: tc.exemptPaths,
+				Target:        upstream.URL,
+				ExcludedPaths: tc.excludedPaths,
 			})
 			defer cleanup()
 			handler := mw(nextHandler)

--- a/middleware/reverse_proxy_test.go
+++ b/middleware/reverse_proxy_test.go
@@ -210,35 +210,35 @@ func TestReverseProxy_ForwardHeaders(t *testing.T) {
 	}
 }
 
-func TestReverseProxy_ExemptPaths(t *testing.T) {
+func TestReverseProxy_ExcludedPaths(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("upstream"))
 	}))
 	defer upstream.Close()
 
 	mw, _ := ReverseProxy(config.ReverseProxyConfig{
-		Target:      upstream.URL,
-		ExemptPaths: []string{"/health", "/metrics"},
+		Target:        upstream.URL,
+		ExcludedPaths: []string{"/health", "/metrics"},
 	})
 
-	// Test exempt path - should call next handler
+	// Test excluded path - should call next handler
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	rec := httptest.NewRecorder()
 
 	nextCalled := false
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		nextCalled = true
-		_, _ = w.Write([]byte("exempt"))
+		_, _ = w.Write([]byte("excluded"))
 	})
 
 	mw(next).ServeHTTP(rec, req)
 
 	if !nextCalled {
-		t.Error("expected next handler to be called for exempt path")
+		t.Error("expected next handler to be called for excluded path")
 	}
-	zhtest.AssertWith(t, rec).Body("exempt")
+	zhtest.AssertWith(t, rec).Body("excluded")
 
-	// Test non-exempt path - should go to upstream
+	// Test non-excluded path - should go to upstream
 	req2 := httptest.NewRequest(http.MethodGet, "/api", nil)
 	rec2 := httptest.NewRecorder()
 
@@ -572,7 +572,7 @@ func TestReverseProxy_WithNextHandler(t *testing.T) {
 	mw(next).ServeHTTP(rec, req)
 
 	if nextCalled {
-		t.Error("expected next handler NOT to be called without exempt paths")
+		t.Error("expected next handler NOT to be called without excluded paths")
 	}
 	zhtest.AssertWith(t, rec).Body("upstream")
 }
@@ -740,4 +740,71 @@ func TestReverseProxy_proxyResponseRecorder_Flush(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReverseProxy_IncludedPaths(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("upstream response: " + r.URL.Path))
+	}))
+	defer upstream.Close()
+
+	mw, _ := ReverseProxy(config.ReverseProxyConfig{
+		Target:        upstream.URL,
+		IncludedPaths: []string{"/api/", "/admin"},
+	})
+
+	tests := []struct {
+		name           string
+		path           string
+		expectUpstream bool
+		expectBody     string
+	}{
+		{"allowed path - goes to upstream", "/api/users", true, "upstream response: /api/users"},
+		{"allowed exact path", "/admin", true, "upstream response: /admin"},
+		{"non-allowed path - calls next", "/health", false, "next handler"},
+		{"non-allowed path 2", "/metrics", false, "next handler"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rec := httptest.NewRecorder()
+
+			nextCalled := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				_, _ = w.Write([]byte("next handler"))
+			})
+
+			mw(next).ServeHTTP(rec, req)
+
+			if tt.expectUpstream && nextCalled {
+				t.Error("expected upstream to handle request, but next was called")
+			}
+			if !tt.expectUpstream && !nextCalled {
+				t.Error("expected next handler to be called, but upstream handled it")
+			}
+			zhtest.AssertWith(t, rec).Body(tt.expectBody)
+		})
+	}
+}
+
+func TestReverseProxy_BothExcludedAndIncludedPathsPanics(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when both ExcludedPaths and IncludedPaths are set")
+		}
+	}()
+
+	_, _ = ReverseProxy(config.ReverseProxyConfig{
+		Target:        upstream.URL,
+		ExcludedPaths: []string{"/health"},
+		IncludedPaths: []string{"/api"},
+	})
 }

--- a/middleware/security_headers.go
+++ b/middleware/security_headers.go
@@ -21,13 +21,13 @@ func SecurityHeaders(cfg ...config.SecurityHeadersConfig) func(http.Handler) htt
 		zconfig.Merge(&c, cfg[0])
 	}
 
+	validatePathConfig(c.ExcludedPaths, c.IncludedPaths, "SecurityHeaders")
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			for _, exemptPath := range c.ExemptPaths {
-				if pathMatches(r.URL.Path, exemptPath) {
-					next.ServeHTTP(w, r)
-					return
-				}
+			if !shouldProcessMiddleware(r.URL.Path, c.IncludedPaths, c.ExcludedPaths) {
+				next.ServeHTTP(w, r)
+				return
 			}
 
 			csp := c.ContentSecurityPolicy

--- a/middleware/security_headers_test.go
+++ b/middleware/security_headers_test.go
@@ -115,7 +115,7 @@ func TestSecurityHeaders_HSTSWithNestedOptions(t *testing.T) {
 	zhtest.AssertWith(t, w).Header("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload")
 }
 
-func TestSecurityHeaders_ExemptPaths(t *testing.T) {
+func TestSecurityHeaders_ExcludedPaths(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -123,7 +123,7 @@ func TestSecurityHeaders_ExemptPaths(t *testing.T) {
 	w := zhtest.TestMiddlewareWithHandler(
 		SecurityHeaders(config.SecurityHeadersConfig{
 			ContentSecurityPolicy: "default-src 'self'",
-			ExemptPaths:           []string{"/skipme"},
+			ExcludedPaths:         []string{"/skipme"},
 		}),
 		handler,
 		req,
@@ -385,4 +385,53 @@ func TestGetCSPNonce_NotFound(t *testing.T) {
 	if nonce != "" {
 		t.Errorf("Expected empty string for missing nonce, got %q", nonce)
 	}
+}
+
+func TestSecurityHeaders_IncludedPaths(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	tests := []struct {
+		name               string
+		path               string
+		expectSecurityHdrs bool
+	}{
+		{"allowed path - has headers", "/api/users", true},
+		{"allowed exact path", "/admin", true},
+		{"non-allowed path - no headers", "/health", false},
+		{"non-allowed path 2", "/metrics", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := zhtest.NewRequest(http.MethodGet, tt.path).Build()
+			mw := SecurityHeaders(config.SecurityHeadersConfig{
+				ContentSecurityPolicy: "default-src 'self'",
+				IncludedPaths:         []string{"/api/", "/admin"},
+			})
+			w := zhtest.TestMiddlewareWithHandler(mw, handler, req)
+
+			zhtest.AssertWith(t, w).Status(http.StatusOK)
+			if tt.expectSecurityHdrs {
+				zhtest.AssertWith(t, w).HeaderExists(httpx.HeaderContentSecurityPolicy)
+			} else {
+				zhtest.AssertWith(t, w).HeaderNotExists(httpx.HeaderContentSecurityPolicy)
+			}
+		})
+	}
+}
+
+func TestSecurityHeaders_BothExcludedAndIncludedPathsPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when both ExcludedPaths and IncludedPaths are set")
+		}
+	}()
+
+	_ = SecurityHeaders(config.SecurityHeadersConfig{
+		ContentSecurityPolicy: "default-src 'self'",
+		ExcludedPaths:         []string{"/health"},
+		IncludedPaths:         []string{"/api"},
+	})
 }

--- a/middleware/timeout.go
+++ b/middleware/timeout.go
@@ -30,13 +30,13 @@ func Timeout(cfg ...config.TimeoutConfig) func(http.Handler) http.Handler {
 		zconfig.Merge(&c, cfg[0])
 	}
 
+	validatePathConfig(c.ExcludedPaths, c.IncludedPaths, "Timeout")
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			for _, exemptPath := range c.ExemptPaths {
-				if pathMatches(r.URL.Path, exemptPath) {
-					next.ServeHTTP(w, r)
-					return
-				}
+			if !shouldProcessMiddleware(r.URL.Path, c.IncludedPaths, c.ExcludedPaths) {
+				next.ServeHTTP(w, r)
+				return
 			}
 
 			ctx, cancel := context.WithTimeout(r.Context(), c.Timeout)

--- a/middleware/timeout_test.go
+++ b/middleware/timeout_test.go
@@ -94,8 +94,8 @@ func TestTimeout_DefaultValues(t *testing.T) {
 			},
 		},
 		{
-			"nil exempt paths uses default",
-			config.TimeoutConfig{Timeout: 50 * time.Millisecond, ExemptPaths: nil},
+			"nil excluded paths uses default",
+			config.TimeoutConfig{Timeout: 50 * time.Millisecond, ExcludedPaths: nil},
 			100 * time.Millisecond,
 			func(t *testing.T, w *httptest.ResponseRecorder) {
 				zhtest.AssertWith(t, w).Status(http.StatusGatewayTimeout)
@@ -135,14 +135,14 @@ func TestTimeout_AllDefaults(t *testing.T) {
 	zhtest.AssertWith(t, w).Status(http.StatusOK).Body("success")
 }
 
-func TestTimeout_ExemptPaths(t *testing.T) {
+func TestTimeout_ExcludedPaths(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(100 * time.Millisecond)
 		_, _ = w.Write([]byte("done"))
 	})
 	middleware := Timeout(config.TimeoutConfig{
-		Timeout:     50 * time.Millisecond,
-		ExemptPaths: []string{"/health"},
+		Timeout:       50 * time.Millisecond,
+		ExcludedPaths: []string{"/health"},
 	})(handler)
 
 	req := zhtest.NewRequest(http.MethodGet, "/health").Build()
@@ -336,4 +336,56 @@ func TestTimeout_Flush_WritesBufferedData(t *testing.T) {
 	if rec.Body.String() != "hello" {
 		t.Errorf("expected body 'hello', got '%s'", rec.Body.String())
 	}
+}
+
+func TestTimeout_IncludedPaths(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		_, _ = w.Write([]byte("done"))
+	})
+
+	middleware := Timeout(config.TimeoutConfig{
+		Timeout:       50 * time.Millisecond,
+		IncludedPaths: []string{"/api/", "/admin"},
+	})(handler)
+
+	tests := []struct {
+		name       string
+		path       string
+		wantStatus int
+		wantBody   string
+	}{
+		{"allowed path - timeout applies", "/api/users", http.StatusGatewayTimeout, ""},
+		{"allowed exact path", "/admin", http.StatusGatewayTimeout, ""},
+		{"non-allowed path - no timeout", "/health", http.StatusOK, "done"},
+		{"non-allowed path 2", "/metrics", http.StatusOK, "done"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := zhtest.NewRequest(http.MethodGet, tt.path).Build()
+			w := zhtest.Serve(middleware, req)
+
+			if tt.wantStatus == http.StatusOK {
+				zhtest.AssertWith(t, w).Status(tt.wantStatus).Body(tt.wantBody)
+			} else {
+				// Timeout cases
+				zhtest.AssertWith(t, w).Status(tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestTimeout_BothExcludedAndIncludedPathsPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when both ExcludedPaths and IncludedPaths are set")
+		}
+	}()
+
+	_ = Timeout(config.TimeoutConfig{
+		Timeout:       50 * time.Millisecond,
+		ExcludedPaths: []string{"/health"},
+		IncludedPaths: []string{"/api"},
+	})
 }

--- a/middleware/tracer.go
+++ b/middleware/tracer.go
@@ -21,11 +21,13 @@ func Tracer(tracer trace.Tracer, cfg ...config.TracerConfig) func(http.Handler) 
 		zconfig.Merge(&c, cfg[0])
 	}
 
+	validatePathConfig(c.ExcludedPaths, c.IncludedPaths, "Tracer")
+
 	wrapper := c.Wrap()
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if wrapper.IsExempt(r.URL.Path) {
+			if !shouldProcessMiddleware(r.URL.Path, c.IncludedPaths, c.ExcludedPaths) {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/middleware/tracer_test.go
+++ b/middleware/tracer_test.go
@@ -131,32 +131,32 @@ func TestTrace_ContentLength(t *testing.T) {
 	}
 }
 
-func TestTrace_ExemptPaths(t *testing.T) {
+func TestTrace_ExcludedPaths(t *testing.T) {
 	mock := &mockTracer{}
 	mw := Tracer(mock, config.TracerConfig{
-		ExemptPaths: []string{"/health", "/metrics"},
+		ExcludedPaths: []string{"/health", "/metrics"},
 	})
 
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	// Request to exempt path should not create span
+	// Request to excluded path should not create span
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
 	if len(mock.spans) != 0 {
-		t.Errorf("Expected 0 spans for exempt path, got %d", len(mock.spans))
+		t.Errorf("Expected 0 spans for excluded path, got %d", len(mock.spans))
 	}
 
-	// Request to non-exempt path should create span
+	// Request to non-excluded path should create span
 	req = httptest.NewRequest(http.MethodGet, "/api/users", nil)
 	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
 	if len(mock.spans) != 1 {
-		t.Errorf("Expected 1 span for non-exempt path, got %d", len(mock.spans))
+		t.Errorf("Expected 1 span for non-excluded path, got %d", len(mock.spans))
 	}
 }
 
@@ -290,4 +290,60 @@ func TestTraceResponseWriter(t *testing.T) {
 	if trw.StatusCode() != 200 {
 		t.Error("WriteHeader should not change status after already written")
 	}
+}
+
+func TestTrace_IncludedPaths(t *testing.T) {
+	mock := &mockTracer{}
+	mw := Tracer(mock, config.TracerConfig{
+		IncludedPaths: []string{"/api/", "/admin"},
+	})
+
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	tests := []struct {
+		name       string
+		path       string
+		expectSpan bool
+	}{
+		{"allowed path - creates span", "/api/users", true},
+		{"allowed exact path", "/admin", true},
+		{"non-allowed path - no span", "/health", false},
+		{"non-allowed path 2", "/metrics", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset spans for each test
+			mock.spans = nil
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if tt.expectSpan {
+				if len(mock.spans) != 1 {
+					t.Errorf("Expected 1 span for allowed path, got %d", len(mock.spans))
+				}
+			} else {
+				if len(mock.spans) != 0 {
+					t.Errorf("Expected 0 spans for non-allowed path, got %d", len(mock.spans))
+				}
+			}
+		})
+	}
+}
+
+func TestTrace_BothExcludedAndIncludedPathsPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when both ExcludedPaths and IncludedPaths are set")
+		}
+	}()
+
+	_ = Tracer(&mockTracer{}, config.TracerConfig{
+		ExcludedPaths: []string{"/health"},
+		IncludedPaths: []string{"/api"},
+	})
 }


### PR DESCRIPTION
Add IncludedPaths field to all middleware configs, allowing users to explicitly specify which paths a middleware should apply to (allow-list approach) instead of just excluding paths (block-list approach).

- Added IncludedPaths to 19 config structs
- Added shouldProcessMiddleware() and validatePathConfig() helpers
- Updated all 17 middlewares to support both ExcludedPaths and IncludedPaths
- Standardized ExcludedPaths documentation across all configs
- Fixed tracer.go defaults to use []string{} for consistency
- Added comprehensive tests for path filtering in all config test files