### PR TITLE
fix(compress): add skip conditions and fix ETag integration

### DIFF
--- a/config/etag.go
+++ b/config/etag.go
@@ -55,7 +55,7 @@ type ETagConfig struct {
 // DefaultETagConfig contains the default values for ETag configuration
 var DefaultETagConfig = ETagConfig{
 	Algorithm:     FNV,
-	Weak:          Bool(true),
+	Weak:          Bool(false),
 	MaxBufferSize: 1024 * 1024, // 1MB
 	SkipStatusCodes: map[int]struct{}{
 		http.StatusNoContent:           {},

--- a/config/etag_test.go
+++ b/config/etag_test.go
@@ -12,8 +12,8 @@ func TestDefaultETagConfig(t *testing.T) {
 		t.Errorf("expected default algorithm to be FNV, got %s", cfg.Algorithm)
 	}
 
-	if cfg.Weak == nil || !*cfg.Weak {
-		t.Error("expected default Weak to be true")
+	if cfg.Weak == nil || *cfg.Weak {
+		t.Error("expected default Weak to be false")
 	}
 
 	if cfg.MaxBufferSize != 1024*1024 {

--- a/httpx/httpx.go
+++ b/httpx/httpx.go
@@ -187,10 +187,11 @@ const (
 
 	CacheControlNoCache        = "no-cache"
 	CacheControlNoStore        = "no-store"
-	CacheControlMustRevalidate = "must-revalidate"
-	CacheControlPublic         = "public"
-	CacheControlPrivate        = "private"
+	CacheControlNoTransform    = "no-transform"
 	CacheControlMaxAge         = "max-age"
+	CacheControlMustRevalidate = "must-revalidate"
+	CacheControlPrivate        = "private"
+	CacheControlPublic         = "public"
 
 	ContentEncodingGzip    = "gzip"
 	ContentEncodingDeflate = "deflate"

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -260,13 +260,45 @@ func (cw *compressResponseWriter) isCompressible() bool {
 	return false
 }
 
+// shouldCompress returns true if the response should be compressed based on various criteria
+func (cw *compressResponseWriter) shouldCompress(code int) bool {
+	// Skip 1xx Informational, 204 No Content, and 304 Not Modified
+	// These status codes don't have bodies per RFC 7230
+	if code < 200 || code == http.StatusNoContent || code == http.StatusNotModified {
+		return false
+	}
+
+	// Skip if Content-Encoding already set (already encoded)
+	if cw.Header().Get(httpx.HeaderContentEncoding) != "" {
+		return false
+	}
+
+	// Skip 206 Partial Content (range requests should not be transformed)
+	if code == http.StatusPartialContent {
+		return false
+	}
+
+	// Skip if Cache-Control: no-transform is set
+	cacheControl := cw.Header().Get(httpx.HeaderCacheControl)
+	if strings.Contains(cacheControl, httpx.CacheControlNoTransform) {
+		return false
+	}
+
+	// Skip if no encoding was selected
+	if cw.encoding == "" {
+		return false
+	}
+
+	return true
+}
+
 func (cw *compressResponseWriter) WriteHeader(code int) {
 	if cw.wroteHeader {
 		return
 	}
 	cw.wroteHeader = true
 
-	if cw.Header().Get(httpx.HeaderContentEncoding) == "" && cw.encoding != "" {
+	if cw.shouldCompress(code) {
 		isCompressible := cw.isCompressible()
 		contentType := cw.Header().Get(httpx.HeaderContentType)
 

--- a/middleware/compress_etag_test.go
+++ b/middleware/compress_etag_test.go
@@ -1,0 +1,337 @@
+package middleware
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/alexferl/zerohttp/config"
+	"github.com/alexferl/zerohttp/httpx"
+)
+
+// TestCompressETag_OrderIndependent verifies correct behavior regardless of
+// middleware order. Per RFC 7232, ETags must represent the actual bytes sent.
+// RECOMMENDED: Place ETag BEFORE Compress (ETag outer) so ETag captures
+// compressed bytes from the inner Compress middleware.
+// When Compress is before ETag, ETag captures uncompressed content.
+func TestCompressETag_OrderIndependent(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(httpx.HeaderContentType, httpx.MIMETextPlain)
+		_, _ = w.Write([]byte("hello world test content"))
+	})
+
+	// Order 1: Compress -> ETag (Compress inner, ETag outer - RECOMMENDED)
+	// ETag captures compressed content from inner Compress and computes correct ETag
+	compressMw := Compress(config.CompressConfig{
+		Types: []string{"text/plain"},
+	})
+	etagMw := ETag()
+	chain1 := etagMw(compressMw(handler))
+
+	// Order 2: ETag -> Compress (ETag inner, Compress outer - NOT RECOMMENDED)
+	// ETag captures uncompressed content before outer Compress compresses it
+	chain2 := compressMw(etagMw(handler))
+
+	// Request with Accept-Encoding: gzip
+	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req1.Header.Set(httpx.HeaderAcceptEncoding, httpx.ContentEncodingGzip)
+	rec1 := httptest.NewRecorder()
+	chain1.ServeHTTP(rec1, req1)
+
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req2.Header.Set(httpx.HeaderAcceptEncoding, httpx.ContentEncodingGzip)
+	rec2 := httptest.NewRecorder()
+	chain2.ServeHTTP(rec2, req2)
+
+	// Both should return Content-Encoding: gzip
+	if rec1.Header().Get(httpx.HeaderContentEncoding) != httpx.ContentEncodingGzip {
+		t.Errorf("chain1: expected Content-Encoding=%q, got %q",
+			httpx.ContentEncodingGzip, rec1.Header().Get(httpx.HeaderContentEncoding))
+	}
+	if rec2.Header().Get(httpx.HeaderContentEncoding) != httpx.ContentEncodingGzip {
+		t.Errorf("chain2: expected Content-Encoding=%q, got %q",
+			httpx.ContentEncodingGzip, rec2.Header().Get(httpx.HeaderContentEncoding))
+	}
+
+	// Both should have ETags
+	etag1 := rec1.Header().Get(httpx.HeaderETag)
+	etag2 := rec2.Header().Get(httpx.HeaderETag)
+	if etag1 == "" {
+		t.Error("chain1 (ETag->Compress): expected ETag header")
+	}
+	if etag2 == "" {
+		t.Error("chain2 (Compress->ETag): expected ETag header")
+	}
+
+	// ETags will be different because they're computed on different content:
+	// - chain1 (RECOMMENDED): ETag is for compressed content (correct)
+	// - chain2: ETag is for uncompressed content (incorrect when compressed)
+	if etag1 == etag2 {
+		t.Error("ETags should be different (one for compressed, one for uncompressed)")
+	}
+
+	// Both should return the same compressed body that decompresses to same content
+	body1 := decompressGzip(t, rec1.Body.Bytes())
+	body2 := decompressGzip(t, rec2.Body.Bytes())
+	if body1 != body2 {
+		t.Errorf("Bodies should be identical. Got:\n%s\nvs\n%s", body1, body2)
+	}
+}
+
+// TestCompressETag_AlreadyEncoded verifies behavior when response
+// already has Content-Encoding header set (should skip compression)
+func TestCompressETag_AlreadyEncoded(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(httpx.HeaderContentEncoding, "br") // Already encoded
+		w.Header().Set(httpx.HeaderContentType, httpx.MIMETextPlain)
+		_, _ = w.Write([]byte("already compressed"))
+	})
+
+	compressMw := Compress(config.CompressConfig{
+		Types: []string{"text/plain"},
+	})
+	etagMw := ETag()
+	chain := compressMw(etagMw(handler))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(httpx.HeaderAcceptEncoding, httpx.ContentEncodingGzip)
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+
+	// Should preserve the original Content-Encoding (br), not gzip
+	encoding := rec.Header().Get(httpx.HeaderContentEncoding)
+	if encoding != "br" {
+		t.Errorf("expected Content-Encoding to remain 'br', got %q", encoding)
+	}
+}
+
+// TestCompressETag_RangeRequest verifies that 206 Partial Content responses
+// are not compressed (per spec, range requests should not be transformed)
+func TestCompressETag_RangeRequest(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(httpx.HeaderContentType, httpx.MIMETextPlain)
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write([]byte("partial"))
+	})
+
+	compressMw := Compress(config.CompressConfig{
+		Types: []string{"text/plain"},
+	})
+	etagMw := ETag()
+	chain := compressMw(etagMw(handler))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(httpx.HeaderAcceptEncoding, httpx.ContentEncodingGzip)
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+
+	// 206 responses should not be compressed
+	if rec.Code != http.StatusPartialContent {
+		t.Errorf("expected status %d, got %d", http.StatusPartialContent, rec.Code)
+	}
+	if rec.Header().Get(httpx.HeaderContentEncoding) != "" {
+		t.Error("206 Partial Content should not be compressed")
+	}
+}
+
+// TestCompressETag_CacheControlNoTransform verifies that Cache-Control: no-transform
+// prevents compression
+func TestCompressETag_CacheControlNoTransform(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(httpx.HeaderCacheControl, httpx.CacheControlNoTransform)
+		w.Header().Set(httpx.HeaderContentType, httpx.MIMETextPlain)
+		_, _ = w.Write([]byte("do not transform"))
+	})
+
+	compressMw := Compress(config.CompressConfig{
+		Types: []string{"text/plain"},
+	})
+	etagMw := ETag()
+	chain := compressMw(etagMw(handler))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(httpx.HeaderAcceptEncoding, httpx.ContentEncodingGzip)
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+
+	// Should not be compressed when no-transform is set
+	if rec.Header().Get(httpx.HeaderContentEncoding) != "" {
+		t.Error("Cache-Control: no-transform should prevent compression")
+	}
+}
+
+// TestCompressETag_HeadRequest verifies HEAD requests negotiate compression
+// (headers reflect encoded representation) but body is empty
+func TestCompressETag_HeadRequest(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(httpx.HeaderContentType, httpx.MIMETextPlain)
+		// Write would be called but body discarded for HEAD
+		_, _ = w.Write([]byte("this is the body content"))
+	})
+
+	compressMw := Compress(config.CompressConfig{
+		Types: []string{"text/plain"},
+	})
+	etagMw := ETag()
+	chain := compressMw(etagMw(handler))
+
+	req := httptest.NewRequest(http.MethodHead, "/", nil)
+	req.Header.Set(httpx.HeaderAcceptEncoding, httpx.ContentEncodingGzip)
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+
+	// HEAD request should have Content-Encoding header set (negotiated)
+	if rec.Header().Get(httpx.HeaderContentEncoding) != httpx.ContentEncodingGzip {
+		t.Errorf("HEAD request should negotiate Content-Encoding, got %q",
+			rec.Header().Get(httpx.HeaderContentEncoding))
+	}
+
+	// HEAD request body should be empty
+	if rec.Body.Len() != 0 {
+		t.Errorf("HEAD request body should be empty, got %d bytes", rec.Body.Len())
+	}
+
+	// ETag should be present (reflecting the encoded representation)
+	if rec.Header().Get(httpx.HeaderETag) == "" {
+		t.Error("HEAD request should have ETag header")
+	}
+}
+
+// TestCompressETag_ETagRecomputedFromCompressedBytes verifies that ETags
+// are computed differently for compressed vs uncompressed content.
+// When ETag wraps Compress (RECOMMENDED order), the ETag is computed on compressed bytes.
+func TestCompressETag_ETagRecomputedFromCompressedBytes(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(httpx.HeaderContentType, httpx.MIMETextPlain)
+		_, _ = w.Write([]byte("test content for etag"))
+	})
+
+	// First, get ETag without compression
+	etagMw := ETag()
+	chainNoCompress := etagMw(handler)
+
+	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	// No Accept-Encoding, so no compression
+	rec1 := httptest.NewRecorder()
+	chainNoCompress.ServeHTTP(rec1, req1)
+
+	etagNoCompress := rec1.Header().Get(httpx.HeaderETag)
+	if etagNoCompress == "" {
+		t.Fatal("Expected ETag for uncompressed response")
+	}
+
+	// Now get ETag with compression using RECOMMENDED order (ETag wraps Compress)
+	compressMw := Compress(config.CompressConfig{
+		Types: []string{"text/plain"},
+	})
+	chainWithCompress := etagMw(compressMw(handler))
+
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req2.Header.Set(httpx.HeaderAcceptEncoding, httpx.ContentEncodingGzip)
+	rec2 := httptest.NewRecorder()
+	chainWithCompress.ServeHTTP(rec2, req2)
+
+	etagWithCompress := rec2.Header().Get(httpx.HeaderETag)
+	if etagWithCompress == "" {
+		t.Fatal("Expected ETag for compressed response when ETag wraps Compress")
+	}
+
+	// ETags should be different because content is different (compressed vs uncompressed)
+	if etagNoCompress == etagWithCompress {
+		t.Error("ETag should be different for compressed vs uncompressed content")
+	}
+
+	// Both should be strong ETags (no W/ prefix by default)
+	if !strings.HasPrefix(etagNoCompress, `"`) {
+		t.Errorf("Expected strong ETag format for uncompressed, got %s", etagNoCompress)
+	}
+	if !strings.HasPrefix(etagWithCompress, `"`) {
+		t.Errorf("Expected strong ETag format for compressed, got %s", etagWithCompress)
+	}
+}
+
+// TestCompress_StatusCodesWithoutBodies verifies that status codes without
+// bodies (1xx, 204, 304) are not compressed
+func TestCompress_StatusCodesWithoutBodies(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+	}{
+		{"100 Continue", http.StatusContinue},
+		{"101 Switching Protocols", http.StatusSwitchingProtocols},
+		{"204 No Content", http.StatusNoContent},
+		{"304 Not Modified", http.StatusNotModified},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set(httpx.HeaderContentType, httpx.MIMETextPlain)
+				w.WriteHeader(tt.status)
+			})
+
+			compressMw := Compress(config.CompressConfig{
+				Types: []string{"text/plain"},
+			})
+			chain := compressMw(handler)
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set(httpx.HeaderAcceptEncoding, httpx.ContentEncodingGzip)
+			rec := httptest.NewRecorder()
+			chain.ServeHTTP(rec, req)
+
+			if rec.Code != tt.status {
+				t.Errorf("expected status %d, got %d", tt.status, rec.Code)
+			}
+			// These status codes should not be compressed
+			if rec.Header().Get(httpx.HeaderContentEncoding) != "" {
+				t.Errorf("status %d should not be compressed", tt.status)
+			}
+		})
+	}
+}
+
+// TestCompressETag_VaryHeaderAdded verifies that Accept-Encoding is added to Vary
+func TestCompressETag_VaryHeaderAdded(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(httpx.HeaderContentType, httpx.MIMETextPlain)
+		_, _ = w.Write([]byte("test content"))
+	})
+
+	compressMw := Compress(config.CompressConfig{
+		Types: []string{"text/plain"},
+	})
+	etagMw := ETag()
+	chain := compressMw(etagMw(handler))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(httpx.HeaderAcceptEncoding, httpx.ContentEncodingGzip)
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+
+	// Vary header should include Accept-Encoding
+	vary := rec.Header()["Vary"]
+	if !slices.Contains(vary, httpx.HeaderAcceptEncoding) {
+		t.Errorf("Vary header should include %q, got %v", httpx.HeaderAcceptEncoding, vary)
+	}
+}
+
+// decompressGzip decompresses gzip-encoded bytes for testing
+func decompressGzip(t *testing.T, data []byte) string {
+	reader, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("failed to create gzip reader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	result, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("failed to decompress: %v", err)
+	}
+	return string(result)
+}

