### PR TITLE
fix(compress,router): return Content-Encoding for HEAD requests

### DIFF
--- a/config/cors.go
+++ b/config/cors.go
@@ -69,7 +69,7 @@ var DefaultCORSConfig = CORSConfig{
 		httpx.HeaderAuthorization,
 		httpx.HeaderContentType,
 		httpx.HeaderXCSRFToken,
-		httpx.HeaderXRequestID,
+		httpx.HeaderXRequestId,
 	},
 	ExposedHeaders:     []string{},
 	AllowCredentials:   false,

--- a/config/cors_test.go
+++ b/config/cors_test.go
@@ -48,7 +48,7 @@ func TestCORSConfig_DefaultValues(t *testing.T) {
 	}
 
 	// Test default header values
-	expectedHeaders := []string{httpx.HeaderAccept, httpx.HeaderAuthorization, httpx.HeaderContentType, httpx.HeaderXCSRFToken, httpx.HeaderXRequestID}
+	expectedHeaders := []string{httpx.HeaderAccept, httpx.HeaderAuthorization, httpx.HeaderContentType, httpx.HeaderXCSRFToken, httpx.HeaderXRequestId}
 	if !reflect.DeepEqual(cfg.AllowedHeaders, expectedHeaders) {
 		t.Errorf("expected default headers = %v, got %v", expectedHeaders, cfg.AllowedHeaders)
 	}

--- a/config/no_cache.go
+++ b/config/no_cache.go
@@ -10,10 +10,10 @@ import (
 var Epoch = time.Unix(0, 0).UTC().Format(http.TimeFormat)
 
 var DefaultNoCacheHeaders = map[string]string{
-	httpx.HeaderExpires:      Epoch,
-	httpx.HeaderCacheControl: "no-cache, no-store, no-transform, must-revalidate, private, max-age=0",
-	httpx.HeaderPragma:       httpx.CacheControlNoCache,
-	httpx.HeaderAccelExpires: "0",
+	httpx.HeaderExpires:       Epoch,
+	httpx.HeaderCacheControl:  "no-cache, no-store, no-transform, must-revalidate, private, max-age=0",
+	httpx.HeaderPragma:        httpx.CacheControlNoCache,
+	httpx.HeaderXAccelExpires: "0",
 }
 
 var DefaultETagHeaders = []string{

--- a/examples/middleware/cors/main.go
+++ b/examples/middleware/cors/main.go
@@ -18,7 +18,7 @@ func main() {
 		AllowedOrigins:   []string{"http://localhost:3000", "https://example.com"},
 		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 		AllowedHeaders:   []string{httpx.HeaderAccept, httpx.HeaderAuthorization, httpx.HeaderContentType, httpx.HeaderXCSRFToken},
-		ExposedHeaders:   []string{httpx.HeaderXRequestID},
+		ExposedHeaders:   []string{httpx.HeaderXRequestId},
 		AllowCredentials: true,
 		MaxAge:           86400,
 	}))

--- a/examples/middleware/rate_limit_redis/main.go
+++ b/examples/middleware/rate_limit_redis/main.go
@@ -9,6 +9,7 @@ import (
 
 	zh "github.com/alexferl/zerohttp"
 	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/httpx"
 	"github.com/alexferl/zerohttp/middleware"
 	"github.com/redis/go-redis/v9"
 )
