### PR TITLE
fix(server): capture TLS errors in structured logs

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 )
 
 // Logger defines the interface for logging in the framework
@@ -152,4 +153,33 @@ func formatValue(v any) string {
 	default:
 		return fmt.Sprint(val)
 	}
+}
+
+// logWriter is an io.Writer adapter that writes to a Logger.
+// It's used to bridge Go's standard log package with structured loggers.
+type logWriter struct {
+	logger Logger
+}
+
+// Write implements io.Writer, writing the message to the underlying logger.
+// It trims trailing newlines for cleaner log output.
+func (w *logWriter) Write(p []byte) (n int, err error) {
+	msg := strings.TrimSuffix(string(p), "\n")
+	msg = strings.TrimSuffix(msg, "\r")
+	w.logger.Error(msg)
+	return len(p), nil
+}
+
+// StdLogger returns a standard library *log.Logger that writes to the provided Logger.
+// This is useful for integrating with libraries that expect a standard logger,
+// such as http.Server.ErrorLog.
+//
+// Example usage with http.Server:
+//
+//	logger := log.NewZerologLogger() // or any Logger implementation
+//	server := &http.Server{
+//	    ErrorLog: log.StdLogger(logger),
+//	}
+func StdLogger(logger Logger) *log.Logger {
+	return log.New(&logWriter{logger: logger}, "", 0)
 }

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -204,3 +204,46 @@ func TestChainedWithFields(t *testing.T) {
 		}
 	}
 }
+
+func TestStdLogger(t *testing.T) {
+	logger, buf := createTestLogger()
+
+	stdLogger := StdLogger(logger)
+
+	stdLogger.Println("TLS handshake error: test")
+
+	output := buf.String()
+	if !strings.Contains(output, "[ERROR]") {
+		t.Errorf("expected output to contain '[ERROR]', got '%s'", output)
+	}
+	if !strings.Contains(output, "TLS handshake error: test") {
+		t.Errorf("expected output to contain 'TLS handshake error: test', got '%s'", output)
+	}
+	if strings.Contains(output, "\n\n") {
+		t.Errorf("expected no double newlines, output had double newline: '%s'", output)
+	}
+}
+
+func TestLogWriter(t *testing.T) {
+	logger, buf := createTestLogger()
+	writer := &logWriter{logger: logger}
+
+	n, err := writer.Write([]byte("test message\n"))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if n != 13 {
+		t.Errorf("expected 13 bytes written, got %d", n)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "[ERROR]") {
+		t.Errorf("expected output to contain '[ERROR]', got '%s'", output)
+	}
+	if !strings.Contains(output, "test message") {
+		t.Errorf("expected output to contain 'test message', got '%s'", output)
+	}
+	if strings.Contains(output, "\n\n") {
+		t.Errorf("expected no double newlines from trimming, got: '%s'", output)
+	}
+}

--- a/server.go
+++ b/server.go
@@ -183,10 +183,10 @@ func New(cfg ...config.Config) *Server {
 	router.SetLogger(logger)
 	router.SetConfig(c)
 
-	server := createHTTPServer(c)
-	tlsServer := createTLSServer(c)
+	server := createHTTPServer(c, logger)
+	tlsServer := createTLSServer(c, logger)
 	registry := createMetricsRegistry(c)
-	metricsServer := createMetricsServer(c, registry)
+	metricsServer := createMetricsServer(c, registry, logger)
 
 	baseCtx, cancelBaseCtx := context.WithCancel(context.Background())
 
@@ -761,8 +761,11 @@ func createLogger(c config.Config) log.Logger {
 }
 
 // createHTTPServer creates the HTTP server from config.
-func createHTTPServer(c config.Config) *http.Server {
+func createHTTPServer(c config.Config, logger log.Logger) *http.Server {
 	if c.Server != nil {
+		if c.Server.ErrorLog == nil {
+			c.Server.ErrorLog = log.StdLogger(logger)
+		}
 		return c.Server
 	}
 	return &http.Server{
@@ -772,12 +775,16 @@ func createHTTPServer(c config.Config) *http.Server {
 		WriteTimeout:      DefaultWriteTimeout,
 		IdleTimeout:       DefaultIdleTimeout,
 		MaxHeaderBytes:    1 << 20, // 1 MB
+		ErrorLog:          log.StdLogger(logger),
 	}
 }
 
 // createTLSServer creates the TLS server from config if TLS is configured.
-func createTLSServer(c config.Config) *http.Server {
+func createTLSServer(c config.Config, logger log.Logger) *http.Server {
 	if c.TLS.Server != nil {
+		if c.TLS.Server.ErrorLog == nil {
+			c.TLS.Server.ErrorLog = log.StdLogger(logger)
+		}
 		return c.TLS.Server
 	}
 	if !needsTLSServer(c) {
@@ -790,6 +797,7 @@ func createTLSServer(c config.Config) *http.Server {
 		WriteTimeout:      DefaultWriteTimeout,
 		IdleTimeout:       DefaultIdleTimeout,
 		MaxHeaderBytes:    1 << 20, // 1 MB
+		ErrorLog:          log.StdLogger(logger),
 		TLSConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,
 			NextProtos: []string{"h2", "http/1.1"},
@@ -817,7 +825,7 @@ func createMetricsRegistry(c config.Config) metrics.Registry {
 
 // createMetricsServer creates a separate metrics server if ServerAddr indicates a separate server.
 // Returns nil if ServerAddr is empty (metrics on main server) or metrics disabled.
-func createMetricsServer(c config.Config, registry metrics.Registry) *http.Server {
+func createMetricsServer(c config.Config, registry metrics.Registry, logger log.Logger) *http.Server {
 	if registry == nil {
 		return nil
 	}
@@ -843,6 +851,7 @@ func createMetricsServer(c config.Config, registry metrics.Registry) *http.Serve
 		WriteTimeout:      DefaultWriteTimeout,
 		IdleTimeout:       DefaultIdleTimeout,
 		Handler:           handler,
+		ErrorLog:          log.StdLogger(logger),
 	}
 }
 


### PR DESCRIPTION
Add log.StdLogger() adapter to bridge Go's standard log.Logger with the zerolog interface. Set ErrorLog on all HTTP servers so TLS handshake errors are logged via zerolog instead of stderr.