### PR TITLE
feat(log): add ANSI color support with auto-detection

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -8,6 +8,31 @@ import (
 	"strings"
 )
 
+// ANSI color codes for terminal output
+const (
+	colorReset       = "\033[0m"
+	colorRed         = "\033[31m"
+	colorGreen       = "\033[32m"
+	colorYellow      = "\033[33m"
+	colorBlue        = "\033[34m"
+	colorMagenta     = "\033[35m"
+	colorCyan        = "\033[36m"
+	colorGray        = "\033[90m"
+	colorWhiteBold   = "\033[1;37m"
+	colorWhiteOnRed  = "\033[97;41m"
+	colorWhiteOnBlue = "\033[97;44m"
+)
+
+// levelColors maps log levels to ANSI colors
+var levelColors = map[string]string{
+	"DBG": colorWhiteOnBlue,
+	"INF": colorGreen,
+	"WRN": colorYellow,
+	"ERR": colorRed,
+	"PNC": colorMagenta,
+	"FTL": colorWhiteOnRed,
+}
+
 // Logger defines the interface for logging in the framework
 type Logger interface {
 	// Debug logs a debug message
@@ -61,48 +86,93 @@ var _ Logger = (*DefaultLogger)(nil)
 
 // DefaultLogger is a simple implementation using Go's standard log package
 type DefaultLogger struct {
-	logger *log.Logger
-	fields []Field
+	logger   *log.Logger
+	fields   []Field
+	colorize bool
 }
 
 // NewDefaultLogger creates a new default logger instance.
 // It uses Go's standard log package with stdout output and standard flags.
+// Colors are enabled by default for TTY terminals, unless NO_COLOR is set
+// or running in a CI environment.
 func NewDefaultLogger() *DefaultLogger {
 	return &DefaultLogger{
-		logger: log.New(os.Stdout, "", log.LstdFlags),
-		fields: make([]Field, 0),
+		logger:   log.New(os.Stdout, "", log.LstdFlags),
+		fields:   make([]Field, 0),
+		colorize: shouldColorize(),
 	}
+}
+
+// shouldColorize returns true if colors should be enabled.
+// It checks for NO_COLOR environment variable and common CI environments.
+func shouldColorize() bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+
+	// Check for common CI environment variables
+	ciVars := []string{"CI", "CONTINUOUS_INTEGRATION", "BUILD_ID", "BUILD_NUMBER"}
+	for _, v := range ciVars {
+		if os.Getenv(v) != "" {
+			return false
+		}
+	}
+
+	// Check for specific CI services
+	ciServices := []string{
+		"GITHUB_ACTIONS",
+		"GITLAB_CI",
+		"CIRCLECI",
+		"TRAVIS",
+		"JENKINS_URL",
+		"BUILDKITE",
+		"DRONE",
+		"TEAMCITY_VERSION",
+	}
+	for _, v := range ciServices {
+		if os.Getenv(v) != "" {
+			return false
+		}
+	}
+
+	return true
+}
+
+// SetColorize enables or disables colored output.
+// When disabled, logs are output without ANSI color codes.
+func (l *DefaultLogger) SetColorize(enabled bool) {
+	l.colorize = enabled
 }
 
 // Debug logs a debug message with optional fields
 func (l *DefaultLogger) Debug(msg string, fields ...Field) {
-	l.logWithLevel("DEBUG", msg, fields...)
+	l.logWithLevel("DBG", msg, fields...)
 }
 
 // Info logs an info message with optional fields
 func (l *DefaultLogger) Info(msg string, fields ...Field) {
-	l.logWithLevel("INFO", msg, fields...)
+	l.logWithLevel("INF", msg, fields...)
 }
 
 // Warn logs a warning message with optional fields
 func (l *DefaultLogger) Warn(msg string, fields ...Field) {
-	l.logWithLevel("WARN", msg, fields...)
+	l.logWithLevel("WRN", msg, fields...)
 }
 
 // Error logs an error message with optional fields
 func (l *DefaultLogger) Error(msg string, fields ...Field) {
-	l.logWithLevel("ERROR", msg, fields...)
+	l.logWithLevel("ERR", msg, fields...)
 }
 
 // Panic logs a panic message with optional fields and then panics
 func (l *DefaultLogger) Panic(msg string, fields ...Field) {
-	l.logWithLevel("PANIC", msg, fields...)
+	l.logWithLevel("PNC", msg, fields...)
 	panic(msg)
 }
 
 // Fatal logs a fatal message with optional fields and then exits with code 1
 func (l *DefaultLogger) Fatal(msg string, fields ...Field) {
-	l.logWithLevel("FATAL", msg, fields...)
+	l.logWithLevel("FTL", msg, fields...)
 	os.Exit(1)
 }
 
