### PR TITLE
fix(validator): remove double colon from non-struct validation errors

### DIFF
--- a/router.go
+++ b/router.go
@@ -140,6 +140,9 @@ func handleHandlerError(w http.ResponseWriter, err error) {
 	}
 
 	// For all other errors, return 500 Internal Server Error
+	// Log the actual error for debugging
+	log.GetGlobalLogger().Error("Handler error", log.E(err))
+
 	w.Header().Set(httpx.HeaderContentType, httpx.MIMEApplicationProblemJSON)
 	w.WriteHeader(http.StatusInternalServerError)
 	response := map[string]any{

--- a/validate.go
+++ b/validate.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 
 	"github.com/alexferl/zerohttp/httpx"
@@ -119,10 +120,35 @@ func IsValidationError(err error) bool {
 //	    return zh.RenderAndValidate(w, http.StatusOK, user)
 //	}
 func RenderAndValidate(w http.ResponseWriter, status int, data any) error {
-	if err := V.Struct(data); err != nil {
+	if err := validateResponseData(data); err != nil {
 		// Log error for developers - this is a server-side bug
 		// Use %v (not %w) to prevent errors.As from matching ValidationErrorer
 		return fmt.Errorf("invalid response data: %v", err)
 	}
 	return R.JSON(w, status, data)
+}
+
+// validateResponseData validates data for response rendering.
+// It handles both structs and slices of structs.
+func validateResponseData(data any) error {
+	v := reflect.ValueOf(data)
+
+	// Handle pointer
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	// Handle slices - validate each element
+	if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
+		for i := 0; i < v.Len(); i++ {
+			elem := v.Index(i).Interface()
+			if err := V.Struct(elem); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// Handle structs
+	return V.Struct(data)
 }

--- a/validate_test.go
+++ b/validate_test.go
@@ -141,6 +141,83 @@ func TestRenderAndValidate(t *testing.T) {
 			t.Errorf("expected error to contain 'invalid response data', got %v", err)
 		}
 	})
+
+	t.Run("valid slice of structs", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		data := []TestResponse{
+			{Name: "John", Email: "john@example.com"},
+			{Name: "Jane", Email: "jane@example.com"},
+		}
+		err := RenderAndValidate(w, http.StatusOK, data)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+			return
+		}
+		if w.Code != http.StatusOK {
+			t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+		}
+	})
+
+	t.Run("invalid slice of structs", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		data := []TestResponse{
+			{Name: "John", Email: "john@example.com"},
+			{Name: "J", Email: "invalid"}, // invalid entry
+		}
+		err := RenderAndValidate(w, http.StatusOK, data)
+		if err == nil {
+			t.Errorf("expected error, got nil")
+			return
+		}
+		if !strings.Contains(err.Error(), "invalid response data") {
+			t.Errorf("expected error to contain 'invalid response data', got %v", err)
+		}
+	})
+
+	t.Run("valid pointer to slice of structs", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		data := &[]TestResponse{
+			{Name: "John", Email: "john@example.com"},
+			{Name: "Jane", Email: "jane@example.com"},
+		}
+		err := RenderAndValidate(w, http.StatusOK, data)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+			return
+		}
+		if w.Code != http.StatusOK {
+			t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+		}
+	})
+
+	t.Run("valid array of structs", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		data := [2]TestResponse{
+			{Name: "John", Email: "john@example.com"},
+			{Name: "Jane", Email: "jane@example.com"},
+		}
+		err := RenderAndValidate(w, http.StatusOK, data)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+			return
+		}
+		if w.Code != http.StatusOK {
+			t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+		}
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		data := []TestResponse{}
+		err := RenderAndValidate(w, http.StatusOK, data)
+		if err != nil {
+			t.Errorf("expected no error for empty slice, got %v", err)
+			return
+		}
+		if w.Code != http.StatusOK {
+			t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+		}
+	})
 }
 
 func TestBindError_Unwrap(t *testing.T) {

--- a/validator/errors.go
+++ b/validator/errors.go
@@ -18,7 +18,11 @@ func (ve ValidationErrors) Error() string {
 
 	var parts []string
 	for field, errs := range ve {
-		parts = append(parts, fmt.Sprintf("%s: %s", field, strings.Join(errs, ", ")))
+		if field == "" {
+			parts = append(parts, strings.Join(errs, ", "))
+		} else {
+			parts = append(parts, fmt.Sprintf("%s: %s", field, strings.Join(errs, ", ")))
+		}
 	}
 	return "validation failed: " + strings.Join(parts, "; ")
 }


### PR DESCRIPTION
Add test coverage for slice/array struct validation in RenderAndValidate.