### PR TITLE
feat(log): add log level filtering with SetLevel/GetLevel

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -23,6 +23,7 @@ Basic functionality that doesn't require external dependencies beyond the standa
 - [**`healthcheck/`**](core/healthcheck/) - Health check endpoints
 - [**`hello_world/`**](core/hello_world/) - Simplest possible server
 - [**`lifecycle/`**](core/lifecycle/) - Server lifecycle hooks
+- [**`logger/`**](core/logger/) - Log level filtering
 - [**`metrics/`**](core/metrics/) - Prometheus metrics endpoint
 - [**`pprof/`**](core/pprof/) - Performance profiling endpoints
 - [**`problem_detail/`**](core/problem_detail/) - RFC 7807 Problem Detail responses

--- a/examples/core/logger/README.md
+++ b/examples/core/logger/README.md
@@ -1,0 +1,69 @@
+# Logger Example
+
+This example demonstrates how to use log level filtering with zerohttp's built-in logger.
+
+## Running
+
+```bash
+go run main.go
+```
+
+## Endpoints
+
+### GET /demo
+
+Logs messages at all levels (Debug, Info, Warn, Error) since the logger is set to `DebugLevel`.
+
+```bash
+curl http://localhost:8080/demo
+```
+
+Expected output in console:
+```
+[DBG] This is a debug message
+[INF] This is an info message
+[WRN] This is a warning message
+[ERR] This is an error message
+```
+
+### GET /filter
+
+Demonstrates log filtering by changing the level to `WarnLevel`. Only Warn and Error messages are logged.
+
+```bash
+curl http://localhost:8080/filter
+```
+
+Expected output in console:
+```
+[WRN] This warning message WILL be logged
+[ERR] This error message WILL be logged
+```
+
+## Available Log Levels
+
+| Level      | Value | Description                    |
+|------------|-------|--------------------------------|
+| DebugLevel | 0     | Most verbose - logs everything |
+| InfoLevel  | 1     | Default - logs Info and above  |
+| WarnLevel  | 2     | Logs warnings and errors       |
+| ErrorLevel | 3     | Logs only errors               |
+| PanicLevel | 4     | Used for panic messages        |
+| FatalLevel | 5     | Used for fatal messages        |
+
+## Usage
+
+```go
+logger := log.NewDefaultLogger()
+logger.SetLevel(log.DebugLevel)  // Show all messages
+
+app := zh.New(config.Config{
+    Logger: logger,
+})
+```
+
+To change the level at runtime:
+
+```go
+app.Logger().(*log.DefaultLogger).SetLevel(log.WarnLevel)
+```

--- a/examples/core/logger/main.go
+++ b/examples/core/logger/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
+	zlog "github.com/alexferl/zerohttp/log"
+)
+
+func main() {
+	// Create a logger and set the log level
+	// Available levels: DebugLevel, InfoLevel (default), WarnLevel, ErrorLevel, PanicLevel, FatalLevel
+	logger := zlog.NewDefaultLogger()
+	logger.SetLevel(zlog.DebugLevel)
+
+	app := zh.New(config.Config{
+		Logger: logger,
+	})
+
+	app.GET("/demo", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		// These will all be logged since level is DebugLevel
+		app.Logger().Debug("This is a debug message")
+		app.Logger().Info("This is an info message")
+		app.Logger().Warn("This is a warning message")
+		app.Logger().Error("This is an error message")
+
+		return zh.Render.JSON(w, http.StatusOK, zh.M{
+			"message": "Check your console for log output",
+		})
+	}))
+
+	app.GET("/filter", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		// Change log level to Warn - only Warn and above will show
+		app.Logger().(*zlog.DefaultLogger).SetLevel(zlog.WarnLevel)
+
+		app.Logger().Debug("This debug message will NOT be logged")
+		app.Logger().Info("This info message will NOT be logged")
+		app.Logger().Warn("This warning message WILL be logged")
+		app.Logger().Error("This error message WILL be logged")
+
+		// Reset back to Info for other requests
+		app.Logger().(*zlog.DefaultLogger).SetLevel(zlog.InfoLevel)
+
+		return zh.Render.JSON(w, http.StatusOK, zh.M{
+			"message": "Check your console - only Warn and Error should appear",
+		})
+	}))
+
+	log.Fatal(app.Start())
+}

--- a/log/doc.go
+++ b/log/doc.go
@@ -29,6 +29,29 @@
 //	logger := log.GetGlobalLogger()
 //	logger.Info("Server starting", log.F("port", 8080))
 //