@@ -128,18 +198,53 @@ func (l *DefaultLogger) WithContext(ctx context.Context) Logger {
 
 // logWithLevel logs a message at the specified level with fields.
 // It formats the message with the level prefix and appends all fields.
+// If colorize is enabled, it applies ANSI color codes to the level and field keys.
 func (l *DefaultLogger) logWithLevel(level, msg string, fields ...Field) {
 	allFields := append(l.fields, fields...)
 
-	logMsg := "[" + level + "] " + msg
-	if len(allFields) > 0 {
-		logMsg += " |"
-		for _, field := range allFields {
-			logMsg += " " + field.Key + "=" + formatValue(field.Value)
+	var b strings.Builder
+	if l.colorize {
+		levelColor := levelColors[level]
+		if levelColor == "" {
+			levelColor = colorReset
+		}
+		b.WriteString(levelColor)
+		b.WriteString("[")
+		b.WriteString(level)
+		b.WriteString("]")
+		b.WriteString(colorReset)
+		b.WriteString(" ")
+		b.WriteString(colorWhiteBold)
+		b.WriteString(msg)
+		b.WriteString(colorReset)
+		if len(allFields) > 0 {
+			b.WriteString(" |")
+			for _, field := range allFields {
+				b.WriteString(" ")
+				b.WriteString(colorCyan)
+				b.WriteString(field.Key)
+				b.WriteString(colorReset)
+				b.WriteString("=")
+				b.WriteString(formatValue(field.Value))
+			}
+		}
+	} else {
+		b.WriteString("[")
+		b.WriteString(level)
+		b.WriteString("] ")
+		b.WriteString(msg)
+		if len(allFields) > 0 {
+			b.WriteString(" |")
+			for _, field := range allFields {
+				b.WriteString(" ")
+				b.WriteString(field.Key)
+				b.WriteString("=")
+				b.WriteString(formatValue(field.Value))
+			}
 		}
 	}
 
-	l.logger.Println(logMsg)
+	l.logger.Println(b.String())
 }
 
 // formatValue converts a field value to its string representation.

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -247,3 +247,186 @@ func TestLogWriter(t *testing.T) {
 		t.Errorf("expected no double newlines from trimming, got: '%s'", output)
 	}
 }
+
+func TestSetColorize(t *testing.T) {
+	logger, buf := createTestLogger()
+
+	// Test disabling colors
+	logger.SetColorize(false)
+	logger.Info("no color message")
+
+	output := buf.String()
+	if !strings.Contains(output, "[INF]") {
+		t.Errorf("expected output to contain '[INF]', got '%s'", output)
+	}
+	if !strings.Contains(output, "no color message") {
+		t.Errorf("expected output to contain 'no color message', got '%s'", output)
+	}
+	// With colors disabled, there should be no ANSI codes
+	if strings.Contains(output, "\033[") {
+		t.Errorf("expected no ANSI codes when colorize is disabled, got '%s'", output)
+	}
+
+	// Test re-enabling colors
+	buf.Reset()
+	logger.SetColorize(true)
+	logger.Info("color message")
+
+	output = buf.String()
+	if !strings.Contains(output, "[INF]") {
+		t.Errorf("expected output to contain '[INF]', got '%s'", output)
+	}
+}
+
+func TestLogWithColorsEnabled(t *testing.T) {
+	logger, buf := createTestLogger()
+	logger.SetColorize(true)
+
+	logger.Info("colored info")
+	output := buf.String()
+
+	// Should contain ANSI color codes
+	if !strings.Contains(output, "\033[") {
+		t.Errorf("expected ANSI codes when colors enabled, got '%s'", output)
+	}
+}
+
+func TestLogWithColorsDisabled(t *testing.T) {
+	logger, buf := createTestLogger()
+	logger.SetColorize(false)
+
+	logger.Info("plain info")
+	output := buf.String()
+
+	// Should NOT contain ANSI color codes
+	if strings.Contains(output, "\033[") {
+		t.Errorf("expected no ANSI codes when colors disabled, got '%s'", output)
+	}
+}
+
+func TestShouldColorize_NO_COLOR(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	result := shouldColorize()
+	if result {
+		t.Error("shouldColorize should return false when NO_COLOR is set")
+	}
+}
+
+func TestShouldColorize_CI(t *testing.T) {
+	tests := []string{"CI", "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI", "TRAVIS"}
+
+	for _, envVar := range tests {
+		t.Run(envVar, func(t *testing.T) {
+			t.Setenv(envVar, "true")
+			result := shouldColorize()
+			if result {
+				t.Errorf("shouldColorize should return false when %s is set", envVar)
+			}
+		})
+	}
+}
+
+func TestGlobalLogger(t *testing.T) {
+	// Save original logger
+	original := GetGlobalLogger()
+	defer SetGlobalLogger(original)
+
+	// Set up test logger
+	testLogger := NewDefaultLogger()
+	SetGlobalLogger(testLogger)
+
+	// Test GetGlobalLogger returns our test logger
+	if GetGlobalLogger() != testLogger {
+		t.Error("GetGlobalLogger should return the set global logger")
+	}
+}
+
+func TestGlobalLoggerMethods(t *testing.T) {
+	// Save and restore original
+	original := GetGlobalLogger()
+	defer SetGlobalLogger(original)
+
+	// Use NoopLogger to avoid output during tests
+	SetGlobalLogger(&NoopLogger{})
+
+	// Test that global methods don't panic via GetGlobalLogger
+	GetGlobalLogger().Debug("debug message", F("key", "value"))
+	GetGlobalLogger().Info("info message", F("key", "value"))
+	GetGlobalLogger().Warn("warn message", F("key", "value"))
+	GetGlobalLogger().Error("error message", F("key", "value"))
+
+	// Test WithFields chaining on global
+	logger := GetGlobalLogger().WithFields(F("field", "value"))
+	logger.Info("chained message")
+}
+
+func TestLogFatal(t *testing.T) {
+	logger, _ := createTestLogger()
+
+	// We can't actually test Fatal since it calls os.Exit
+	// Just verify the method exists and has correct signature by compiling
+	_ = logger.Fatal
+}
+
+func TestLogWithAllLevels(t *testing.T) {
+	logger, buf := createTestLogger()
+	logger.SetColorize(false)
+
+	tests := []struct {
+		name     string
+		logFunc  func(string, ...Field)
+		expected string
+	}{
+		{"Debug", logger.Debug, "[DBG]"},
+		{"Info", logger.Info, "[INF]"},
+		{"Warn", logger.Warn, "[WRN]"},
+		{"Error", logger.Error, "[ERR]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf.Reset()
+			tt.logFunc("test")
+			output := buf.String()
+			if !strings.Contains(output, tt.expected) {
+				t.Errorf("expected output to contain '%s', got '%s'", tt.expected, output)
+			}
+		})
+	}
+}
+
+func TestLogWithFieldsColorKeys(t *testing.T) {
+	logger, buf := createTestLogger()
+	logger.SetColorize(true)
+
+	logger.Info("test", F("mykey", "myvalue"))
+	output := buf.String()
+
+	// Should contain the key with cyan color
+	if !strings.Contains(output, "mykey") {
+		t.Errorf("expected output to contain 'mykey', got '%s'", output)
+	}
+	if !strings.Contains(output, "myvalue") {
+		t.Errorf("expected output to contain 'myvalue', got '%s'", output)
+	}
+}
+
+func TestLogAllLevelColors(t *testing.T) {
+	logger, _ := createTestLogger()
+	logger.SetColorize(true)
+
+	// Just ensure all levels work with colors
+	levels := []struct {
+		name string
+		fn   func(string, ...Field)
+	}{
+		{"DBG", logger.Debug},
+		{"INF", logger.Info},
+		{"WRN", logger.Warn},
+		{"ERR", logger.Error},
+	}
+
+	for _, level := range levels {
+		level.fn("test message for " + level.name)
+	}
+}

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -72,10 +72,10 @@ func TestLogLevels(t *testing.T) {
 		logFunc  func(*DefaultLogger, string, ...Field)
 		expected string
 	}{
-		{"Debug", (*DefaultLogger).Debug, "[DEBUG]"},
-		{"Info", (*DefaultLogger).Info, "[INFO]"},
-		{"Warn", (*DefaultLogger).Warn, "[WARN]"},
-		{"Error", (*DefaultLogger).Error, "[ERROR]"},
+		{"Debug", (*DefaultLogger).Debug, "[DBG]"},
+		{"Info", (*DefaultLogger).Info, "[INF]"},
+		{"Warn", (*DefaultLogger).Warn, "[WRN]"},
+		{"Error", (*DefaultLogger).Error, "[ERR]"},
 	}
 
 	for _, tt := range tests {
@@ -99,7 +99,7 @@ func TestLogWithFields(t *testing.T) {
 	logger.Info("test", F("key1", "value1"), F("key2", 42))
 
 	output := buf.String()
-	expected := []string{"[INFO]", "test", "key1=value1", "key2=42"}
+	expected := []string{"[INF]", "test", "key1=value1", "key2=42"}
 
 	for _, exp := range expected {
 		if !strings.Contains(output, exp) {
@@ -119,8 +119,8 @@ func TestLogPanic(t *testing.T) {
 		}
 
 		output := buf.String()
-		if !strings.Contains(output, "[PANIC]") {
-			t.Errorf("expected output to contain '[PANIC]', got '%s'", output)
+		if !strings.Contains(output, "[PNC]") {
+			t.Errorf("expected output to contain '[PNC]', got '%s'", output)
 		}
 		if !strings.Contains(output, "panic message") {
 			t.Errorf("expected output to contain 'panic message', got '%s'", output)
@@ -142,7 +142,7 @@ func TestWithFields(t *testing.T) {
 	loggerWithFields.Info("test message", F("extra", "field"))
 
 	output := buf.String()
-	expected := []string{"[INFO]", "test message", "base=value", "count=1", "extra=field"}
+	expected := []string{"[INF]", "test message", "base=value", "count=1", "extra=field"}
 
 	for _, exp := range expected {
 		if !strings.Contains(output, exp) {
@@ -213,8 +213,8 @@ func TestStdLogger(t *testing.T) {
 	stdLogger.Println("TLS handshake error: test")
 
 	output := buf.String()
-	if !strings.Contains(output, "[ERROR]") {
-		t.Errorf("expected output to contain '[ERROR]', got '%s'", output)
+	if !strings.Contains(output, "[ERR]") {
+		t.Errorf("expected output to contain '[ERR]', got '%s'", output)
 	}
 	if !strings.Contains(output, "TLS handshake error: test") {
 		t.Errorf("expected output to contain 'TLS handshake error: test', got '%s'", output)
@@ -237,8 +237,8 @@ func TestLogWriter(t *testing.T) {
 	}
 
 	output := buf.String()
-	if !strings.Contains(output, "[ERROR]") {
-		t.Errorf("expected output to contain '[ERROR]', got '%s'", output)
+	if !strings.Contains(output, "[ERR]") {
+		t.Errorf("expected output to contain '[ERR]', got '%s'", output)
 	}
 	if !strings.Contains(output, "test message") {
 		t.Errorf("expected output to contain 'test message', got '%s'", output)

--- a/router.go
+++ b/router.go
@@ -818,10 +818,6 @@ func (r *defaultRouter) catchAllHandler() http.HandlerFunc {
 				methodNotAllowedHandler := r.methodNotAllowedHandler
 				r.handlerMu.RUnlock()
 				methodNotAllowedHandler.ServeHTTP(w, req)
-
-				if shouldLog {
-					middleware.LogRequest(logger, requestLoggerConfig, nil, req, http.StatusMethodNotAllowed, time.Since(start), "", "")
-				}
 				return
 			}
 
@@ -839,10 +835,6 @@ func (r *defaultRouter) catchAllHandler() http.HandlerFunc {
 		notFoundHandler := r.notFoundHandler
 		r.handlerMu.RUnlock()
 		notFoundHandler.ServeHTTP(w, req)
-
-		if shouldLog {
-			middleware.LogRequest(logger, requestLoggerConfig, nil, req, http.StatusNotFound, time.Since(start), "", "")
-		}
 	}
 }
 


### PR DESCRIPTION
  - Add colors for log levels: DBG (white/blue), INF (green), WRN (yellow), ERR (red), PNC (magenta), FTL (white/red)
  - Log messages are now white + bold
  - Auto-detect color support: disabled in CI, respects NO_COLOR
  - Shorten level names: DEBUG→DBG, INFO→INF, WARN→WRN, ERROR→ERR
  - Update tests for new level strings
  - Fix duplicate request logging for 404/405 errors