### PR TITLE
fix(compress): defer header flush until Write()

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -159,6 +159,8 @@ func (c *Compressor) Handler(next http.Handler) http.Handler {
 			}()
 		}
 		defer func() {
+			// Flush headers if not already flushed (e.g., for HEAD requests that don't write body)
+			cw.flushHeader()
 			// Record metric for encoding used
 			enc := encoding
 			if enc == "" {
@@ -244,6 +246,8 @@ type compressResponseWriter struct {
 	wroteHeader      bool
 	compressible     bool
 	isHeadRequest    bool
+	statusCode       int  // stored status for deferred WriteHeader
+	headerFlushed    bool // whether headers have been flushed to underlying ResponseWriter
 }
 
 func (cw *compressResponseWriter) isCompressible() bool {
@@ -266,13 +270,25 @@ func (cw *compressResponseWriter) WriteHeader(code int) {
 		return
 	}
 	cw.wroteHeader = true
-	defer cw.ResponseWriter.WriteHeader(code)
+	cw.statusCode = code
+	// Don't call underlying WriteHeader yet - defer until Write() is called
+	// This allows handlers to set status before writing body without breaking compression
+}
 
-	if cw.Header().Get(httpx.HeaderContentEncoding) != "" {
+// flushHeader writes the stored status and headers to the underlying ResponseWriter.
+// This is called on the first Write() to ensure headers are sent with the correct status.
+func (cw *compressResponseWriter) flushHeader() {
+	if cw.headerFlushed {
 		return
 	}
+	cw.headerFlushed = true
 
-	if cw.encoding != "" {
+	code := cw.statusCode
+	if code == 0 {
+		code = http.StatusOK
+	}
+
+	if cw.Header().Get(httpx.HeaderContentEncoding) == "" && cw.encoding != "" {
 		isCompressible := cw.isCompressible()
 		contentType := cw.Header().Get(httpx.HeaderContentType)
 
@@ -289,12 +305,12 @@ func (cw *compressResponseWriter) WriteHeader(code int) {
 			cw.compressible = true
 		}
 	}
+
+	cw.ResponseWriter.WriteHeader(code)
 }
 
 func (cw *compressResponseWriter) Write(p []byte) (int, error) {
-	if !cw.wroteHeader {
-		cw.WriteHeader(http.StatusOK)
-	}
+	cw.flushHeader()
 	// For HEAD requests, don't write body to response.
 	// We can't set Content-Length correctly because:
 	// 1. WriteHeader is already called by this point

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -1242,3 +1242,90 @@ func (p *testProvider) GetEncoder(encoding string) config.CompressionEncoder {
 	}
 	return nil
 }
+
+// TestCompress_WriteHeaderBeforeWrite tests that calling WriteHeader before Write
+// still works correctly with compression middleware
+func TestCompress_WriteHeaderBeforeWrite(t *testing.T) {
+	t.Run("status code is preserved when WriteHeader is called before Write", func(t *testing.T) {
+		mw := Compress(config.CompressConfig{
+			Types: []string{"text/html"},
+		})
+
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Header().Set(httpx.HeaderContentType, httpx.MIMETextHTML)
+			_, _ = w.Write([]byte("<html><body>Not Found</body></html>"))
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set(httpx.HeaderAcceptEncoding, httpx.ContentEncodingGzip)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusNotFound {
+			t.Errorf("expected status code %d, got %d", http.StatusNotFound, rr.Code)
+		}
+
+		if rr.Header().Get(httpx.HeaderContentEncoding) != httpx.ContentEncodingGzip {
+			t.Errorf("expected Content-Encoding=%q, got %q", httpx.ContentEncodingGzip, rr.Header().Get(httpx.HeaderContentEncoding))
+		}
+	})
+
+	t.Run("non-200 status codes work correctly", func(t *testing.T) {
+		mw := Compress(config.CompressConfig{
+			Types: []string{"application/json"},
+		})
+
+		testCases := []int{
+			http.StatusBadRequest,
+			http.StatusUnauthorized,
+			http.StatusForbidden,
+			http.StatusNotFound,
+			http.StatusInternalServerError,
+		}
+
+		for _, status := range testCases {
+			t.Run(fmt.Sprintf("status_%d", status), func(t *testing.T) {
+				handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(status)
+					w.Header().Set(httpx.HeaderContentType, httpx.MIMEApplicationJSON)
+					_, _ = w.Write([]byte(`{"error":"test"}`))
+				}))
+
+				req := httptest.NewRequest(http.MethodGet, "/test", nil)
+				req.Header.Set(httpx.HeaderAcceptEncoding, httpx.ContentEncodingGzip)
+				rr := httptest.NewRecorder()
+
+				handler.ServeHTTP(rr, req)
+
+				if rr.Code != status {
+					t.Errorf("expected status code %d, got %d", status, rr.Code)
+				}
+			})
+		}
+	})
+
+	t.Run("multiple WriteHeader calls use first status", func(t *testing.T) {
+		mw := Compress(config.CompressConfig{
+			Types: []string{"text/plain"},
+		})
+
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.WriteHeader(http.StatusOK) // Should be ignored
+			w.Header().Set(httpx.HeaderContentType, httpx.MIMETextPlain)
+			_, _ = w.Write([]byte("content"))
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set(httpx.HeaderAcceptEncoding, httpx.ContentEncodingGzip)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusNotFound {
+			t.Errorf("expected status code %d, got %d", http.StatusNotFound, rr.Code)
+		}
+	})
+}


### PR DESCRIPTION
  Allow handlers to call WriteHeader before Write without breaking
  compression middleware. ProblemDetail now implements error interface.