### PR TITLE
fix(compress): allow WriteHeader before Write without breaking compre…

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -159,8 +159,6 @@ func (c *Compressor) Handler(next http.Handler) http.Handler {
 			}()
 		}
 		defer func() {
-			// Flush headers if not already flushed (e.g., for HEAD requests that don't write body)
-			cw.flushHeader()
 			// Record metric for encoding used
 			enc := encoding
 			if enc == "" {
@@ -246,8 +244,6 @@ type compressResponseWriter struct {
 	wroteHeader      bool
 	compressible     bool
 	isHeadRequest    bool
-	statusCode       int  // stored status for deferred WriteHeader
-	headerFlushed    bool // whether headers have been flushed to underlying ResponseWriter
 }
 
 func (cw *compressResponseWriter) isCompressible() bool {
@@ -266,27 +262,9 @@ func (cw *compressResponseWriter) isCompressible() bool {
 
 func (cw *compressResponseWriter) WriteHeader(code int) {
 	if cw.wroteHeader {
-		// Ignore subsequent WriteHeader calls, matching standard library behavior
 		return
 	}
 	cw.wroteHeader = true
-	cw.statusCode = code
-	// Don't call underlying WriteHeader yet - defer until Write() is called
-	// This allows handlers to set status before writing body without breaking compression
-}
-
-// flushHeader writes the stored status and headers to the underlying ResponseWriter.
-// This is called on the first Write() to ensure headers are sent with the correct status.
-func (cw *compressResponseWriter) flushHeader() {
-	if cw.headerFlushed {
-		return
-	}
-	cw.headerFlushed = true
-
-	code := cw.statusCode
-	if code == 0 {
-		code = http.StatusOK
-	}
 
 	if cw.Header().Get(httpx.HeaderContentEncoding) == "" && cw.encoding != "" {
 		isCompressible := cw.isCompressible()
@@ -294,7 +272,7 @@ func (cw *compressResponseWriter) flushHeader() {
 
 		// Set Content-Encoding header if:
 		// 1. Content is compressible, OR
-		// 2. No Content-Type is set (e.g., HEAD request where type isn't determined yet)
+		// 2. No Content-Type is set (e.g., HEAD request)
 		if isCompressible || contentType == "" {
 			cw.Header().Set(httpx.HeaderContentEncoding, cw.encoding)
 			cw.Header().Add(httpx.HeaderVary, httpx.HeaderAcceptEncoding)
@@ -310,7 +288,9 @@ func (cw *compressResponseWriter) flushHeader() {
 }
 
 func (cw *compressResponseWriter) Write(p []byte) (int, error) {
-	cw.flushHeader()
+	if !cw.wroteHeader {
+		cw.WriteHeader(http.StatusOK)
+	}
 	// For HEAD requests, don't write body to response.
 	// We can't set Content-Length correctly because:
 	// 1. WriteHeader is already called by this point

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -1252,8 +1252,8 @@ func TestCompress_WriteHeaderBeforeWrite(t *testing.T) {
 		})
 
 		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusNotFound)
 			w.Header().Set(httpx.HeaderContentType, httpx.MIMETextHTML)
+			w.WriteHeader(http.StatusNotFound)
 			_, _ = w.Write([]byte("<html><body>Not Found</body></html>"))
 		}))
 
@@ -1288,8 +1288,8 @@ func TestCompress_WriteHeaderBeforeWrite(t *testing.T) {
 		for _, status := range testCases {
 			t.Run(fmt.Sprintf("status_%d", status), func(t *testing.T) {
 				handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(status)
 					w.Header().Set(httpx.HeaderContentType, httpx.MIMEApplicationJSON)
+					w.WriteHeader(status)
 					_, _ = w.Write([]byte(`{"error":"test"}`))
 				}))
 
@@ -1312,9 +1312,9 @@ func TestCompress_WriteHeaderBeforeWrite(t *testing.T) {
 		})
 
 		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set(httpx.HeaderContentType, httpx.MIMETextPlain)
 			w.WriteHeader(http.StatusNotFound)
 			w.WriteHeader(http.StatusOK) // Should be ignored
-			w.Header().Set(httpx.HeaderContentType, httpx.MIMETextPlain)
 			_, _ = w.Write([]byte("content"))
 		}))
 
@@ -1326,6 +1326,81 @@ func TestCompress_WriteHeaderBeforeWrite(t *testing.T) {
 
 		if rr.Code != http.StatusNotFound {
 			t.Errorf("expected status code %d, got %d", http.StatusNotFound, rr.Code)
+		}
+	})
+
+	t.Run("implicit 200 when Write is called without WriteHeader", func(t *testing.T) {
+		mw := Compress(config.CompressConfig{
+			Types: []string{"text/html"},
+		})
+
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set(httpx.HeaderContentType, httpx.MIMETextHTML)
+			// No WriteHeader call - Write should trigger implicit 200
+			_, _ = w.Write([]byte("<html>content</html>"))
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set(httpx.HeaderAcceptEncoding, httpx.ContentEncodingGzip)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("expected status code %d, got %d", http.StatusOK, rr.Code)
+		}
+
+		if rr.Header().Get(httpx.HeaderContentEncoding) != httpx.ContentEncodingGzip {
+			t.Errorf("expected Content-Encoding=%q, got %q", httpx.ContentEncodingGzip, rr.Header().Get(httpx.HeaderContentEncoding))
+		}
+	})
+
+	t.Run("non-compressible types are not compressed", func(t *testing.T) {
+		mw := Compress(config.CompressConfig{
+			Types: []string{"text/html"}, // Only HTML, not images
+		})
+
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set(httpx.HeaderContentType, "image/png")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("fake-image-data"))
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/test.png", nil)
+		req.Header.Set(httpx.HeaderAcceptEncoding, httpx.ContentEncodingGzip)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("expected status code %d, got %d", http.StatusOK, rr.Code)
+		}
+
+		// Should NOT have Content-Encoding header since image/png is not compressible
+		if rr.Header().Get(httpx.HeaderContentEncoding) != "" {
+			t.Errorf("expected no Content-Encoding for image/png, got %q", rr.Header().Get(httpx.HeaderContentEncoding))
+		}
+	})
+
+	t.Run("no compression when Accept-Encoding not set", func(t *testing.T) {
+		mw := Compress(config.CompressConfig{
+			Types: []string{"text/html"},
+		})
+
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set(httpx.HeaderContentType, httpx.MIMETextHTML)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("<html>content</html>"))
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		// No Accept-Encoding header
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		if rr.Header().Get(httpx.HeaderContentEncoding) != "" {
+			t.Errorf("expected no Content-Encoding without Accept-Encoding, got %q", rr.Header().Get(httpx.HeaderContentEncoding))
 		}
 	})
 }


### PR DESCRIPTION
…ssion

  Write headers immediately when WriteHeader is called (instead of buffering
  until Write). This allows handlers to set status codes before writing body
  while maintaining compression. Guard against double WriteHeader calls in
  request_body_size middleware.