### PR TITLE
refactor: remove duplicate IsBindingError function

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -124,11 +124,6 @@ func IsBindError(err error) bool {
 	return zerrors.IsBindError(err)
 }
 
-// IsBindingError checks if an error is a binding error (should return 400).
-func IsBindingError(err error) bool {
-	return IsBindError(err)
-}
-
 // IsValidationError checks if an error is a validation error (should return 422).
 func IsValidationError(err error) bool {
 	var validationErrorer ValidationErrorer

--- a/validate_test.go
+++ b/validate_test.go
@@ -550,7 +550,7 @@ func TestBindAndValidate(t *testing.T) {
 					t.Errorf("expected error, got nil")
 					return
 				}
-				if tt.isBindingError && !IsBindingError(err) {
+				if tt.isBindingError && !IsBindError(err) {
 					t.Errorf("expected binding error, got %T: %v", err, err)
 				}
 				if !tt.isBindingError && !IsValidationError(err) {
@@ -649,9 +649,9 @@ func TestBindError_Unwrap(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	// Test IsBindingError with nil
-	if IsBindingError(nil) {
-		t.Error("expected IsBindingError(nil) to be false")
+	// Test IsBindError with nil
+	if IsBindError(nil) {
+		t.Error("expected IsBindError(nil) to be false")
 	}
 	// Test errors.As works with wrapped error
 	var bindErr *BindError


### PR DESCRIPTION
IsBindingError was just an alias for IsBindError. Keep the shorter name to match BindError type and internal package naming.