### PR TITLE
fix: RenderAndValidate returns 500 instead of 422

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -145,7 +145,8 @@ func IsValidationError(err error) bool {
 func RenderAndValidate(w http.ResponseWriter, status int, data any) error {
 	if err := V.Struct(data); err != nil {
 		// Log error for developers - this is a server-side bug
-		return fmt.Errorf("invalid response data: %w", err)
+		// Use %v (not %w) to prevent errors.As from matching ValidationErrorer
+		return fmt.Errorf("invalid response data: %v", err)
 	}
 	return R.JSON(w, status, data)
 }

--- a/validate_integration_test.go
+++ b/validate_integration_test.go
@@ -358,3 +358,37 @@ func TestValidationWithAndWithoutRecoverMiddleware(t *testing.T) {
 		}
 	}
 }
+
+// TestRenderAndValidate_Returns500 tests that RenderAndValidate returns 500 (not 422)
+// when response validation fails. This is a server-side bug, not a client error.
+func TestRenderAndValidate_Returns500(t *testing.T) {
+	type TestResponse struct {
+		Name  string `json:"name" validate:"required,min=2"`
+		Email string `json:"email" validate:"required,email"`
+	}
+
+	handler := HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		// Create invalid response data (simulating a server bug)
+		data := TestResponse{Name: "J", Email: "not-an-email"}
+		return RenderAndValidate(w, http.StatusOK, data)
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
+	if err != nil {
+		t.Fatalf("failed to make request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Should return 500, NOT 422 - this is a server bug, not client error
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected status %d (Internal Server Error), got %d", http.StatusInternalServerError, resp.StatusCode)
+	}
+
+	// Verify it's not returning 422 Unprocessable Entity
+	if resp.StatusCode == http.StatusUnprocessableEntity {
+		t.Error("RenderAndValidate incorrectly returned 422 Unprocessable Entity - should be 500 for server-side bugs")
+	}
+}


### PR DESCRIPTION
Use %v instead of %w when wrapping validation errors to prevent errors.As from matching ValidationErrorer interface. Response validation failures are server-side bugs, not client errors.