### PR TITLE
feat(jwtauth): add storage adapter for token revocation

### DIFF
--- a/middleware/jwtauth/adapter.go
+++ b/middleware/jwtauth/adapter.go
@@ -1,0 +1,84 @@
+package jwtauth
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/alexferl/zerohttp/storage"
+)
+
+// StorageAdapter wraps a storage.Storage to implement RevocationStore.
+// This allows jwtauth to use any storage.Storage backend for token revocation.
+type StorageAdapter struct {
+	storage   storage.Storage
+	keyPrefix string
+}
+
+// StorageAdapterConfig configures the StorageAdapter.
+type StorageAdapterConfig struct {
+	// KeyPrefix is the prefix for revocation keys.
+	// Default: "jwt:revoke:"
+	KeyPrefix string
+}
+
+// DefaultStorageAdapterConfig is the default configuration for StorageAdapter.
+var DefaultStorageAdapterConfig = StorageAdapterConfig{
+	KeyPrefix: "jwt:revoke:",
+}
+
+// NewStorageAdapter creates a RevocationStore from a storage.Storage.
+// This allows sharing the same storage backend between idempotency, cache, and jwtauth.
+//
+// Example:
+//
+//	redisStorage := storage.NewRedisStorage(redisClient, storage.RedisStorageConfig{
+//	    KeyPrefix: "app:",
+//	})
+//	revocationStore := jwtauth.NewStorageAdapter(redisStorage)
+//
+//	// Use with HS256Store for revocation support
+//	store := jwtauth.NewHS256StoreWithRevocation(secret, jwtauth.HS256Config{}, revocationStore)
+//
+//	// Or use with a custom Store
+//	type myStore struct {
+//	    jwtauth.RevocationStore
+//	    // ... other fields
+//	}
+func NewStorageAdapter(s storage.Storage, cfg ...StorageAdapterConfig) RevocationStore {
+	c := DefaultStorageAdapterConfig
+	if len(cfg) > 0 {
+		if cfg[0].KeyPrefix != "" {
+			c.KeyPrefix = cfg[0].KeyPrefix
+		}
+	}
+
+	return &StorageAdapter{
+		storage:   s,
+		keyPrefix: c.KeyPrefix,
+	}
+}
+
+func (a *StorageAdapter) revokeKey(jti string) string {
+	return a.keyPrefix + jti
+}
+
+// Revoke stores a revocation marker for the given JTI with the specified TTL.
+// The marker value is a simple "1" to minimize storage.
+func (a *StorageAdapter) Revoke(ctx context.Context, jti string, ttl time.Duration) error {
+	return a.storage.Set(ctx, a.revokeKey(jti), []byte("1"), ttl)
+}
+
+// IsRevoked checks if a revocation marker exists for the given JTI.
+func (a *StorageAdapter) IsRevoked(ctx context.Context, jti string) (bool, error) {
+	_, found, err := a.storage.Get(ctx, a.revokeKey(jti))
+	if err != nil {
+		return false, fmt.Errorf("failed to check token revocation: %w", err)
+	}
+	return found, nil
+}
+
+// Close releases resources associated with the underlying storage.
+func (a *StorageAdapter) Close() error {
+	return a.storage.Close()
+}