@@ -107,9 +108,9 @@ func main() {
 	}))
 
 	app.GET("/", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-		limit := w.Header().Get("X-RateLimit-Limit")
-		remaining := w.Header().Get("X-RateLimit-Remaining")
-		reset := w.Header().Get("X-RateLimit-Reset")
+		limit := w.Header().Get(httpx.HeaderXRateLimitLimit)
+		remaining := w.Header().Get(httpx.HeaderXRateLimitRemaining)
+		reset := w.Header().Get(httpx.HeaderXRateLimitReset)
 
 		return zh.R.JSON(w, http.StatusOK, zh.M{
 			"message":   "Hello with Redis rate limiting!",

--- a/examples/middleware/request_id/main.go
+++ b/examples/middleware/request_id/main.go
@@ -30,7 +30,7 @@ func main() {
 	// This endpoint returns the request ID from the response header
 	app.GET("/headers", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 		// The middleware automatically sets the response header
-		requestID := w.Header().Get(httpx.HeaderXRequestID)
+		requestID := w.Header().Get(httpx.HeaderXRequestId)
 
 		return zh.R.JSON(w, http.StatusOK, map[string]string{
 			"message":    "Check response headers too!",
@@ -48,7 +48,7 @@ func main() {
 		})
 	}),
 		middleware.RequestID(config.RequestIDConfig{
-			Header: httpx.HeaderXRequestID,
+			Header: httpx.HeaderXRequestId,
 			Generator: func() string {
 				// Simple UUID-like format for demo purposes
 				// In production, use github.com/google/uuid

--- a/httpx/httpx.go
+++ b/httpx/httpx.go
@@ -8,7 +8,7 @@
 //
 // Header name constants include (among others):
 //
-//	[HeaderContentType], [HeaderAuthorization], [HeaderXRequestID]
+//	[HeaderContentType], [HeaderAuthorization], [HeaderXRequestId]
 //	[HeaderCacheControl], [HeaderETag], [HeaderLocation]
 //
 // CORS and Security headers include (among others):
@@ -65,7 +65,7 @@ const (
 	HeaderIfNoneMatch       = "If-None-Match"
 	HeaderIfRange           = "If-Range"
 	HeaderIfUnmodifiedSince = "If-Unmodified-Since"
-	HeaderLastEventID       = "Last-Event-ID"
+	HeaderLastEventId       = "Last-Event-Id"
 	HeaderMaxForwards       = "Max-Forwards"
 	HeaderOrigin            = "Origin"
 	HeaderPragma            = "Pragma"
@@ -139,7 +139,7 @@ const (
 
 // Custom/Extension Headers
 const (
-	HeaderAccelExpires        = "X-Accel-Expires"
+	HeaderXAccelExpires       = "X-Accel-Expires"
 	HeaderXAPIKey             = "X-API-Key"
 	HeaderXCache              = "X-Cache"
 	HeaderXCSRFToken          = "X-CSRF-Token"
@@ -156,7 +156,7 @@ const (
 	HeaderXRateLimitReset     = "X-RateLimit-Reset"
 	HeaderXRateLimitWindow    = "X-RateLimit-Window"
 	HeaderXRealIP             = "X-Real-IP"
-	HeaderXRequestID          = "X-Request-ID"
+	HeaderXRequestId          = "X-Request-Id"
 	HeaderXRequestedWith      = "X-Requested-With"
 	HeaderXTimestamp          = "X-Timestamp"
 )

--- a/internal/rwutil/response_writer_test.go
+++ b/internal/rwutil/response_writer_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/alexferl/zerohttp/httpx"
 )
 
 // flusherRecorder is a test ResponseWriter that implements http.Flusher
@@ -207,7 +209,7 @@ func TestResponseWriter_Flush_SupportsSSE(t *testing.T) {
 	}
 
 	// Write and flush like SSE would
-	rw.Header().Set("Content-Type", "text/event-stream")
+	rw.Header().Set(httpx.HeaderContentType, httpx.MIMETextEventStream)
 	rw.WriteHeader(http.StatusOK)
 	_, _ = rw.Write([]byte("data: hello\n\n"))
 	f.Flush()

--- a/metrics/middleware_test.go
+++ b/metrics/middleware_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/httpx"
 )
 
 // flusherRecorder is a test ResponseWriter that implements http.Flusher
@@ -940,7 +941,7 @@ func TestMiddleware_responseWriter_Flush_SupportsSSE(t *testing.T) {
 		}
 
 		// Write and flush like SSE would
-		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set(httpx.HeaderContentType, httpx.MIMETextEventStream)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("data: hello\n\n"))
 		f.Flush()

--- a/middleware/cache_test.go
+++ b/middleware/cache_test.go
@@ -152,7 +152,7 @@ func TestCache_ConditionalRequests(t *testing.T) {
 		w1 := httptest.NewRecorder()
 		cacheMiddleware(handler).ServeHTTP(w1, req1)
 
-		etag := w1.Header().Get("ETag")
+		etag := w1.Header().Get(httpx.HeaderETag)
 		if etag == "" {
 			t.Fatal("Expected ETag to be set")
 		}
@@ -185,14 +185,14 @@ func TestCache_ConditionalRequests(t *testing.T) {
 		w1 := httptest.NewRecorder()
 		cacheMiddleware(handler).ServeHTTP(w1, req1)
 
-		lastModified := w1.Header().Get("Last-Modified")
+		lastModified := w1.Header().Get(httpx.HeaderLastModified)
 		if lastModified == "" {
 			t.Fatal("Expected Last-Modified to be set")
 		}
 
 		// Second request with If-Modified-Since
 		req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
-		req2.Header.Set("If-Modified-Since", lastModified)
+		req2.Header.Set(httpx.HeaderIfModifiedSince, lastModified)
 		w2 := httptest.NewRecorder()
 		cacheMiddleware(handler).ServeHTTP(w2, req2)
 
@@ -205,25 +205,25 @@ func TestCache_VaryHeaders(t *testing.T) {
 		callCount := 0
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			callCount++
-			w.Header().Set(httpx.HeaderContentType, r.Header.Get("Accept"))
+			w.Header().Set(httpx.HeaderContentType, r.Header.Get(httpx.HeaderAccept))
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("response"))
 		})
 
 		cacheMiddleware := Cache(config.CacheConfig{
 			DefaultTTL: time.Minute,
-			Vary:       []string{"Accept"},
+			Vary:       []string{httpx.HeaderAccept},
 		})
 
 		// JSON request
 		req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
-		req1.Header.Set("Accept", "application/json")
+		req1.Header.Set(httpx.HeaderAccept, httpx.MIMEApplicationJSON)
 		w1 := httptest.NewRecorder()
 		cacheMiddleware(handler).ServeHTTP(w1, req1)
 
 		// XML request - should hit handler again
 		req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
-		req2.Header.Set("Accept", "application/xml")
+		req2.Header.Set(httpx.HeaderAccept, httpx.MIMEApplicationXML)
 		w2 := httptest.NewRecorder()
 		cacheMiddleware(handler).ServeHTTP(w2, req2)
 
@@ -233,7 +233,7 @@ func TestCache_VaryHeaders(t *testing.T) {
 
 		// Same JSON request - should be cached
 		req3 := httptest.NewRequest(http.MethodGet, "/test", nil)
-		req3.Header.Set("Accept", "application/json")
+		req3.Header.Set(httpx.HeaderAccept, httpx.MIMEApplicationJSON)
 		w3 := httptest.NewRecorder()
 		cacheMiddleware(handler).ServeHTTP(w3, req3)
 
@@ -530,7 +530,7 @@ func TestCache_NoDuplicateHeaders(t *testing.T) {
 		if len(contentTypeValues) != 1 {
 			t.Errorf("expected Content-Type to appear exactly once, got %d times: %v", len(contentTypeValues), contentTypeValues)
 		}
-		if w.Header().Get(httpx.HeaderContentType) != "application/json" {
+		if w.Header().Get(httpx.HeaderContentType) != httpx.MIMEApplicationJSON {
 			t.Errorf("expected Content-Type to be application/json, got %s", w.Header().Get(httpx.HeaderContentType))
 		}
 
@@ -558,7 +558,7 @@ func TestCache_NoDuplicateHeaders(t *testing.T) {
 		req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
 		w1 := httptest.NewRecorder()
 		w1.Header().Set("X-Security-Header", "security-value")
-		w1.Header().Set("X-Request-Id", "req-123")
+		w1.Header().Set(httpx.HeaderXRequestId, "req-123")
 
 		cacheMiddleware(handler).ServeHTTP(w1, req1)
 
@@ -570,7 +570,7 @@ func TestCache_NoDuplicateHeaders(t *testing.T) {
 		req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
 		w2 := httptest.NewRecorder()
 		w2.Header().Set("X-Security-Header", "security-value")
-		w2.Header().Set("X-Request-Id", "req-456")
+		w2.Header().Set(httpx.HeaderXRequestId, "req-456")
 
 		cacheMiddleware(handler).ServeHTTP(w2, req2)
 
@@ -585,12 +585,12 @@ func TestCache_NoDuplicateHeaders(t *testing.T) {
 		}
 
 		// Request ID should be the NEW one (from middleware), not cached
-		requestIDs := w2.Header()["X-Request-Id"]
+		requestIDs := w2.Header()[httpx.HeaderXRequestId]
 		if len(requestIDs) != 1 {
 			t.Errorf("X-Request-Id should appear exactly once, got %d: %v", len(requestIDs), requestIDs)
 		}
-		if w2.Header().Get("X-Request-Id") != "req-456" {
-			t.Errorf("X-Request-Id should be 'req-456' (from middleware), got %q", w2.Header().Get("X-Request-Id"))
+		if w2.Header().Get(httpx.HeaderXRequestId) != "req-456" {
+			t.Errorf("X-Request-Id should be 'req-456' (from middleware), got %q", w2.Header().Get(httpx.HeaderXRequestId))
 		}
 
 		// Handler's custom header should be present from cache

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -127,6 +127,7 @@ func (c *Compressor) Handler(next http.Handler) http.Handler {
 		reg := metrics.SafeRegistry(metrics.GetRegistry(r.Context()))
 
 		encoder, encoding, cleanup := c.selectEncoder(r.Header, w)
+		isHead := r.Method == http.MethodHead
 		cw := &compressResponseWriter{
 			ResponseWriter:   w,
 			w:                w,
@@ -134,14 +135,21 @@ func (c *Compressor) Handler(next http.Handler) http.Handler {
 			contentWildcards: c.allowedWildcards,
 			encoding:         encoding,
 			compressible:     false,
+			isHeadRequest:    isHead,
 		}
-		if encoder != nil {
+		// Don't use encoder for HEAD requests - it would set incorrect Content-Length
+		if encoder != nil && !isHead {
 			cw.w = encoder
 		}
 
-		defer cleanup()
+		// Only cleanup/close encoder if we used it
+		if !isHead {
+			defer cleanup()
+			defer func() {
+				_ = cw.Close()
+			}()
+		}
 		defer func() {
-			_ = cw.Close()
 			// Record metric for encoding used
 			enc := encoding
 			if enc == "" {
@@ -231,6 +239,7 @@ type compressResponseWriter struct {
 	encoding         string
 	wroteHeader      bool
 	compressible     bool
+	isHeadRequest    bool
 }
 
 func (cw *compressResponseWriter) isCompressible() bool {
@@ -259,22 +268,35 @@ func (cw *compressResponseWriter) WriteHeader(code int) {
 		return
 	}
 
-	if !cw.isCompressible() {
-		cw.compressible = false
-		return
-	}
-
 	if cw.encoding != "" {
-		cw.compressible = true
-		cw.Header().Set(httpx.HeaderContentEncoding, cw.encoding)
-		cw.Header().Add(httpx.HeaderVary, httpx.HeaderAcceptEncoding)
-		cw.Header().Del(httpx.HeaderContentLength)
+		isCompressible := cw.isCompressible()
+		contentType := cw.Header().Get(httpx.HeaderContentType)
+
+		// Set Content-Encoding header if:
+		// 1. Content is compressible, OR
+		// 2. No Content-Type is set (e.g., HEAD request where type isn't determined yet)
+		if isCompressible || contentType == "" {
+			cw.Header().Set(httpx.HeaderContentEncoding, cw.encoding)
+			cw.Header().Add(httpx.HeaderVary, httpx.HeaderAcceptEncoding)
+			cw.Header().Del(httpx.HeaderContentLength)
+		}
+
+		if isCompressible {
+			cw.compressible = true
+		}
 	}
 }
 
 func (cw *compressResponseWriter) Write(p []byte) (int, error) {
 	if !cw.wroteHeader {
 		cw.WriteHeader(http.StatusOK)
+	}
+	// For HEAD requests, don't write body to response.
+	// We can't set Content-Length correctly because:
+	// 1. WriteHeader is already called by this point
+	// 2. We don't know compressed size without actually compressing
+	if cw.isHeadRequest {
+		return len(p), nil
 	}
 	return cw.writer().Write(p)
 }

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -801,6 +801,91 @@ func TestCompress_WriteHeader_MultipleCalls(t *testing.T) {
 	}
 }
 
+func TestCompress_HEADRequest_ContentEncoding(t *testing.T) {
+	// Test that HEAD requests return Content-Encoding header when compression is applicable
+	// even when Content-Type is not explicitly set (relies on default detection)
+	mw := Compress(config.CompressConfig{
+		Types: []string{"text/html"},
+	})
+
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Handler does NOT set Content-Type explicitly
+		// This simulates real-world cases where WriteHeader is called before Content-Type is determined
+		w.WriteHeader(http.StatusOK)
+		// Note: No body written, which is typical for HEAD requests
+	}))
+
+	req := httptest.NewRequest(http.MethodHead, "/test", nil)
+	req.Header.Set(httpx.HeaderAcceptEncoding, httpx.ContentEncodingGzip)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	// HEAD requests should still return Content-Encoding header when Accept-Encoding is sent
+	// because the middleware should assume compression is possible
+	encoding := rr.Header().Get(httpx.HeaderContentEncoding)
+	if encoding != httpx.ContentEncodingGzip {
+		t.Errorf("HEAD request: expected Content-Encoding=%q, got %q", httpx.ContentEncodingGzip, encoding)
+	}
+}
+
+func TestCompress_HEADRequest_WithContentType_ContentEncoding(t *testing.T) {
+	// Test that HEAD requests return Content-Encoding header when Content-Type is set
+	mw := Compress(config.CompressConfig{
+		Types: []string{"text/html"},
+	})
+
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(httpx.HeaderContentType, "text/html")
+		w.WriteHeader(http.StatusOK)
+		// Note: No body written, which is typical for HEAD requests
+	}))
+
+	req := httptest.NewRequest(http.MethodHead, "/test", nil)
+	req.Header.Set(httpx.HeaderAcceptEncoding, httpx.ContentEncodingGzip)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	// HEAD requests should return Content-Encoding header when Content-Type is compressible
+	encoding := rr.Header().Get(httpx.HeaderContentEncoding)
+	if encoding != httpx.ContentEncodingGzip {
+		t.Errorf("HEAD request with Content-Type: expected Content-Encoding=%q, got %q", httpx.ContentEncodingGzip, encoding)
+	}
+}
+
+func TestCompress_HEADRequest_NoContentLength(t *testing.T) {
+	// Test that HEAD requests don't have Content-Length set for compressed responses
+	// since we can't know the compressed size without actually compressing
+	mw := Compress(config.CompressConfig{
+		Types: []string{"text/html"},
+	})
+
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(httpx.HeaderContentType, "text/html")
+		_, _ = w.Write([]byte("test content that would be compressed"))
+	}))
+
+	req := httptest.NewRequest(http.MethodHead, "/test", nil)
+	req.Header.Set(httpx.HeaderAcceptEncoding, httpx.ContentEncodingGzip)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	// HEAD requests should not have Content-Length for compressed responses
+	// since we can't determine the compressed size without actually compressing
+	contentLength := rr.Header().Get(httpx.HeaderContentLength)
+	if contentLength != "" {
+		t.Errorf("HEAD request: expected no Content-Length for compressed response, got %q", contentLength)
+	}
+
+	// But Content-Encoding should still be set
+	encoding := rr.Header().Get(httpx.HeaderContentEncoding)
+	if encoding != httpx.ContentEncodingGzip {
+		t.Errorf("HEAD request: expected Content-Encoding=%q, got %q", httpx.ContentEncodingGzip, encoding)
+	}
+}
+
 func TestCompress_IncludedPaths(t *testing.T) {
 	middleware := Compress(config.CompressConfig{
 		IncludedPaths: []string{"/api/", "/compress/*"},

--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -53,11 +53,11 @@ func TestCORSPreflightRequest(t *testing.T) {
 		checkProblemDetail            bool
 		checkAllowHeader              bool
 	}{
-		{"valid", "https://example.com", http.MethodPost, "Content-Type", http.StatusNoContent, false, false, false},
+		{"valid", "https://example.com", http.MethodPost, httpx.HeaderContentType, http.StatusNoContent, false, false, false},
 		{"multiple headers", "https://example.com", http.MethodPut, "Content-Type, Authorization", http.StatusNoContent, false, false, false},
 		{"bad method", "https://example.com", http.MethodTrace, "", http.StatusMethodNotAllowed, false, true, true},
 		{"bad header", "https://example.com", http.MethodPost, "X-Custom-Header", http.StatusForbidden, false, true, false},
-		{"no origin", "", http.MethodPost, "Content-Type", http.StatusNoContent, false, false, false},
+		{"no origin", "", http.MethodPost, httpx.HeaderContentType, http.StatusNoContent, false, false, false},
 	}
 	mw := CORS()
 	for _, tt := range tests {
@@ -233,13 +233,13 @@ func TestCORSCustomConfig(t *testing.T) {
 	mw := CORS(config.CORSConfig{
 		AllowedOrigins: []string{"https://myapp.com"},
 		AllowedMethods: []string{http.MethodGet, http.MethodPost},
-		AllowedHeaders: []string{"Content-Type"},
+		AllowedHeaders: []string{httpx.HeaderContentType},
 		MaxAge:         3600,
 	})
 	req := httptest.NewRequest(http.MethodOptions, "/test", nil)
 	req.Header.Set(httpx.HeaderOrigin, "https://myapp.com")
 	req.Header.Set(httpx.HeaderAccessControlRequestMethod, http.MethodPost)
-	req.Header.Set(httpx.HeaderAccessControlRequestHeaders, "Content-Type")
+	req.Header.Set(httpx.HeaderAccessControlRequestHeaders, httpx.HeaderContentType)
 	rr := httptest.NewRecorder()
 	mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})).ServeHTTP(rr, req)
 
@@ -371,7 +371,7 @@ func TestCORS_Metrics(t *testing.T) {
 
 	// Test preflight request
 	req1 := httptest.NewRequest(http.MethodOptions, "/test", nil)
-	req1.Header.Set("Origin", "https://allowed.com")
+	req1.Header.Set(httpx.HeaderOrigin, "https://allowed.com")
 	req1.Header.Set(httpx.HeaderAccessControlRequestMethod, http.MethodPost)
 	rr1 := httptest.NewRecorder()
 	wrapped.ServeHTTP(rr1, req1)
@@ -382,7 +382,7 @@ func TestCORS_Metrics(t *testing.T) {
 
 	// Test allowed origin
 	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req2.Header.Set("Origin", "https://allowed.com")
+	req2.Header.Set(httpx.HeaderOrigin, "https://allowed.com")
 	rr2 := httptest.NewRecorder()
 	wrapped.ServeHTTP(rr2, req2)
 
@@ -392,7 +392,7 @@ func TestCORS_Metrics(t *testing.T) {
 
 	// Test rejected origin
 	req3 := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req3.Header.Set("Origin", "https://rejected.com")
+	req3.Header.Set(httpx.HeaderOrigin, "https://rejected.com")
 	rr3 := httptest.NewRecorder()
 	wrapped.ServeHTTP(rr3, req3)
 
@@ -500,11 +500,11 @@ func TestCORSAllowOriginFunc(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})).ServeHTTP(rr, req)
 
-			varyHeader := rr.Header().Get("Vary")
-			if tt.expectVary && varyHeader != "Origin" {
+			varyHeader := rr.Header().Get(httpx.HeaderVary)
+			if tt.expectVary && varyHeader != httpx.HeaderOrigin {
 				t.Errorf("expected Vary: Origin, got %s", varyHeader)
 			}
-			if !tt.expectVary && varyHeader == "Origin" {
+			if !tt.expectVary && varyHeader == httpx.HeaderOrigin {
 				t.Errorf("unexpected Vary: Origin header")
 			}
 
@@ -544,7 +544,7 @@ func TestCORSCustomOriginFuncWithCredentials(t *testing.T) {
 		t.Errorf("expected credentials header, got %s", got)
 	}
 
-	if got := rr.Header().Get("Vary"); got != "Origin" {
+	if got := rr.Header().Get(httpx.HeaderVary); got != httpx.HeaderOrigin {
 		t.Errorf("expected Vary: Origin, got %s", got)
 	}
 }

--- a/middleware/etag_test.go
+++ b/middleware/etag_test.go
@@ -26,7 +26,7 @@ func TestETag_GeneratesETag(t *testing.T) {
 
 	zhtest.AssertWith(t, rec).Status(http.StatusOK)
 
-	etag := rec.Header().Get("ETag")
+	etag := rec.Header().Get(httpx.HeaderETag)
 	if etag == "" {
 		t.Error("expected ETag header to be set")
 	}
@@ -47,7 +47,7 @@ func TestETag_NotModified(t *testing.T) {
 	rec1 := httptest.NewRecorder()
 	handler.ServeHTTP(rec1, req1)
 
-	etag := rec1.Header().Get("ETag")
+	etag := rec1.Header().Get(httpx.HeaderETag)
 	if etag == "" {
 		t.Fatal("expected ETag header to be set")
 	}
@@ -72,7 +72,7 @@ func TestETag_NotModified_MultipleETags(t *testing.T) {
 	rec1 := httptest.NewRecorder()
 	handler.ServeHTTP(rec1, req1)
 
-	etag := rec1.Header().Get("ETag")
+	etag := rec1.Header().Get(httpx.HeaderETag)
 
 	// Request with multiple ETags in If-None-Match
 	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -106,7 +106,7 @@ func TestETag_NoETagOnPOST(t *testing.T) {
 
 	handler.ServeHTTP(rec, req)
 
-	if rec.Header().Get("ETag") != "" {
+	if rec.Header().Get(httpx.HeaderETag) != "" {
 		t.Error("expected no ETag header for POST request")
 	}
 }
@@ -122,7 +122,7 @@ func TestETag_NoETagOnErrorStatus(t *testing.T) {
 
 	handler.ServeHTTP(rec, req)
 
-	if rec.Header().Get("ETag") != "" {
+	if rec.Header().Get(httpx.HeaderETag) != "" {
 		t.Error("expected no ETag header for error response")
 	}
 }
@@ -137,7 +137,7 @@ func TestETag_NoETagOnNoContent(t *testing.T) {
 
 	handler.ServeHTTP(rec, req)
 
-	if rec.Header().Get("ETag") != "" {
+	if rec.Header().Get(httpx.HeaderETag) != "" {
 		t.Error("expected no ETag header for 204 response")
 	}
 }
@@ -153,14 +153,14 @@ func TestETag_NoETagOnStreamingContent(t *testing.T) {
 
 	handler.ServeHTTP(rec, req)
 
-	if rec.Header().Get("ETag") != "" {
+	if rec.Header().Get(httpx.HeaderETag) != "" {
 		t.Error("expected no ETag header for SSE streaming content")
 	}
 }
 
 func TestETag_NoETagOnNoStore(t *testing.T) {
 	handler := ETag()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set(httpx.HeaderCacheControl, httpx.CacheControlNoStore)
 		_, _ = w.Write([]byte("hello"))
 	}))
 
@@ -169,7 +169,7 @@ func TestETag_NoETagOnNoStore(t *testing.T) {
 
 	handler.ServeHTTP(rec, req)
 
-	if rec.Header().Get("ETag") != "" {
+	if rec.Header().Get(httpx.HeaderETag) != "" {
 		t.Error("expected no ETag header when Cache-Control: no-store")
 	}
 }
@@ -185,8 +185,8 @@ func TestETag_PreservesExistingETag(t *testing.T) {
 
 	handler.ServeHTTP(rec, req)
 
-	if rec.Header().Get("ETag") != `"custom-etag"` {
-		t.Errorf("expected custom ETag to be preserved, got %s", rec.Header().Get("ETag"))
+	if rec.Header().Get(httpx.HeaderETag) != `"custom-etag"` {
+		t.Errorf("expected custom ETag to be preserved, got %s", rec.Header().Get(httpx.HeaderETag))
 	}
 }
 
@@ -200,7 +200,7 @@ func TestETag_StrongETag(t *testing.T) {
 
 	handler.ServeHTTP(rec, req)
 
-	etag := rec.Header().Get("ETag")
+	etag := rec.Header().Get(httpx.HeaderETag)
 	if strings.HasPrefix(etag, `W/`) {
 		t.Errorf("expected strong ETag without W/ prefix, got %s", etag)
 	}
@@ -220,12 +220,12 @@ func TestETag_MD5Algorithm(t *testing.T) {
 	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec1 := httptest.NewRecorder()
 	fnvHandler.ServeHTTP(rec1, req1)
-	fnvETag := rec1.Header().Get("ETag")
+	fnvETag := rec1.Header().Get(httpx.HeaderETag)
 
 	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec2 := httptest.NewRecorder()
 	md5Handler.ServeHTTP(rec2, req2)
-	md5ETag := rec2.Header().Get("ETag")
+	md5ETag := rec2.Header().Get(httpx.HeaderETag)
 
 	if fnvETag == md5ETag {
 		t.Error("expected different ETags for FNV and MD5 algorithms")
@@ -247,7 +247,7 @@ func TestETag_ExcludedPaths(t *testing.T) {
 	rec1 := httptest.NewRecorder()
 	handler.ServeHTTP(rec1, req1)
 
-	if rec1.Header().Get("ETag") != "" {
+	if rec1.Header().Get(httpx.HeaderETag) != "" {
 		t.Error("expected no ETag header for excluded path")
 	}
 
@@ -256,7 +256,7 @@ func TestETag_ExcludedPaths(t *testing.T) {
 	rec2 := httptest.NewRecorder()
 	handler.ServeHTTP(rec2, req2)
 
-	if rec2.Header().Get("ETag") == "" {
+	if rec2.Header().Get(httpx.HeaderETag) == "" {
 		t.Error("expected ETag header for non-excluded path")
 	}
 }
@@ -276,7 +276,7 @@ func TestETag_ExcludedFunc(t *testing.T) {
 	rec1 := httptest.NewRecorder()
 	handler.ServeHTTP(rec1, req1)
 
-	if rec1.Header().Get("ETag") != "" {
+	if rec1.Header().Get(httpx.HeaderETag) != "" {
 		t.Error("expected no ETag header when excluded func returns true")
 	}
 
@@ -285,7 +285,7 @@ func TestETag_ExcludedFunc(t *testing.T) {
 	rec2 := httptest.NewRecorder()
 	handler.ServeHTTP(rec2, req2)
 
-	if rec2.Header().Get("ETag") == "" {
+	if rec2.Header().Get(httpx.HeaderETag) == "" {
 		t.Error("expected ETag header when excluded func returns false")
 	}
 }
@@ -300,7 +300,7 @@ func TestETag_SkipContentTypes(t *testing.T) {
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
-	if rec.Header().Get("ETag") != "" {
+	if rec.Header().Get(httpx.HeaderETag) != "" {
 		t.Error("expected no ETag header for skipped content type")
 	}
 }
@@ -315,7 +315,7 @@ func TestETag_SkipStatusCodes(t *testing.T) {
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
-	if rec.Header().Get("ETag") != "" {
+	if rec.Header().Get(httpx.HeaderETag) != "" {
 		t.Error("expected no ETag header for skipped status code")
 	}
 }
@@ -337,7 +337,7 @@ func TestETag_MaxBufferSize(t *testing.T) {
 		t.Error("expected full response body even when buffer exceeded")
 	}
 
-	if rec.Header().Get("ETag") != "" {
+	if rec.Header().Get(httpx.HeaderETag) != "" {
 		t.Error("expected no ETag when content exceeds max buffer size")
 	}
 }
@@ -352,7 +352,7 @@ func TestETag_HEADRequest(t *testing.T) {
 
 	handler.ServeHTTP(rec, req)
 
-	etag := rec.Header().Get("ETag")
+	etag := rec.Header().Get(httpx.HeaderETag)
 	if etag == "" {
 		t.Error("expected ETag header for HEAD request")
 	}
@@ -368,12 +368,12 @@ func TestETag_ChangedContent(t *testing.T) {
 	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec1 := httptest.NewRecorder()
 	handler.ServeHTTP(rec1, req1)
-	etag1 := rec1.Header().Get("ETag")
+	etag1 := rec1.Header().Get(httpx.HeaderETag)
 
 	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec2 := httptest.NewRecorder()
 	handler.ServeHTTP(rec2, req2)
-	etag2 := rec2.Header().Get("ETag")
+	etag2 := rec2.Header().Get(httpx.HeaderETag)
 
 	if etag1 == etag2 {
 		t.Error("expected different ETags for different content")
@@ -399,7 +399,7 @@ func TestETag_NotModified_StrongVsWeak(t *testing.T) {
 	handler.ServeHTTP(rec1, req1)
 
 	// Extract just the hash part from the weak ETag (remove W/ prefix and quotes)
-	weakETag := rec1.Header().Get("ETag")
+	weakETag := rec1.Header().Get(httpx.HeaderETag)
 	hashPart := weakETag[3 : len(weakETag)-1] // Remove W/" and "
 	strongETag := `"` + hashPart + `"`
 
@@ -421,7 +421,7 @@ func TestETag_DefaultConfig(t *testing.T) {
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
-	if rec.Header().Get("ETag") == "" {
+	if rec.Header().Get(httpx.HeaderETag) == "" {
 		t.Error("expected ETag header")
 	}
 }
@@ -442,12 +442,12 @@ func TestETag_ContentEncodingAware(t *testing.T) {
 	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec1 := httptest.NewRecorder()
 	handlerGzip.ServeHTTP(rec1, req1)
-	etagGzip := rec1.Header().Get("ETag")
+	etagGzip := rec1.Header().Get(httpx.HeaderETag)
 
 	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec2 := httptest.NewRecorder()
 	handlerPlain.ServeHTTP(rec2, req2)
-	etagPlain := rec2.Header().Get("ETag")
+	etagPlain := rec2.Header().Get(httpx.HeaderETag)
 
 	if etagGzip == etagPlain {
 		t.Error("expected different ETags for gzip vs plain content")
@@ -464,7 +464,7 @@ func TestETag_ContentEncodingNotModified(t *testing.T) {
 	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec1 := httptest.NewRecorder()
 	handler.ServeHTTP(rec1, req1)
-	etag := rec1.Header().Get("ETag")
+	etag := rec1.Header().Get(httpx.HeaderETag)
 
 	// Second request with matching If-None-Match
 	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -486,7 +486,7 @@ func TestETag_IfRange_MatchingETag(t *testing.T) {
 	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec1 := httptest.NewRecorder()
 	handler.ServeHTTP(rec1, req1)
-	etag := rec1.Header().Get("ETag")
+	etag := rec1.Header().Get(httpx.HeaderETag)
 
 	// Range request with matching If-Range
 	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -630,7 +630,7 @@ func TestETag_Range_OpenEnded(t *testing.T) {
 	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec1 := httptest.NewRecorder()
 	handler.ServeHTTP(rec1, req1)
-	etag := rec1.Header().Get("ETag")
+	etag := rec1.Header().Get(httpx.HeaderETag)
 
 	// Range request with open-ended range (bytes=5-)
 	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -653,7 +653,7 @@ func TestETag_Range_InvalidRange(t *testing.T) {
 	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec1 := httptest.NewRecorder()
 	handler.ServeHTTP(rec1, req1)
-	etag := rec1.Header().Get("ETag")
+	etag := rec1.Header().Get(httpx.HeaderETag)
 
 	// Range request with invalid range (start > end)
 	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -679,7 +679,7 @@ func TestETag_IfMatch_Matches(t *testing.T) {
 	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec1 := httptest.NewRecorder()
 	handler.ServeHTTP(rec1, req1)
-	etag := rec1.Header().Get("ETag")
+	etag := rec1.Header().Get(httpx.HeaderETag)
 
 	// Request with matching If-Match should succeed
 	req2 := httptest.NewRequest(http.MethodPut, "/", nil)
@@ -786,7 +786,7 @@ func TestETag_FlushPreventsDoubleWrite(t *testing.T) {
 	}
 
 	// Also verify the ETag was generated correctly
-	etag := rec.Header().Get("ETag")
+	etag := rec.Header().Get(httpx.HeaderETag)
 	if etag == "" {
 		t.Error("expected ETag header to be set")
 	}
@@ -803,7 +803,7 @@ func TestETag_Range_InvalidFormat(t *testing.T) {
 	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec1 := httptest.NewRecorder()
 	handler.ServeHTTP(rec1, req1)
-	etag := rec1.Header().Get("ETag")
+	etag := rec1.Header().Get(httpx.HeaderETag)
 
 	// Range request with invalid format (missing dash)
 	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -825,7 +825,7 @@ func TestETag_Range_NonNumericStart(t *testing.T) {
 	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec1 := httptest.NewRecorder()
 	handler.ServeHTTP(rec1, req1)
-	etag := rec1.Header().Get("ETag")
+	etag := rec1.Header().Get(httpx.HeaderETag)
 
 	// Range request with non-numeric start
 	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -847,7 +847,7 @@ func TestETag_Range_NonNumericEnd(t *testing.T) {
 	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec1 := httptest.NewRecorder()
 	handler.ServeHTTP(rec1, req1)
-	etag := rec1.Header().Get("ETag")
+	etag := rec1.Header().Get(httpx.HeaderETag)
 
 	// Range request with non-numeric end
 	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -872,7 +872,7 @@ func TestETag_InvalidAlgorithm(t *testing.T) {
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
-	if rec.Header().Get("ETag") == "" {
+	if rec.Header().Get(httpx.HeaderETag) == "" {
 		t.Error("expected ETag header even with invalid algorithm")
 	}
 }
@@ -934,7 +934,7 @@ func TestServeContentWithETag_ServesContent(t *testing.T) {
 
 	zhtest.AssertWith(t, rec).Status(http.StatusOK)
 
-	if rec.Header().Get("ETag") == "" {
+	if rec.Header().Get(httpx.HeaderETag) == "" {
 		t.Error("expected ETag header")
 	}
 }
@@ -999,7 +999,7 @@ func TestETag_EmptyBody(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	// Empty body should not generate ETag
-	etag := rec.Header().Get("ETag")
+	etag := rec.Header().Get(httpx.HeaderETag)
 	// ETag might be empty or a valid hash of empty content depending on implementation
 	// The important thing is it doesn't panic
 	_ = etag
@@ -1043,7 +1043,7 @@ func TestETag_ExcludedPaths_PrefixMatch(t *testing.T) {
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
-	if rec.Header().Get("ETag") != "" {
+	if rec.Header().Get(httpx.HeaderETag) != "" {
 		t.Error("expected no ETag header for excluded path prefix")
 	}
 }
@@ -1144,7 +1144,7 @@ func TestETag_PUTWithoutIfMatch(t *testing.T) {
 	zhtest.AssertWith(t, rec).Status(http.StatusOK)
 
 	// No ETag generated for non-GET/HEAD
-	if rec.Header().Get("ETag") != "" {
+	if rec.Header().Get(httpx.HeaderETag) != "" {
 		t.Error("expected no ETag for PUT without If-Match")
 	}
 }
@@ -1207,7 +1207,7 @@ func TestETag_NilSkipContentTypes(t *testing.T) {
 	zhtest.AssertWith(t, rec).Status(http.StatusOK)
 
 	// Should generate ETag even with nil SkipContentTypes
-	if rec.Header().Get("ETag") == "" {
+	if rec.Header().Get(httpx.HeaderETag) == "" {
 		t.Error("expected ETag header")
 	}
 }
@@ -1215,7 +1215,7 @@ func TestETag_NilSkipContentTypes(t *testing.T) {
 func TestETag_ChunkedTransferEncoding(t *testing.T) {
 	// Chunked transfer encoding should skip ETag
 	handler := ETag()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Transfer-Encoding", "chunked")
+		w.Header().Set(httpx.HeaderTransferEncoding, httpx.TransferEncodingChunked)
 		_, _ = w.Write([]byte("chunked data"))
 	}))
 
@@ -1224,7 +1224,7 @@ func TestETag_ChunkedTransferEncoding(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	// Should not generate ETag for chunked responses
-	if rec.Header().Get("ETag") != "" {
+	if rec.Header().Get(httpx.HeaderETag) != "" {
 		t.Error("expected no ETag for chunked transfer encoding")
 	}
 
@@ -1258,7 +1258,7 @@ func TestETag_Metrics(t *testing.T) {
 		t.Errorf("expected 200, got %d", rr1.Code)
 	}
 
-	etag := rr1.Header().Get("ETag")
+	etag := rr1.Header().Get(httpx.HeaderETag)
 	if etag == "" {
 		t.Fatal("expected ETag")
 	}
@@ -1383,7 +1383,7 @@ func TestETag_IncludedPaths(t *testing.T) {
 	rec1 := httptest.NewRecorder()
 	handler.ServeHTTP(rec1, req1)
 
-	if rec1.Header().Get("ETag") == "" {
+	if rec1.Header().Get(httpx.HeaderETag) == "" {
 		t.Error("expected ETag header for allowed path")
 	}
 
@@ -1392,7 +1392,7 @@ func TestETag_IncludedPaths(t *testing.T) {
 	rec2 := httptest.NewRecorder()
 	handler.ServeHTTP(rec2, req2)
 
-	if rec2.Header().Get("ETag") != "" {
+	if rec2.Header().Get(httpx.HeaderETag) != "" {
 		t.Error("expected no ETag header for non-allowed path")
 	}
 }

--- a/middleware/hmac_auth_test.go
+++ b/middleware/hmac_auth_test.go
@@ -1345,13 +1345,13 @@ func TestHMACAuth_HeaderTampering_Detected(t *testing.T) {
 
 	// Sign a request with specific headers
 	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
-	req.Header.Set(httpx.HeaderXRequestID, "original-request-id")
+	req.Header.Set(httpx.HeaderXRequestId, "original-request-id")
 	if err := signer.SignRequest(req); err != nil {
 		t.Fatalf("failed to sign request: %v", err)
 	}
 
 	// Tamper with the header after signing
-	req.Header.Set(httpx.HeaderXRequestID, "tampered-request-id")
+	req.Header.Set(httpx.HeaderXRequestId, "tampered-request-id")
 
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)

--- a/middleware/hmac_signer_test.go
+++ b/middleware/hmac_signer_test.go
@@ -281,7 +281,7 @@ func TestHMACSigner_CustomHeadersRoundTrip(t *testing.T) {
 	signer.SetHeadersToSign([]string{"host", "x-timestamp", "x-request-id"})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
-	req.Header.Set(httpx.HeaderXRequestID, "test-request-123")
+	req.Header.Set(httpx.HeaderXRequestId, "test-request-123")
 	if err := signer.SignRequest(req); err != nil {
 		t.Fatalf("failed to sign request: %v", err)
 	}

--- a/middleware/idempotency_bench_test.go
+++ b/middleware/idempotency_bench_test.go
@@ -92,7 +92,7 @@ func BenchmarkIdempotency_HeaderReplay(b *testing.B) {
 		for j := 0; j < len(record.Headers)-1; j += 2 {
 			w.Header().Add(record.Headers[j], record.Headers[j+1])
 		}
-		w.Header().Set("X-Idempotency-Replay", "true")
+		w.Header().Set(httpx.HeaderXIdempotencyReplay, "true")
 		w.WriteHeader(record.StatusCode)
 		_, _ = w.Write(record.Body)
 	}

--- a/middleware/idempotency_test.go
+++ b/middleware/idempotency_test.go
@@ -39,7 +39,7 @@ func TestIdempotency_Basic(t *testing.T) {
 		if callCount != 1 {
 			t.Errorf("Expected 1 handler call, got %d", callCount)
 		}
-		if w1.Header().Get("X-Idempotency-Replay") != "" {
+		if w1.Header().Get(httpx.HeaderXIdempotencyReplay) != "" {
 			t.Error("First request should not have X-Idempotency-Replay header")
 		}
 
@@ -53,7 +53,7 @@ func TestIdempotency_Basic(t *testing.T) {
 		if callCount != 1 {
 			t.Errorf("Expected still 1 handler call, got %d (should be cached)", callCount)
 		}
-		if w2.Header().Get("X-Idempotency-Replay") != "true" {
+		if w2.Header().Get(httpx.HeaderXIdempotencyReplay) != "true" {
 			t.Error("Replayed request should have X-Idempotency-Replay: true header")
 		}
 		if w2.Header().Get("X-Custom") != "value" {
@@ -324,7 +324,7 @@ func TestIdempotency_CustomHeaderName(t *testing.T) {
 		if callCount != 1 {
 			t.Errorf("Expected 1 handler call (cached), got %d", callCount)
 		}
-		if w2.Header().Get("X-Idempotency-Replay") != "true" {
+		if w2.Header().Get(httpx.HeaderXIdempotencyReplay) != "true" {
 			t.Error("Expected X-Idempotency-Replay header on replay")
 		}
 	})
@@ -403,7 +403,7 @@ func TestIdempotency_ConcurrentLock(t *testing.T) {
 		if w2.Code != http.StatusCreated {
 			t.Errorf("Expected 201 for second request, got %d", w2.Code)
 		}
-		if w2.Header().Get("X-Idempotency-Replay") != "true" {
+		if w2.Header().Get(httpx.HeaderXIdempotencyReplay) != "true" {
 			t.Error("Second request should have X-Idempotency-Replay: true header")
 		}
 		if w2.Header().Get("X-Handler") != "first" {
@@ -627,7 +627,7 @@ func TestIdempotency_NoDuplicateHeaders(t *testing.T) {
 
 		// Simulate middleware that sets headers before idempotency
 		w1.Header().Set("X-Security-Header", "security-value")
-		w1.Header().Set("X-Request-Id", "req-123")
+		w1.Header().Set(httpx.HeaderXRequestId, "req-123")
 
 		idempotencyMiddleware(handler).ServeHTTP(w1, req1)
 
@@ -638,7 +638,7 @@ func TestIdempotency_NoDuplicateHeaders(t *testing.T) {
 
 		// Simulate same middleware setting headers before idempotency replay
 		w2.Header().Set("X-Security-Header", "security-value")
-		w2.Header().Set("X-Request-Id", "req-456") // Different request ID
+		w2.Header().Set(httpx.HeaderXRequestId, "req-456") // Different request ID
 
 		idempotencyMiddleware(handler).ServeHTTP(w2, req2)
 
@@ -648,7 +648,7 @@ func TestIdempotency_NoDuplicateHeaders(t *testing.T) {
 			t.Errorf("X-Security-Header should appear once, got %d: %v", len(securityHeaders), securityHeaders)
 		}
 
-		requestIds := w2.Header()["X-Request-Id"]
+		requestIds := w2.Header()[httpx.HeaderXRequestId]
 		if len(requestIds) != 1 {
 			t.Errorf("X-Request-Id should appear once, got %d: %v", len(requestIds), requestIds)
 		}
@@ -662,7 +662,7 @@ func TestIdempotency_NoDuplicateHeaders(t *testing.T) {
 			t.Error("X-Custom header should be replayed from cache")
 		}
 
-		if w2.Header().Get("X-Idempotency-Replay") != "true" {
+		if w2.Header().Get(httpx.HeaderXIdempotencyReplay) != "true" {
 			t.Error("Expected X-Idempotency-Replay header on replay")
 		}
 	})
@@ -758,7 +758,7 @@ func TestIdempotency_HandlerWritesNothing(t *testing.T) {
 		if callCount != 1 {
 			t.Errorf("Expected 1 handler call (cached), got %d", callCount)
 		}
-		if w2.Header().Get("X-Idempotency-Replay") != "true" {
+		if w2.Header().Get(httpx.HeaderXIdempotencyReplay) != "true" {
 			t.Error("Expected X-Idempotency-Replay header on replay")
 		}
 	})
@@ -956,8 +956,8 @@ func TestIdempotency_WriteHeaderHopByHop(t *testing.T) {
 		callCount := 0
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			callCount++
-			w.Header().Set("Connection", "keep-alive")
-			w.Header().Set("Keep-Alive", "timeout=5")
+			w.Header().Set(httpx.HeaderConnection, httpx.ConnectionKeepAlive)
+			w.Header().Set(httpx.HeaderKeepAlive, "timeout=5")
 			w.Header().Set("X-Custom", "value")
 			w.WriteHeader(http.StatusCreated)
 			_, _ = w.Write([]byte(`{"id":"123"}`))
@@ -980,10 +980,10 @@ func TestIdempotency_WriteHeaderHopByHop(t *testing.T) {
 		idempotencyMiddleware(handler).ServeHTTP(w2, req2)
 
 		// Hop-by-hop headers should not be replayed
-		if w2.Header().Get("Connection") != "" {
+		if w2.Header().Get(httpx.HeaderConnection) != "" {
 			t.Error("Connection header should not be replayed (hop-by-hop)")
 		}
-		if w2.Header().Get("Keep-Alive") != "" {
+		if w2.Header().Get(httpx.HeaderKeepAlive) != "" {
 			t.Error("Keep-Alive header should not be replayed (hop-by-hop)")
 		}
 		// Custom header should be replayed
@@ -1047,7 +1047,7 @@ func TestIdempotency_IncludedPaths(t *testing.T) {
 		if callCount != 1 {
 			t.Errorf("Expected 1 handler call for allowed path (cached), got %d", callCount)
 		}
-		if w2.Header().Get("X-Idempotency-Replay") != "true" {
+		if w2.Header().Get(httpx.HeaderXIdempotencyReplay) != "true" {
 			t.Error("Replayed request should have X-Idempotency-Replay header")
 		}
 

--- a/middleware/no_cache_test.go
+++ b/middleware/no_cache_test.go
@@ -32,10 +32,10 @@ func TestNoCacheResponseHeaders(t *testing.T) {
 	w := zhtest.Serve(middleware(next), req)
 
 	expectedHeaders := map[string]string{
-		"Expires":         config.Epoch,
-		"Cache-Control":   "no-cache, no-store, no-transform, must-revalidate, private, max-age=0",
-		"Pragma":          "no-cache",
-		"X-Accel-Expires": "0",
+		httpx.HeaderExpires:       config.Epoch,
+		httpx.HeaderCacheControl:  "no-cache, no-store, no-transform, must-revalidate, private, max-age=0",
+		httpx.HeaderPragma:        "no-cache",
+		httpx.HeaderXAccelExpires: "0",
 	}
 	for header, expected := range expectedHeaders {
 		if got := w.Header().Get(header); got != expected {
@@ -48,21 +48,21 @@ func TestNoCacheResponseHeaders(t *testing.T) {
 func TestNoCacheRequestHeaderRemoval(t *testing.T) {
 	middleware := NoCache()
 	headers := map[string]string{
-		"ETag":                `"abc123"`,
-		"If-Modified-Since":   "Wed, 21 Oct 2015 07:28:00 GMT",
-		"If-Match":            `"abc123"`,
-		"If-None-Match":       `"def456"`,
-		"If-Range":            `"ghi789"`,
-		"If-Unmodified-Since": "Wed, 21 Oct 2015 07:28:00 GMT",
-		"User-Agent":          "test-agent",
+		httpx.HeaderETag:              `"abc123"`,
+		httpx.HeaderIfModifiedSince:   "Wed, 21 Oct 2015 07:28:00 GMT",
+		httpx.HeaderIfMatch:           `"abc123"`,
+		httpx.HeaderIfNoneMatch:       `"def456"`,
+		httpx.HeaderIfRange:           `"ghi789"`,
+		httpx.HeaderIfUnmodifiedSince: "Wed, 21 Oct 2015 07:28:00 GMT",
+		httpx.HeaderUserAgent:         "test-agent",
 	}
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		for _, header := range []string{"ETag", "If-Modified-Since", "If-Match", "If-None-Match", "If-Range", "If-Unmodified-Since"} {
+		for _, header := range []string{httpx.HeaderETag, httpx.HeaderIfModifiedSince, httpx.HeaderIfMatch, httpx.HeaderIfNoneMatch, httpx.HeaderIfRange, httpx.HeaderIfUnmodifiedSince} {
 			if value := r.Header.Get(header); value != "" {
 				t.Errorf("expected %s header to be removed, but got %s", header, value)
 			}
 		}
-		if userAgent := r.Header.Get("User-Agent"); userAgent != "test-agent" {
+		if userAgent := r.Header.Get(httpx.HeaderUserAgent); userAgent != "test-agent" {
 			t.Errorf("expected User-Agent to remain, got %s", userAgent)
 		}
 		w.WriteHeader(http.StatusOK)
@@ -74,31 +74,34 @@ func TestNoCacheRequestHeaderRemoval(t *testing.T) {
 func TestNoCacheCustomConfig(t *testing.T) {
 	middleware := NoCache(config.NoCacheConfig{
 		NoCacheHeaders: map[string]string{
-			"Cache-Control": "no-cache",
-			"Expires":       "0",
+			httpx.HeaderCacheControl: httpx.CacheControlNoCache,
+			httpx.HeaderExpires:      "0",
 		},
-		ETagHeaders: []string{"ETag", "If-None-Match"},
+		ETagHeaders: []string{httpx.HeaderETag, httpx.HeaderIfNoneMatch},
 	})
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if etag := r.Header.Get("ETag"); etag != "" {
+		if etag := r.Header.Get(httpx.HeaderETag); etag != "" {
 			t.Errorf("expected ETag to be removed, got %s", etag)
 		}
-		if ifNoneMatch := r.Header.Get("If-None-Match"); ifNoneMatch != "" {
+		if ifNoneMatch := r.Header.Get(httpx.HeaderIfNoneMatch); ifNoneMatch != "" {
 			t.Errorf("expected If-None-Match to be removed, got %s", ifNoneMatch)
 		}
-		if ifModified := r.Header.Get("If-Modified-Since"); ifModified == "" {
+		if ifModified := r.Header.Get(httpx.HeaderIfModifiedSince); ifModified == "" {
 			t.Error("expected If-Modified-Since to remain")
 		}
 		w.WriteHeader(http.StatusOK)
 	})
 	req := zhtest.NewRequest(http.MethodGet, "/test").
-		WithHeader("ETag", `"test123"`).
-		WithHeader("If-None-Match", `"test456"`).
-		WithHeader("If-Modified-Since", "Wed, 21 Oct 2015 07:28:00 GMT").
+		WithHeader(httpx.HeaderETag, `"test123"`).
+		WithHeader(httpx.HeaderIfNoneMatch, `"test456"`).
+		WithHeader(httpx.HeaderIfModifiedSince, "Wed, 21 Oct 2015 07:28:00 GMT").
 		Build()
 	w := zhtest.Serve(middleware(next), req)
 
-	zhtest.AssertWith(t, w).Header("Cache-Control", "no-cache").Header("Expires", "0").HeaderNotExists("Pragma")
+	zhtest.AssertWith(t, w).
+		Header(httpx.HeaderCacheControl, httpx.CacheControlNoCache).
+		Header(httpx.HeaderExpires, "0").
+		HeaderNotExists(httpx.HeaderPragma)
 }
 
 func TestNoCacheNilConfig(t *testing.T) {
@@ -107,15 +110,15 @@ func TestNoCacheNilConfig(t *testing.T) {
 		ETagHeaders:    nil,
 	})
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if etag := r.Header.Get("ETag"); etag != "" {
+		if etag := r.Header.Get(httpx.HeaderETag); etag != "" {
 			t.Errorf("expected ETag to be removed with nil config, got %s", etag)
 		}
 		w.WriteHeader(http.StatusOK)
 	})
-	req := zhtest.NewRequest(http.MethodGet, "/test").WithHeader("ETag", `"test123"`).Build()
+	req := zhtest.NewRequest(http.MethodGet, "/test").WithHeader(httpx.HeaderETag, `"test123"`).Build()
 	w := zhtest.Serve(middleware(next), req)
 
-	for _, header := range []string{"Expires", "Cache-Control", "Pragma", "X-Accel-Expires"} {
+	for _, header := range []string{httpx.HeaderExpires, httpx.HeaderCacheControl, httpx.HeaderPragma, httpx.HeaderXAccelExpires} {
 		zhtest.AssertWith(t, w).HeaderExists(header)
 	}
 }
@@ -126,16 +129,16 @@ func TestNoCacheHTTPMethods(t *testing.T) {
 	for _, method := range methods {
 		t.Run(method, func(t *testing.T) {
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if etag := r.Header.Get("ETag"); etag != "" {
+				if etag := r.Header.Get(httpx.HeaderETag); etag != "" {
 					t.Errorf("expected ETag to be removed for %s method, got %s", method, etag)
 				}
 				w.WriteHeader(http.StatusOK)
 			})
 
-			req := zhtest.NewRequest(method, "/test").WithHeader("ETag", `"test123"`).Build()
+			req := zhtest.NewRequest(method, "/test").WithHeader(httpx.HeaderETag, `"test123"`).Build()
 			w := zhtest.Serve(middleware(next), req)
 
-			zhtest.AssertWith(t, w).HeaderExists("Cache-Control").Status(http.StatusOK)
+			zhtest.AssertWith(t, w).HeaderExists(httpx.HeaderCacheControl).Status(http.StatusOK)
 		})
 	}
 }
@@ -146,21 +149,21 @@ func TestNoCacheEmptyHeaders(t *testing.T) {
 		ETagHeaders:    []string{},
 	})
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if etag := r.Header.Get("ETag"); etag != `"test123"` {
+		if etag := r.Header.Get(httpx.HeaderETag); etag != `"test123"` {
 			t.Errorf("expected ETag to remain with empty config, got %s", etag)
 		}
-		if ifNoneMatch := r.Header.Get("If-None-Match"); ifNoneMatch != `"test456"` {
+		if ifNoneMatch := r.Header.Get(httpx.HeaderIfNoneMatch); ifNoneMatch != `"test456"` {
 			t.Errorf("expected If-None-Match to remain with empty config, got %s", ifNoneMatch)
 		}
 		w.WriteHeader(http.StatusOK)
 	})
 	req := zhtest.NewRequest(http.MethodGet, "/test").
-		WithHeader("ETag", `"test123"`).
-		WithHeader("If-None-Match", `"test456"`).
+		WithHeader(httpx.HeaderETag, `"test123"`).
+		WithHeader(httpx.HeaderIfNoneMatch, `"test456"`).
 		Build()
 	w := zhtest.Serve(middleware(next), req)
 
-	for _, header := range []string{"Expires", "Cache-Control", "Pragma", "X-Accel-Expires"} {
+	for _, header := range []string{httpx.HeaderExpires, httpx.HeaderCacheControl, httpx.HeaderPragma, httpx.HeaderXAccelExpires} {
 		zhtest.AssertWith(t, w).HeaderNotExists(header)
 	}
 }
@@ -168,20 +171,20 @@ func TestNoCacheEmptyHeaders(t *testing.T) {
 func TestNoCacheOnlyExistingHeaders(t *testing.T) {
 	middleware := NoCache()
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if ifMatch := r.Header.Get("If-Match"); ifMatch != "" {
+		if ifMatch := r.Header.Get(httpx.HeaderIfMatch); ifMatch != "" {
 			t.Errorf("expected If-Match to be removed, got %s", ifMatch)
 		}
-		if userAgent := r.Header.Get("User-Agent"); userAgent != "test-agent" {
+		if userAgent := r.Header.Get(httpx.HeaderUserAgent); userAgent != "test-agent" {
 			t.Errorf("expected User-Agent to remain, got %s", userAgent)
 		}
-		if etag := r.Header.Get("ETag"); etag != "" {
+		if etag := r.Header.Get(httpx.HeaderETag); etag != "" {
 			t.Errorf("expected ETag to remain empty, got %s", etag)
 		}
 		w.WriteHeader(http.StatusOK)
 	})
 	req := zhtest.NewRequest(http.MethodGet, "/test").
-		WithHeader("If-Match", `"abc123"`).
-		WithHeader("User-Agent", "test-agent").
+		WithHeader(httpx.HeaderIfMatch, `"abc123"`).
+		WithHeader(httpx.HeaderUserAgent, "test-agent").
 		Build()
 	zhtest.Serve(middleware(next), req)
 }
@@ -189,7 +192,7 @@ func TestNoCacheOnlyExistingHeaders(t *testing.T) {
 func TestNoCacheResponseAndRequest(t *testing.T) {
 	middleware := NoCache()
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if ifNoneMatch := r.Header.Get("If-None-Match"); ifNoneMatch != "" {
+		if ifNoneMatch := r.Header.Get(httpx.HeaderIfNoneMatch); ifNoneMatch != "" {
 			t.Errorf("expected If-None-Match to be removed, got %s", ifNoneMatch)
 		}
 		if auth := r.Header.Get(httpx.HeaderAuthorization); auth != "Bearer token123" {
@@ -202,12 +205,12 @@ func TestNoCacheResponseAndRequest(t *testing.T) {
 	})
 
 	req := zhtest.NewRequest(http.MethodGet, "/api/data").
-		WithHeader("If-None-Match", `"cached-etag"`).
+		WithHeader(httpx.HeaderIfNoneMatch, `"cached-etag"`).
 		WithHeader(httpx.HeaderAuthorization, "Bearer token123").
 		Build()
 	w := zhtest.Serve(middleware(next), req)
 
-	if cacheControl := w.Header().Get("Cache-Control"); !strings.Contains(cacheControl, "no-cache") {
+	if cacheControl := w.Header().Get(httpx.HeaderCacheControl); !strings.Contains(cacheControl, "no-cache") {
 		t.Errorf("expected Cache-Control to contain no-cache, got %s", cacheControl)
 	}
 	zhtest.AssertWith(t, w).

--- a/middleware/request_body_size_test.go
+++ b/middleware/request_body_size_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/httpx"
 	"github.com/alexferl/zerohttp/metrics"
 	"github.com/alexferl/zerohttp/zhtest"
 )
@@ -324,7 +325,7 @@ func TestRequestBodySize_Flush_SupportsSSE(t *testing.T) {
 		}
 
 		// Write and flush like SSE would
-		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set(httpx.HeaderContentType, httpx.MIMETextEventStream)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("data: hello\n\n"))
 		f.Flush()

--- a/middleware/request_id_test.go
+++ b/middleware/request_id_test.go
@@ -7,23 +7,24 @@ import (
 	"testing"
 
 	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/httpx"
 	"github.com/alexferl/zerohttp/zhtest"
 )
 
 func TestRequestID_ExistingHeader(t *testing.T) {
 	handler := &testHandler{}
 	existingID := "existing-request-id-123"
-	req := zhtest.NewRequest(http.MethodGet, "/").WithHeader("X-Request-Id", existingID).Build()
+	req := zhtest.NewRequest(http.MethodGet, "/").WithHeader(httpx.HeaderXRequestId, existingID).Build()
 	w := zhtest.TestMiddlewareWithHandler(RequestID(), handler, req)
 
 	zhtest.AssertWith(t, w).Status(http.StatusOK)
 	if handler.requestID != existingID {
 		t.Errorf("Expected to use existing request ID %s, got %s", existingID, handler.requestID)
 	}
-	if reqHeaderValue := handler.request.Header.Get("X-Request-Id"); reqHeaderValue != existingID {
+	if reqHeaderValue := handler.request.Header.Get(httpx.HeaderXRequestId); reqHeaderValue != existingID {
 		t.Errorf("Expected request header to be %s, got %s", existingID, reqHeaderValue)
 	}
-	if respHeaderValue := w.Header().Get("X-Request-Id"); respHeaderValue != existingID {
+	if respHeaderValue := w.Header().Get(httpx.HeaderXRequestId); respHeaderValue != existingID {
 		t.Errorf("Expected response header to be %s, got %s", existingID, respHeaderValue)
 	}
 }
@@ -47,7 +48,7 @@ func TestRequestID_CustomHeader(t *testing.T) {
 	if reqHeaderValue != respHeaderValue {
 		t.Errorf("Expected request and response headers to match: %s != %s", reqHeaderValue, respHeaderValue)
 	}
-	zhtest.AssertWith(t, w).HeaderNotExists("X-Request-Id")
+	zhtest.AssertWith(t, w).HeaderNotExists(httpx.HeaderXRequestId)
 }
 
 func TestRequestID_CustomGenerator(t *testing.T) {
@@ -110,7 +111,7 @@ func TestRequestID_EmptyConfigValues(t *testing.T) {
 	w := zhtest.TestMiddlewareWithHandler(RequestID(config.RequestIDConfig{}), handler, req)
 
 	zhtest.AssertWith(t, w).Status(http.StatusOK)
-	zhtest.AssertWith(t, w).HeaderExists("X-Request-Id")
+	zhtest.AssertWith(t, w).HeaderExists(httpx.HeaderXRequestId)
 	if len(handler.requestID) != 32 {
 		t.Errorf("Expected default generated ID length 32, got %d", len(handler.requestID))
 	}
@@ -163,7 +164,7 @@ func TestGetRequestID_EdgeCases(t *testing.T) {
 
 func TestDefaultRequestIDConfig(t *testing.T) {
 	cfg := config.DefaultRequestIDConfig
-	if cfg.Header != "X-Request-Id" {
+	if cfg.Header != httpx.HeaderXRequestId {
 		t.Errorf("Expected default header 'X-Request-Id', got %s", cfg.Header)
 	}
 	if cfg.Generator == nil {

--- a/middleware/request_logger.go
+++ b/middleware/request_logger.go
@@ -125,7 +125,7 @@ func LogRequest(logger log.Logger, cfg config.RequestLoggerConfig, fieldMap map[
 		logFields = append(logFields, log.F("remote_addr", r.RemoteAddr))
 	}
 	if fieldMap[config.FieldRequestID] {
-		if requestID := r.Header.Get(httpx.HeaderXRequestID); requestID != "" {
+		if requestID := r.Header.Get(httpx.HeaderXRequestId); requestID != "" {
 			logFields = append(logFields, log.F("request_id", requestID))
 		}
 	}

--- a/middleware/request_logger_bench_test.go
+++ b/middleware/request_logger_bench_test.go
@@ -55,7 +55,7 @@ func BenchmarkRequestLogger_FieldConfiguration(b *testing.B) {
 			}))
 
 			req := httptest.NewRequest(http.MethodGet, "/test", nil)
-			req.Header.Set(httpx.HeaderXRequestID, "test-123")
+			req.Header.Set(httpx.HeaderXRequestId, "test-123")
 
 			b.ReportAllocs()
 			b.ResetTimer()
@@ -396,7 +396,7 @@ func BenchmarkRequestLogger_LogRequest(b *testing.B) {
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/api/users", nil)
-	req.Header.Set(httpx.HeaderXRequestID, "test-123")
+	req.Header.Set(httpx.HeaderXRequestId, "test-123")
 
 	logger := &noopLogger{}
 

--- a/middleware/request_logger_test.go
+++ b/middleware/request_logger_test.go
@@ -954,7 +954,7 @@ func TestRequestLogger_Flush_SupportsSSE(t *testing.T) {
 		}
 
 		// Write and flush like SSE would
-		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set(httpx.HeaderContentType, httpx.MIMETextEventStream)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("data: hello\n\n"))
 		f.Flush()

--- a/middleware/security_headers_test.go
+++ b/middleware/security_headers_test.go
@@ -348,7 +348,7 @@ func TestSecurityHeaders_CSPNonceReportOnly(t *testing.T) {
 	zhtest.AssertWith(t, w).Status(http.StatusOK)
 	zhtest.AssertWith(t, w).HeaderNotExists(httpx.HeaderContentSecurityPolicy)
 
-	csp := w.Header().Get("Content-Security-Policy-Report-Only")
+	csp := w.Header().Get(httpx.HeaderContentSecurityPolicyReportOnly)
 	if !strings.Contains(csp, "'nonce-") {
 		t.Errorf("CSP-Report-Only header should contain nonce, got: %s", csp)
 	}

--- a/middleware/set_header_test.go
+++ b/middleware/set_header_test.go
@@ -92,7 +92,7 @@ func TestSetHeader_NilHeaders(t *testing.T) {
 func TestSetHeader_OverrideExistingHeaders(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set(httpx.HeaderContentType, httpx.MIMETextHTML)
-		w.Header().Set("Server", "Default-Server")
+		w.Header().Set(httpx.HeaderServer, "Default-Server")
 		w.WriteHeader(http.StatusOK)
 	})
 	req := zhtest.NewRequest(http.MethodGet, "/").Build()
@@ -111,7 +111,7 @@ func TestSetHeader_OverrideExistingHeaders(t *testing.T) {
 	if contentType := w.Header().Get(httpx.HeaderContentType); contentType != "text/html" {
 		t.Errorf("Expected Content-Type to be overridden to 'text/html', got '%s'", contentType)
 	}
-	if server := w.Header().Get("Server"); server != "Default-Server" {
+	if server := w.Header().Get(httpx.HeaderServer); server != "Default-Server" {
 		t.Errorf("Expected Server to be overridden to 'Default-Server', got '%s'", server)
 	}
 }

--- a/router.go
+++ b/router.go
@@ -77,7 +77,9 @@ func (h HandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// This prevents HTTP/2 "request body closed" errors when handlers
 	// (like templ) try to write during HEAD requests.
 	if r.Method == http.MethodHead {
-		w = &headResponseWriter{ResponseWriter: w}
+		hrw := &headResponseWriter{ResponseWriter: w}
+		w = hrw
+		defer func() { _ = hrw.Close() }() // Ensure Content-Length is set after handler completes
 	}
 
 	if err := h(w, r); err != nil {
@@ -150,17 +152,40 @@ func handleHandlerError(w http.ResponseWriter, err error) {
 	}
 }
 
-// headResponseWriter wraps a ResponseWriter and discards body writes for HEAD requests
+// headResponseWriter wraps a ResponseWriter and discards body writes for HEAD requests.
+// It buffers the response to determine Content-Length before writing headers.
 type headResponseWriter struct {
 	http.ResponseWriter
+	buf  []byte
+	code int
 }
 
 // Ensure headResponseWriter implements http.ResponseWriter
 var _ http.ResponseWriter = (*headResponseWriter)(nil)
 
 func (h *headResponseWriter) Write(p []byte) (int, error) {
-	// Discard body writes for HEAD requests
+	// Buffer the data instead of discarding immediately
+	h.buf = append(h.buf, p...)
 	return len(p), nil
+}
+
+func (h *headResponseWriter) WriteHeader(code int) {
+	h.code = code
+	// Don't write headers yet - we'll do it in Close()
+}
+
+// Close writes the headers with Content-Length and discards the body.
+// This must be called after the handler completes.
+func (h *headResponseWriter) Close() error {
+	if h.code == 0 {
+		h.code = http.StatusOK
+	}
+	// Set Content-Length based on buffered bytes
+	if len(h.buf) > 0 {
+		h.Header().Set(httpx.HeaderContentLength, fmt.Sprintf("%d", len(h.buf)))
+	}
+	h.ResponseWriter.WriteHeader(h.code)
+	return nil
 }
 
 // Flush implements http.Flusher to support streaming responses like SSE.

--- a/router_test.go
+++ b/router_test.go
@@ -163,6 +163,53 @@ func TestHandlerFunc(t *testing.T) {
 		}
 	})
 
+	// Test that headResponseWriter calls WriteHeader on underlying ResponseWriter
+	// This ensures middleware like compress can set headers even for HEAD requests
+	t.Run("headResponseWriter calls WriteHeader", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		hrw := &headResponseWriter{ResponseWriter: recorder}
+
+		// Write without calling WriteHeader first
+		_, _ = hrw.Write([]byte("test"))
+
+		// Verify WriteHeader was called (status should be 200)
+		if recorder.Code != http.StatusOK {
+			t.Errorf("expected status %d, got %d", http.StatusOK, recorder.Code)
+		}
+	})
+
+	t.Run("headResponseWriter Content-Length matches GET", func(t *testing.T) {
+		handler := HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+			w.Header().Set(httpx.HeaderContentType, httpx.MIMEApplicationJSON)
+			return R.JSON(w, http.StatusOK, map[string]string{"message": "hello"})
+		})
+
+		router := NewRouter()
+		router.GET("/test", handler)
+
+		// GET request
+		getReq := httptest.NewRequest(http.MethodGet, "/test", nil)
+		getRec := httptest.NewRecorder()
+		router.ServeHTTP(getRec, getReq)
+		// Use actual body size since httptest doesn't auto-set Content-Length
+		getSize := len(getRec.Body.Bytes())
+
+		// HEAD request
+		headReq := httptest.NewRequest(http.MethodHead, "/test", nil)
+		headRec := httptest.NewRecorder()
+		router.ServeHTTP(headRec, headReq)
+		headCL := headRec.Header().Get(httpx.HeaderContentLength)
+
+		// HEAD Content-Length should match GET body size
+		if headCL == "" {
+			t.Error("HEAD request missing Content-Length header")
+			return
+		}
+		if headCL != fmt.Sprintf("%d", getSize) {
+			t.Errorf("HEAD Content-Length (%s) != GET body size (%d)", headCL, getSize)
+		}
+	})
+
 	t.Run("interface compatibility", func(t *testing.T) {
 		var _ http.Handler = HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 			return nil
@@ -663,7 +710,7 @@ func TestRouter_ErrorHandlers(t *testing.T) {
 		router := NewRouter()
 		router.GET("/test", testHandler("get"))
 		router.OPTIONS("/test", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Allow", "CUSTOM")
+			w.Header().Set(httpx.HeaderAllow, "CUSTOM")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("custom options"))
 		}))

--- a/sse.go
+++ b/sse.go
@@ -519,7 +519,7 @@ func SSEWithReplay(w http.ResponseWriter, r *http.Request, replayer SSEReplayer)
 	}
 
 	// Check for Last-Event-ID header for replay
-	lastEventID := r.Header.Get(httpx.HeaderLastEventID)
+	lastEventID := r.Header.Get(httpx.HeaderLastEventId)
 	if lastEventID != "" {
 		if replayer == nil {
 			_ = stream.Close()

--- a/sse_test.go
+++ b/sse_test.go
@@ -677,7 +677,7 @@ func TestSSEWithReplay(t *testing.T) {
 	t.Run("replays events when Last-Event-ID present", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
-		r.Header.Set(httpx.HeaderLastEventID, "0")
+		r.Header.Set(httpx.HeaderLastEventId, "0")
 		replay := NewInMemoryReplayer(100, 0)
 
 		replay.Store(SSEEvent{Data: []byte("event1")})
@@ -697,7 +697,7 @@ func TestSSEWithReplay(t *testing.T) {
 	t.Run("returns error for invalid Last-Event-ID", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
-		r.Header.Set(httpx.HeaderLastEventID, "not-a-number")
+		r.Header.Set(httpx.HeaderLastEventId, "not-a-number")
 		replay := NewInMemoryReplayer(100, 0)
 
 		_, err := SSEWithReplay(w, r, replay)
@@ -709,7 +709,7 @@ func TestSSEWithReplay(t *testing.T) {
 	t.Run("returns error when Last-Event-ID present but replayer is nil", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
-		r.Header.Set(httpx.HeaderLastEventID, "1")
+		r.Header.Set(httpx.HeaderLastEventId, "1")
 
 		_, err := SSEWithReplay(w, r, nil)
 		if err == nil {

--- a/static_bench_test.go
+++ b/static_bench_test.go
@@ -248,7 +248,7 @@ func BenchmarkStatic_ETagGeneration(b *testing.B) {
 		req := httptest.NewRequest(http.MethodGet, "/app.js", nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
-		etag := w.Header().Get("Etag")
+		etag := w.Header().Get(httpx.HeaderETag)
 
 		// Now benchmark conditional requests with If-None-Match
 		req = httptest.NewRequest(http.MethodGet, "/app.js", nil)


### PR DESCRIPTION
- Fix headResponseWriter to buffer and set Content-Length
- Skip encoder for HEAD to avoid incorrect Content-Length
- Add tests for HEAD request handling