--- a/middleware/etag.go
+++ b/middleware/etag.go
@@ -292,6 +292,11 @@ func (ew *etagResponseWriter) finalizeLocked() {
 	}
 	ew.finalized = true
 
+	// Refresh content encoding from the actual response headers.
+	// This is needed because downstream middleware (e.g., Compress) may have
+	// set Content-Encoding after we initially captured it in writeHeaderLocked.
+	ew.contentEncoding = ew.ResponseWriter.Header().Get(httpx.HeaderContentEncoding)
+
 	etag := ew.generateETag()
 
 	if etag != "" {

--- a/middleware/etag_test.go
+++ b/middleware/etag_test.go
@@ -31,9 +31,12 @@ func TestETag_GeneratesETag(t *testing.T) {
 		t.Error("expected ETag header to be set")
 	}
 
-	// Check that it's a weak ETag by default
-	if !strings.HasPrefix(etag, `W/"`) {
-		t.Errorf("expected weak ETag to start with W/\", got %s", etag)
+	// Check that it's a strong ETag by default
+	if strings.HasPrefix(etag, `W/`) {
+		t.Errorf("expected strong ETag without W/ prefix, got %s", etag)
+	}
+	if !strings.HasPrefix(etag, `"`) {
+		t.Errorf("expected strong ETag to start with quote, got %s", etag)
 	}
 }
 
@@ -231,9 +234,9 @@ func TestETag_MD5Algorithm(t *testing.T) {
 		t.Error("expected different ETags for FNV and MD5 algorithms")
 	}
 
-	// MD5 produces 32 hex characters
-	if len(md5ETag) != len(`W/"`)+32+len(`"`) {
-		t.Errorf("expected MD5 ETag length to be %d, got %d", len(`W/"`)+32+len(`"`), len(md5ETag))
+	// MD5 produces 32 hex characters for strong ETag: " + 32hex + " = 34 chars
+	if len(md5ETag) != 34 {
+		t.Errorf("expected MD5 ETag length to be 34, got %d", len(md5ETag))
 	}
 }
 
@@ -389,7 +392,7 @@ func TestETag_ChangedContent(t *testing.T) {
 }
 
 func TestETag_NotModified_StrongVsWeak(t *testing.T) {
-	// Test that weak ETag from server matches strong ETag in If-None-Match
+	// Test that strong ETag from server matches weak ETag in If-None-Match
 	handler := ETag()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("hello world"))
 	}))