--- a/middleware/jwtauth/adapter_test.go
+++ b/middleware/jwtauth/adapter_test.go
@@ -1,0 +1,156 @@
+package jwtauth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alexferl/zerohttp/storage"
+	"github.com/alexferl/zerohttp/zhtest"
+)
+
+// mockStorage is a simple in-memory storage implementation for testing
+type mockStorage struct {
+	data map[string]mockEntry
+}
+
+type mockEntry struct {
+	value []byte
+	ttl   time.Duration
+}
+
+func newMockStorage() *mockStorage {
+	return &mockStorage{
+		data: make(map[string]mockEntry),
+	}
+}
+
+func (m *mockStorage) Get(ctx context.Context, key string) ([]byte, bool, error) {
+	entry, ok := m.data[key]
+	return entry.value, ok, nil
+}
+
+func (m *mockStorage) Set(ctx context.Context, key string, val []byte, ttl time.Duration) error {
+	m.data[key] = mockEntry{value: val, ttl: ttl}
+	return nil
+}
+
+func (m *mockStorage) Delete(ctx context.Context, key string) error {
+	delete(m.data, key)
+	return nil
+}
+
+func (m *mockStorage) Close() error {
+	return nil
+}
+
+func TestNewStorageAdapter(t *testing.T) {
+	mock := newMockStorage()
+
+	t.Run("default config", func(t *testing.T) {
+		adapter := NewStorageAdapter(mock)
+		zhtest.AssertNotNil(t, adapter)
+
+		sa, ok := adapter.(*StorageAdapter)
+		zhtest.AssertTrue(t, ok)
+		zhtest.AssertEqual(t, "jwt:revoke:", sa.keyPrefix)
+	})
+
+	t.Run("custom prefix", func(t *testing.T) {
+		adapter := NewStorageAdapter(mock, StorageAdapterConfig{KeyPrefix: "custom:"})
+		zhtest.AssertNotNil(t, adapter)
+
+		sa, ok := adapter.(*StorageAdapter)
+		zhtest.AssertTrue(t, ok)
+		zhtest.AssertEqual(t, "custom:", sa.keyPrefix)
+	})
+
+	t.Run("empty prefix uses default", func(t *testing.T) {
+		adapter := NewStorageAdapter(mock, StorageAdapterConfig{KeyPrefix: ""})
+		zhtest.AssertNotNil(t, adapter)
+
+		sa, ok := adapter.(*StorageAdapter)
+		zhtest.AssertTrue(t, ok)
+		zhtest.AssertEqual(t, "jwt:revoke:", sa.keyPrefix)
+	})
+}
+
+func TestStorageAdapter_Revoke(t *testing.T) {
+	mock := newMockStorage()
+	adapter := NewStorageAdapter(mock, StorageAdapterConfig{KeyPrefix: "test:"})
+	ctx := context.Background()
+
+	t.Run("revoke token", func(t *testing.T) {
+		err := adapter.Revoke(ctx, "token-123", time.Hour)
+		zhtest.AssertNoError(t, err)
+
+		// Verify stored with correct key and value
+		entry, ok := mock.data["test:token-123"]
+		zhtest.AssertTrue(t, ok)
+		zhtest.AssertEqual(t, "1", string(entry.value))
+		zhtest.AssertEqual(t, time.Hour, entry.ttl)
+	})
+
+	t.Run("revoke with different TTL", func(t *testing.T) {
+		err := adapter.Revoke(ctx, "token-456", 30*time.Minute)
+		zhtest.AssertNoError(t, err)
+
+		entry, ok := mock.data["test:token-456"]
+		zhtest.AssertTrue(t, ok)
+		zhtest.AssertEqual(t, 30*time.Minute, entry.ttl)
+	})
+}
+
+func TestStorageAdapter_IsRevoked(t *testing.T) {
+	mock := newMockStorage()
+	adapter := NewStorageAdapter(mock, StorageAdapterConfig{KeyPrefix: "test:"})
+	ctx := context.Background()
+
+	t.Run("token is revoked", func(t *testing.T) {
+		// Pre-populate revoked token
+		mock.data["test:revoked-token"] = mockEntry{value: []byte("1")}
+
+		revoked, err := adapter.IsRevoked(ctx, "revoked-token")
+		zhtest.AssertNoError(t, err)
+		zhtest.AssertTrue(t, revoked)
+	})
+
+	t.Run("token is not revoked", func(t *testing.T) {
+		revoked, err := adapter.IsRevoked(ctx, "valid-token")
+		zhtest.AssertNoError(t, err)
+		zhtest.AssertFalse(t, revoked)
+	})
+}
+
+func TestStorageAdapter_Close(t *testing.T) {
+	mock := newMockStorage()
+	adapter := NewStorageAdapter(mock)
+
+	err := adapter.Close()
+	zhtest.AssertNoError(t, err)
+}
+
+func TestStorageAdapter_Integration(t *testing.T) {
+	mock := newMockStorage()
+	adapter := NewStorageAdapter(mock)
+	ctx := context.Background()
+
+	// Full flow: revoke and check
+	err := adapter.Revoke(ctx, "refresh-token-1", time.Hour)
+	zhtest.AssertNoError(t, err)
+
+	revoked, err := adapter.IsRevoked(ctx, "refresh-token-1")
+	zhtest.AssertNoError(t, err)
+	zhtest.AssertTrue(t, revoked)
+
+	// Check different token is not revoked
+	revoked, err = adapter.IsRevoked(ctx, "refresh-token-2")
+	zhtest.AssertNoError(t, err)
+	zhtest.AssertFalse(t, revoked)
+}
+
+// Verify StorageAdapter implements RevocationStore interface
+var _ RevocationStore = (*StorageAdapter)(nil)
+
+// Verify storage.Storage interface compatibility
+var _ storage.Storage = (*mockStorage)(nil)

--- a/middleware/jwtauth/doc.go
+++ b/middleware/jwtauth/doc.go
@@ -8,7 +8,7 @@
 //	import "github.com/alexferl/zerohttp/middleware/jwtauth"
 //
 //	app.Use(jwtauth.New(jwtauth.Config{
