### PR TITLE
fix(compress): use Algorithms order to determine encoder precedence

### DIFF
--- a/config/compress.go
+++ b/config/compress.go
@@ -83,7 +83,9 @@ type CompressConfig struct {
 	// Types are MIME types to compress (defaults to common text types)
 	Types []string
 
-	// Algorithms are compression algorithms to support (defaults to gzip, deflate)
+	// Algorithms are compression algorithms to support (defaults to gzip, deflate).
+	// The order determines precedence when the client accepts multiple encodings -
+	// earlier algorithms are preferred over later ones.
 	Algorithms []CompressionAlgorithm
 
 	// ExcludedPaths contains paths to skip compression.

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -31,6 +31,7 @@ type Compressor struct {
 	encodingPrecedence []string
 	level              int                                  // The compression level.
 	algorithms         map[config.CompressionAlgorithm]bool // Allowed algorithms
+	algorithmOrder     []config.CompressionAlgorithm        // Algorithm precedence order
 	excludedPaths      []string                             // Paths to skip compression
 	includedPaths      []string                             // Paths to allow compression (if set, only these paths)
 }
@@ -69,9 +70,17 @@ func NewCompressor(level int, types ...string) *Compressor {
 	// Set default algorithms
 	c.algorithms[config.Gzip] = true
 	c.algorithms[config.Deflate] = true
+	c.algorithmOrder = []config.CompressionAlgorithm{config.Gzip, config.Deflate}
 
-	c.SetEncoder(httpx.ContentEncodingDeflate, encoderDeflate)
-	c.SetEncoder(httpx.ContentEncodingGzip, encoderGzip)
+	// Register encoders in algorithm order (first = highest precedence)
+	for _, alg := range c.algorithmOrder {
+		switch alg {
+		case config.Gzip:
+			c.SetEncoder(httpx.ContentEncodingGzip, encoderGzip)
+		case config.Deflate:
+			c.SetEncoder(httpx.ContentEncodingDeflate, encoderDeflate)
+		}
+	}
 	return c
 }
 
@@ -163,42 +172,37 @@ func (c *Compressor) Handler(next http.Handler) http.Handler {
 }
 
 // selectEncoder returns the encoder, the name of the encoder, and a closer function.
+// Uses algorithmOrder to determine precedence (first = highest priority).
 func (c *Compressor) selectEncoder(h http.Header, w io.Writer) (io.Writer, string, func()) {
 	header := h.Get(httpx.HeaderAcceptEncoding)
 	accepted := strings.Split(strings.ToLower(header), ",")
 
-	for _, name := range c.encodingPrecedence {
-		if matchAcceptEncoding(accepted, name) {
-			// Check if algorithm is allowed
-			var allowed bool
-			switch name {
-			case httpx.ContentEncodingGzip:
-				allowed = c.algorithms[config.Gzip]
-			case httpx.ContentEncodingDeflate:
-				allowed = c.algorithms[config.Deflate]
-			default:
-				allowed = true // Custom encoders are always allowed if added
-			}
+	// Iterate through algorithms in configured order (highest precedence first)
+	for _, alg := range c.algorithmOrder {
+		name := strings.ToLower(string(alg))
+		if !matchAcceptEncoding(accepted, name) {
+			continue
+		}
 
-			if !allowed {
-				continue
-			}
+		// Check if algorithm is allowed
+		if !c.algorithms[alg] {
+			continue
+		}
 
-			if pool, ok := c.pooledEncoders[name]; ok {
-				encoder := pool.Get().(ioResetterWriter)
-				cleanup := func() {
-					pool.Put(encoder)
-				}
-				encoder.Reset(w)
-				return encoder, name, cleanup
+		if pool, ok := c.pooledEncoders[name]; ok {
+			encoder := pool.Get().(ioResetterWriter)
+			cleanup := func() {
+				pool.Put(encoder)
 			}
-			if fn, ok := c.encoders[name]; ok {
-				encoder := fn(w, c.level)
-				if encoder == nil {
-					continue // Skip if encoder failed to create (invalid level)
-				}
-				return encoder, name, func() {}
+			encoder.Reset(w)
+			return encoder, name, cleanup
+		}
+		if fn, ok := c.encoders[name]; ok {
+			encoder := fn(w, c.level)
+			if encoder == nil {
+				continue // Skip if encoder failed to create (invalid level)
 			}
+			return encoder, name, func() {}
 		}
 	}
 	return nil, "", func() {}
@@ -378,19 +382,39 @@ func Compress(cfg ...config.CompressConfig) func(http.Handler) http.Handler {
 	compressor.excludedPaths = c.ExcludedPaths
 	compressor.includedPaths = c.IncludedPaths
 
-	// Set allowed algorithms
+	// Set allowed algorithms and their precedence order
 	compressor.algorithms = make(map[config.CompressionAlgorithm]bool)
+	compressor.algorithmOrder = make([]config.CompressionAlgorithm, 0, len(c.Algorithms))
+
+	// Process algorithms in order, registering encoders from providers or built-ins
 	for _, alg := range c.Algorithms {
 		compressor.algorithms[alg] = true
-	}
+		algStr := strings.ToLower(string(alg))
 
-	// Add custom encoders from providers if set
-	for _, provider := range c.Providers {
-		for _, alg := range c.Algorithms {
-			if encoder := provider.GetEncoder(string(alg)); encoder != nil {
-				compressor.SetEncoder(encoder.Encoding(), func(w io.Writer, level int) io.Writer {
-					return encoder.Encode(w, level)
-				})
+		// Try to get encoder from providers first
+		var encoder config.CompressionEncoder
+		for _, provider := range c.Providers {
+			if enc := provider.GetEncoder(algStr); enc != nil {
+				encoder = enc
+				break
+			}
+		}
+
+		if encoder != nil {
+			// Custom encoder from provider
+			compressor.SetEncoder(encoder.Encoding(), func(w io.Writer, level int) io.Writer {
+				return encoder.Encode(w, level)
+			})
+			compressor.algorithmOrder = append(compressor.algorithmOrder, alg)
+		} else {
+			// Built-in encoder
+			switch alg {
+			case config.Gzip:
+				compressor.SetEncoder(httpx.ContentEncodingGzip, encoderGzip)
+				compressor.algorithmOrder = append(compressor.algorithmOrder, alg)
+			case config.Deflate:
+				compressor.SetEncoder(httpx.ContentEncodingDeflate, encoderDeflate)
+				compressor.algorithmOrder = append(compressor.algorithmOrder, alg)
 			}
 		}
 	}

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -285,6 +285,9 @@ func TestCompressor(t *testing.T) {
 	compressor.SetEncoder("nop", func(w io.Writer, _ int) io.Writer {
 		return w
 	})
+	// Add nop to algorithm order so selectEncoder will consider it
+	compressor.algorithmOrder = append([]config.CompressionAlgorithm{config.CompressionAlgorithm("nop")}, compressor.algorithmOrder...)
+	compressor.algorithms[config.CompressionAlgorithm("nop")] = true
 
 	if len(compressor.encoders) != 1 {
 		t.Errorf("nop encoder should be stored in the encoders map")
@@ -1144,6 +1147,57 @@ func TestCompressionProvider(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 
 		zhtest.AssertWith(t, rr).Header(httpx.HeaderContentEncoding, httpx.ContentEncodingGzip)
+	})
+
+	t.Run("algorithms order determines precedence with providers", func(t *testing.T) {
+		// When both algorithms are acceptable, the first one in Algorithms list should be chosen
+		brotliEncoder := &testEncoder{encoding: "br"}
+		zstdEncoder := &testEncoder{encoding: "zstd"}
+
+		brotliProvider := &testProvider{encoders: map[string]config.CompressionEncoder{
+			"br": brotliEncoder,
+		}}
+		zstdProvider := &testProvider{encoders: map[string]config.CompressionEncoder{
+			"zstd": zstdEncoder,
+		}}
+
+		// Test with zstd first in algorithms - it should be preferred
+		mw := Compress(config.CompressConfig{
+			Types:      []string{"text/plain"},
+			Algorithms: []config.CompressionAlgorithm{"zstd", "br"},
+			Providers:  []config.CompressionProvider{brotliProvider, zstdProvider},
+		})
+
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set(httpx.HeaderContentType, httpx.MIMETextPlain)
+			_, _ = w.Write([]byte("test content"))
+		}))
+
+		// Client accepts both, but zstd should be chosen (first in Algorithms)
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set(httpx.HeaderAcceptEncoding, "br, zstd")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		zhtest.AssertWith(t, rr).Header(httpx.HeaderContentEncoding, "zstd")
+
+		// Test with brotli first in algorithms - it should be preferred
+		mw2 := Compress(config.CompressConfig{
+			Types:      []string{"text/plain"},
+			Algorithms: []config.CompressionAlgorithm{"br", "zstd"},
+			Providers:  []config.CompressionProvider{zstdProvider, brotliProvider},
+		})
+
+		handler2 := mw2(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set(httpx.HeaderContentType, httpx.MIMETextPlain)
+			_, _ = w.Write([]byte("test content"))
+		}))
+
+		// Client accepts both, but brotli should be chosen (first in Algorithms)
+		req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req2.Header.Set(httpx.HeaderAcceptEncoding, "br, zstd")
+		rr2 := httptest.NewRecorder()
+		handler2.ServeHTTP(rr2, req2)
+		zhtest.AssertWith(t, rr2).Header(httpx.HeaderContentEncoding, "br")
 	})
 }
 


### PR DESCRIPTION
Previously, encoder precedence was determined by provider registration order and SetEncoder call order. Now precedence is explicitly controlled by the Algorithms config - algorithms are checked in the order they appear in the list, with earlier algorithms taking priority over later ones.

This makes configuration more intuitive and predictable.