+// # Log Levels
+//
+// The default logger supports log level filtering. Messages below the configured
+// level are silently discarded.
+//
+// Available levels (in order of verbosity):
+//
+//	log.DebugLevel // 0 - most verbose
+//	log.InfoLevel  // 1 - default
+//	log.WarnLevel  // 2
+//	log.ErrorLevel // 3
+//	log.PanicLevel // 4
+//	log.FatalLevel // 5 - least verbose
+//
+// Set the log level:
+//
+//	logger := log.NewDefaultLogger()
+//	logger.SetLevel(log.DebugLevel) // Show all messages
+//
+// Get the current log level:
+//
+//	level := logger.GetLevel()
+//
 // # Using Fields
 //
 // Create structured log entries with fields:

--- a/log/logger.go
+++ b/log/logger.go
@@ -23,6 +23,44 @@ const (
 	colorWhiteOnBlue = "\033[97;44m"
 )
 
+// LogLevel represents the severity level of a log message.
+type LogLevel int
+
+const (
+	// DebugLevel is the most verbose level, used for detailed debugging information.
+	DebugLevel LogLevel = iota
+	// InfoLevel is used for general informational messages.
+	InfoLevel
+	// WarnLevel is used for warning messages that indicate potential issues.
+	WarnLevel
+	// ErrorLevel is used for error messages.
+	ErrorLevel
+	// PanicLevel is used for critical errors that cause panics.
+	PanicLevel
+	// FatalLevel is used for critical errors that cause the application to exit.
+	FatalLevel
+)
+
+// String returns the string representation of the log level.
+func (l LogLevel) String() string {
+	switch l {
+	case DebugLevel:
+		return "DBG"
+	case InfoLevel:
+		return "INF"
+	case WarnLevel:
+		return "WRN"
+	case ErrorLevel:
+		return "ERR"
+	case PanicLevel:
+		return "PNC"
+	case FatalLevel:
+		return "FTL"
+	default:
+		return "UNK"
+	}
+}
+
 // levelColors maps log levels to ANSI colors
 var levelColors = map[string]string{
 	"DBG": colorWhiteOnBlue,
@@ -89,17 +127,20 @@ type DefaultLogger struct {
 	logger   *log.Logger
 	fields   []Field
 	colorize bool
+	level    LogLevel
 }
 
 // NewDefaultLogger creates a new default logger instance.
 // It uses Go's standard log package with stdout output and standard flags.
 // Colors are enabled by default for TTY terminals, unless NO_COLOR is set
 // or running in a CI environment.
+// The default log level is InfoLevel.
 func NewDefaultLogger() *DefaultLogger {
 	return &DefaultLogger{
 		logger:   log.New(os.Stdout, "", log.LstdFlags),
 		fields:   make([]Field, 0),
 		colorize: shouldColorize(),
+		level:    InfoLevel,
 	}
 }
 
@@ -144,35 +185,59 @@ func (l *DefaultLogger) SetColorize(enabled bool) {
 	l.colorize = enabled
 }
 
+// SetLevel sets the minimum log level for the logger.
+// Messages with a level lower than the set level will be discarded.
+// Default level is InfoLevel.
+func (l *DefaultLogger) SetLevel(level LogLevel) {
+	l.level = level
+}
+
+// GetLevel returns the current minimum log level.
+func (l *DefaultLogger) GetLevel() LogLevel {
+	return l.level
+}
+
 // Debug logs a debug message with optional fields
 func (l *DefaultLogger) Debug(msg string, fields ...Field) {
-	l.logWithLevel("DBG", msg, fields...)
+	if l.level <= DebugLevel {
+		l.logWithLevel(DebugLevel, msg, fields...)
+	}
 }
 
 // Info logs an info message with optional fields
 func (l *DefaultLogger) Info(msg string, fields ...Field) {
-	l.logWithLevel("INF", msg, fields...)
+	if l.level <= InfoLevel {
+		l.logWithLevel(InfoLevel, msg, fields...)
+	}
 }
 
 // Warn logs a warning message with optional fields
 func (l *DefaultLogger) Warn(msg string, fields ...Field) {
-	l.logWithLevel("WRN", msg, fields...)
+	if l.level <= WarnLevel {
+		l.logWithLevel(WarnLevel, msg, fields...)
+	}
 }
 
 // Error logs an error message with optional fields
 func (l *DefaultLogger) Error(msg string, fields ...Field) {
-	l.logWithLevel("ERR", msg, fields...)
+	if l.level <= ErrorLevel {
+		l.logWithLevel(ErrorLevel, msg, fields...)
+	}
 }
 
 // Panic logs a panic message with optional fields and then panics
 func (l *DefaultLogger) Panic(msg string, fields ...Field) {
-	l.logWithLevel("PNC", msg, fields...)
+	if l.level <= PanicLevel {
+		l.logWithLevel(PanicLevel, msg, fields...)
+	}
 	panic(msg)
 }
 
 // Fatal logs a fatal message with optional fields and then exits with code 1
 func (l *DefaultLogger) Fatal(msg string, fields ...Field) {
-	l.logWithLevel("FTL", msg, fields...)
+	if l.level <= FatalLevel {
+		l.logWithLevel(FatalLevel, msg, fields...)
+	}
 	os.Exit(1)
 }
 
@@ -184,8 +249,10 @@ func (l *DefaultLogger) WithFields(fields ...Field) Logger {
 	copy(newFields[len(l.fields):], fields)
 
 	return &DefaultLogger{
-		logger: l.logger,
-		fields: newFields,
+		logger:   l.logger,
+		fields:   newFields,
+		colorize: l.colorize,
+		level:    l.level,
 	}
 }
 
@@ -199,18 +266,19 @@ func (l *DefaultLogger) WithContext(ctx context.Context) Logger {
 // logWithLevel logs a message at the specified level with fields.
 // It formats the message with the level prefix and appends all fields.
 // If colorize is enabled, it applies ANSI color codes to the level and field keys.
-func (l *DefaultLogger) logWithLevel(level, msg string, fields ...Field) {
+func (l *DefaultLogger) logWithLevel(level LogLevel, msg string, fields ...Field) {
 	allFields := append(l.fields, fields...)
 
+	levelStr := level.String()
 	var b strings.Builder
 	if l.colorize {
-		levelColor := levelColors[level]
+		levelColor := levelColors[levelStr]
 		if levelColor == "" {
 			levelColor = colorReset
 		}
 		b.WriteString(levelColor)
 		b.WriteString("[")
-		b.WriteString(level)
+		b.WriteString(levelStr)
 		b.WriteString("]")
 		b.WriteString(colorReset)
 		b.WriteString(" ")
@@ -230,7 +298,7 @@ func (l *DefaultLogger) logWithLevel(level, msg string, fields ...Field) {
 		}
 	} else {
 		b.WriteString("[")
-		b.WriteString(level)
+		b.WriteString(levelStr)
 		b.WriteString("] ")
 		b.WriteString(msg)
 		if len(allFields) > 0 {

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -430,3 +430,143 @@ func TestLogAllLevelColors(t *testing.T) {
 		level.fn("test message for " + level.name)
 	}
 }
+
+func TestLogLevelFiltering(t *testing.T) {
+	tests := []struct {
+		name          string
+		setLevel      LogLevel
+		logLevel      LogLevel
+		shouldLog     bool
+		expectedLevel string
+	}{
+		{"Debug at Debug level", DebugLevel, DebugLevel, true, "[DBG]"},
+		{"Info at Debug level", DebugLevel, InfoLevel, true, "[INF]"},
+		{"Error at Debug level", DebugLevel, ErrorLevel, true, "[ERR]"},
+		{"Debug at Info level", InfoLevel, DebugLevel, false, ""},
+		{"Info at Info level", InfoLevel, InfoLevel, true, "[INF]"},
+		{"Warn at Info level", InfoLevel, WarnLevel, true, "[WRN]"},
+		{"Debug at Warn level", WarnLevel, DebugLevel, false, ""},
+		{"Info at Warn level", WarnLevel, InfoLevel, false, ""},
+		{"Warn at Warn level", WarnLevel, WarnLevel, true, "[WRN]"},
+		{"Error at Warn level", WarnLevel, ErrorLevel, true, "[ERR]"},
+		{"Info at Error level", ErrorLevel, InfoLevel, false, ""},
+		{"Error at Error level", ErrorLevel, ErrorLevel, true, "[ERR]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, buf := createTestLogger()
+			logger.SetLevel(tt.setLevel)
+
+			switch tt.logLevel {
+			case DebugLevel:
+				logger.Debug("test message")
+			case InfoLevel:
+				logger.Info("test message")
+			case WarnLevel:
+				logger.Warn("test message")
+			case ErrorLevel:
+				logger.Error("test message")
+			}
+
+			output := buf.String()
+			if tt.shouldLog {
+				if !strings.Contains(output, tt.expectedLevel) {
+					t.Errorf("expected output to contain '%s', got '%s'", tt.expectedLevel, output)
+				}
+				if !strings.Contains(output, "test message") {
+					t.Errorf("expected output to contain 'test message', got '%s'", output)
+				}
+			} else {
+				if output != "" {
+					t.Errorf("expected no output, got '%s'", output)
+				}
+			}
+		})
+	}
+}
+
+func TestDefaultLogLevel(t *testing.T) {
+	logger := NewDefaultLogger()
+	if logger.GetLevel() != InfoLevel {
+		t.Errorf("expected default log level to be InfoLevel, got %v", logger.GetLevel())
+	}
+}
+
+func TestSetAndGetLevel(t *testing.T) {
+	logger := NewDefaultLogger()
+
+	// Test setting different levels
+	levels := []LogLevel{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, PanicLevel, FatalLevel}
+	for _, level := range levels {
+		logger.SetLevel(level)
+		if logger.GetLevel() != level {
+			t.Errorf("expected level %v, got %v", level, logger.GetLevel())
+		}
+	}
+}
+
+func TestLogLevelString(t *testing.T) {
+	tests := []struct {
+		level    LogLevel
+		expected string
+	}{
+		{DebugLevel, "DBG"},
+		{InfoLevel, "INF"},
+		{WarnLevel, "WRN"},
+		{ErrorLevel, "ERR"},
+		{PanicLevel, "PNC"},
+		{FatalLevel, "FTL"},
+		{LogLevel(999), "UNK"}, // Unknown level
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			result := tt.level.String()
+			if result != tt.expected {
+				t.Errorf("expected '%s', got '%s'", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestWithFieldsPreservesLevel(t *testing.T) {
+	logger, _ := createTestLogger()
+	logger.SetLevel(WarnLevel)
+
+	newLogger := logger.WithFields(F("key", "value"))
+	defaultLogger, ok := newLogger.(*DefaultLogger)
+	if !ok {
+		t.Fatal("WithFields should return *DefaultLogger")
+	}
+
+	if defaultLogger.GetLevel() != WarnLevel {
+		t.Errorf("expected level to be preserved as WarnLevel, got %v", defaultLogger.GetLevel())
+	}
+}
+
+func TestPanicWithLevelFiltering(t *testing.T) {
+	// Test that Panic always panics even when filtered
+	logger, buf := createTestLogger()
+	logger.SetLevel(FatalLevel) // Set level higher than Panic
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic but none occurred")
+		}
+		// Panic should not have logged since level is Fatal
+		output := buf.String()
+		if strings.Contains(output, "[PNC]") {
+			t.Error("Panic should not log when level is Fatal")
+		}
+	}()
+
+	logger.Panic("panic message")
+}
+
+func TestFatalWithLevelFiltering(t *testing.T) {
+	// We can't test Fatal since it calls os.Exit, but we can verify it exists
+	logger, _ := createTestLogger()
+	logger.SetLevel(FatalLevel)
+	_ = logger.Fatal
+}

--- a/server_lifecycle_test.go
+++ b/server_lifecycle_test.go
@@ -395,15 +395,27 @@ func TestServer_RegisterPostStartupHook(t *testing.T) {
 
 func TestServer_StartupHooks_RunInOrder(t *testing.T) {
 	var order []string
+	var mu sync.Mutex
+	hooksDone := make(chan struct{})
 	server := New(config.Config{
 		Lifecycle: config.LifecycleConfig{
 			StartupHooks: []config.StartupHookConfig{
 				{Name: "hook-1", Hook: func(ctx context.Context) error {
+					mu.Lock()
 					order = append(order, "hook-1")
+					mu.Unlock()
 					return nil
 				}},
 				{Name: "hook-2", Hook: func(ctx context.Context) error {
+					mu.Lock()
 					order = append(order, "hook-2")
+					mu.Unlock()
+					return nil
+				}},
+			},
+			PostStartupHooks: []config.StartupHookConfig{
+				{Name: "done", Hook: func(ctx context.Context) error {
+					close(hooksDone)
 					return nil
 				}},
 			},
@@ -414,20 +426,25 @@ func TestServer_StartupHooks_RunInOrder(t *testing.T) {
 	server.listener = listener
 	server.server = &http.Server{Addr: listener.Addr().String()}
 
-	// Start server in goroutine - it will fail because we don't actually run it
-	// but startup hooks will run
+	// Start server in goroutine
 	go func() {
 		_ = server.Start()
 	}()
 
-	// Give time for startup hooks to run
-	time.Sleep(100 * time.Millisecond)
+	// Wait for hooks to complete
+	select {
+	case <-hooksDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for hooks")
+	}
 
 	// Shutdown to clean up
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	_ = server.Shutdown(ctx)
 
+	mu.Lock()
+	defer mu.Unlock()
 	if len(order) != 2 {
 		t.Errorf("Expected 2 hooks to run, got %d", len(order))
 	}
@@ -572,14 +589,20 @@ func TestServer_StartupHook_RespectsContextCancellation(t *testing.T) {
 
 func TestServer_StartupHook_ViaRegisterMethod(t *testing.T) {
 	var order []string
+	var mu sync.Mutex
+	hooksDone := make(chan struct{})
 	server := New()
 
 	server.RegisterStartupHook("hook-a", func(ctx context.Context) error {
+		mu.Lock()
 		order = append(order, "hook-a")
+		mu.Unlock()
 		return nil
 	})
 	server.RegisterStartupHook("hook-b", func(ctx context.Context) error {
+		mu.Lock()
 		order = append(order, "hook-b")
+		mu.Unlock()
 		return nil
 	})
 
@@ -587,7 +610,18 @@ func TestServer_StartupHook_ViaRegisterMethod(t *testing.T) {
 	server.startupHooks = append(server.startupHooks, config.StartupHookConfig{
 		Name: "hook-config",
 		Hook: func(ctx context.Context) error {
+			mu.Lock()
 			order = append(order, "hook-config")
+			mu.Unlock()
+			return nil
+		},
+	})
+
+	// Add post-startup hook to signal completion
+	server.postStartupHooks = append(server.postStartupHooks, config.StartupHookConfig{
+		Name: "done",
+		Hook: func(ctx context.Context) error {
+			close(hooksDone)
 			return nil
 		},
 	})
@@ -600,13 +634,20 @@ func TestServer_StartupHook_ViaRegisterMethod(t *testing.T) {
 		_ = server.Start()
 	}()
 
-	time.Sleep(100 * time.Millisecond)
+	// Wait for hooks to complete
+	select {
+	case <-hooksDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for hooks")
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	_ = server.Shutdown(ctx)
 
 	// Should have 3 hooks: hook-a, hook-b, hook-config
+	mu.Lock()
+	defer mu.Unlock()
 	if len(order) != 3 {
 		t.Errorf("Expected 3 hooks to run, got %d: %v", len(order), order)
 	}
@@ -614,23 +655,32 @@ func TestServer_StartupHook_ViaRegisterMethod(t *testing.T) {
 
 func TestServer_StartupHookOrder(t *testing.T) {
 	var order []string
+	var mu sync.Mutex
+	hooksDone := make(chan struct{})
 	server := New(config.Config{
 		Lifecycle: config.LifecycleConfig{
 			PreStartupHooks: []config.StartupHookConfig{
 				{Name: "pre", Hook: func(ctx context.Context) error {
+					mu.Lock()
 					order = append(order, "pre")
+					mu.Unlock()
 					return nil
 				}},
 			},
 			StartupHooks: []config.StartupHookConfig{
 				{Name: "startup", Hook: func(ctx context.Context) error {
+					mu.Lock()
 					order = append(order, "startup")
+					mu.Unlock()
 					return nil
 				}},
 			},
 			PostStartupHooks: []config.StartupHookConfig{
 				{Name: "post", Hook: func(ctx context.Context) error {
+					mu.Lock()
 					order = append(order, "post")
+					mu.Unlock()
+					close(hooksDone)
 					return nil
 				}},
 			},
@@ -645,12 +695,19 @@ func TestServer_StartupHookOrder(t *testing.T) {
 		_ = server.Start()
 	}()
 
-	time.Sleep(100 * time.Millisecond)
+	// Wait for hooks to complete
+	select {
+	case <-hooksDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for hooks")
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	_ = server.Shutdown(ctx)
 
+	mu.Lock()
+	defer mu.Unlock()
 	if len(order) != 3 {
 		t.Errorf("Expected 3 hooks to run, got %d: %v", len(order), order)
 	}


### PR DESCRIPTION
Add LogLevel type with Debug/Info/Warn/Error/Panic/Fatal levels. Default logger now filters messages below configured level. Includes example, tests, and updated docs.

Fix race conditions in server lifecycle tests by adding proper synchronization for shared state access.