@@ -398,14 +401,14 @@ func TestETag_NotModified_StrongVsWeak(t *testing.T) {
 	rec1 := httptest.NewRecorder()
 	handler.ServeHTTP(rec1, req1)
 
-	// Extract just the hash part from the weak ETag (remove W/ prefix and quotes)
-	weakETag := rec1.Header().Get(httpx.HeaderETag)
-	hashPart := weakETag[3 : len(weakETag)-1] // Remove W/" and "
-	strongETag := `"` + hashPart + `"`
+	// Extract just the hash part from the strong ETag (remove quotes)
+	strongETag := rec1.Header().Get(httpx.HeaderETag)
+	hashPart := strongETag[1 : len(strongETag)-1] // Remove " and "
+	weakETag := `W/"` + hashPart + `"`
 
-	// Request with strong ETag should still match weak ETag
+	// Request with weak ETag should still match strong ETag
 	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
-	req2.Header.Set(httpx.HeaderIfNoneMatch, strongETag)
+	req2.Header.Set(httpx.HeaderIfNoneMatch, weakETag)
 	rec2 := httptest.NewRecorder()
 	handler.ServeHTTP(rec2, req2)
 


### PR DESCRIPTION
  - Skip compression for 1xx/204/304, 206 range requests, already-encoded responses, and Cache-Control: no-transform
  - Fix ETag to recompute when compression is applied downstream
  - Change default ETag from weak to strong per RFC 7232
  - Add comprehensive Compress+ETag integration tests