-//	    TokenStore: myTokenStore,
+//	    Store: myStore,
 //	    RequiredClaims: []string{"sub"},
 //	}))
 //
@@ -17,8 +17,20 @@
 // For a zero-dependency option, use the built-in HS256 implementation:
 //
 //	app.Use(jwtauth.New(jwtauth.Config{
-//	    TokenStore: jwtauth.NewHS256TokenStore(secret, opts),
+//	    Store: jwtauth.NewHS256Store(secret, opts),
 //	}))
+//
+// # Token Revocation
+//
+// For token revocation (logout/refresh), implement Revoke and IsRevoked on your Store,
+// or use the StorageAdapter with a shared storage backend:
+//
+//	// Share storage between idempotency, cache, and jwtauth
+//	redisStorage := storage.NewRedisStorage(redisClient, storage.RedisStorageConfig{})
+//	revocationStore := jwtauth.NewStorageAdapter(redisStorage)
+//
+//	// Use with your custom Store
+//	myStore := &myStoreImpl{RevocationStore: revocationStore}
 //
 // # Accessing Claims
 //

--- a/middleware/jwtauth/store.go
+++ b/middleware/jwtauth/store.go
@@ -1,0 +1,36 @@
+package jwtauth
+
+import (
+	"context"
+	"time"
+)
+
+// RevocationStore defines the interface for JWT token revocation storage.
+// This is a subset of the Store interface, focused only on revocation operations.
+type RevocationStore interface {
+	// Revoke invalidates a token by its JTI (JWT ID).
+	// The TTL should be set to the remaining token lifetime.
+	// Returns an error if the revocation operation fails.
+	Revoke(ctx context.Context, jti string, ttl time.Duration) error
+
+	// IsRevoked checks if a token has been revoked by its JTI.
+	// Returns (true, nil) if revoked, (false, nil) if not revoked.
+	// Returns error if the check fails.
+	IsRevoked(ctx context.Context, jti string) (bool, error)
+
+	// Close releases resources associated with the store.
+	// Returns an error if the close operation fails.
+	Close() error
+}
+
+// GetJTI extracts the JWT ID (jti) claim from the claims map.
+// Returns empty string if jti is not present or not a string.
+func GetJTI(claims map[string]any) string {
+	if claims == nil {
+		return ""
+	}
+	if jti, ok := claims[JWTClaimJWTID].(string); ok {
+		return jti
+	}
+	return ""
+}

--- a/middleware/jwtauth/store_test.go
+++ b/middleware/jwtauth/store_test.go
@@ -1,0 +1,56 @@
+package jwtauth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alexferl/zerohttp/zhtest"
+)
+
+func TestGetJTI(t *testing.T) {
+	t.Run("jti present", func(t *testing.T) {
+		claims := map[string]any{JWTClaimJWTID: "abc-123"}
+		jti := GetJTI(claims)
+		zhtest.AssertEqual(t, "abc-123", jti)
+	})
+
+	t.Run("jti missing", func(t *testing.T) {
+		claims := map[string]any{"sub": "user123"}
+		jti := GetJTI(claims)
+		zhtest.AssertEqual(t, "", jti)
+	})
+
+	t.Run("jti not string", func(t *testing.T) {
+		claims := map[string]any{JWTClaimJWTID: 123}
+		jti := GetJTI(claims)
+		zhtest.AssertEqual(t, "", jti)
+	})
+
+	t.Run("nil claims", func(t *testing.T) {
+		jti := GetJTI(nil)
+		zhtest.AssertEqual(t, "", jti)
+	})
+
+	t.Run("empty claims", func(t *testing.T) {
+		jti := GetJTI(map[string]any{})
+		zhtest.AssertEqual(t, "", jti)
+	})
+}
+
+// Verify RevocationStore interface can be implemented
+type testRevocationStore struct{}
+
+func (t *testRevocationStore) Revoke(ctx context.Context, jti string, ttl time.Duration) error {
+	return nil
+}
+
+func (t *testRevocationStore) IsRevoked(ctx context.Context, jti string) (bool, error) {
+	return false, nil
+}
+
+func (t *testRevocationStore) Close() error {
+	return nil
+}
+
+var _ RevocationStore = (*testRevocationStore)(nil)


### PR DESCRIPTION
Add RevocationStore interface and StorageAdapter to allow jwtauth to share the same storage.Storage backend as idempotency and cache.

- store.go: RevocationStore interface with Revoke/IsRevoked/Close methods
- adapter.go: StorageAdapter wrapping storage.Storage
- GetJTI helper to extract JWT ID from claims
- Split tests across store_test.go and adapter_test.go
- Update package documentation