### PR TITLE
feat(cache,idempotency): add KeyPrefix config option to StorageAdapter

### DIFF
--- a/examples/middleware/tracer_jaeger/README.md
+++ b/examples/middleware/tracer_jaeger/README.md
@@ -16,7 +16,12 @@ This example demonstrates distributed tracing with Jaeger using OpenTelemetry.
 # Start Jaeger container
 docker run -d --name jaeger \
   -p 16686:16686 \
+  -p 4317:4317 \
   -p 4318:4318 \
+  -p 14250:14250 \
+  -p 14268:14268 \
+  -p 14269:14269 \
+  -p 9411:9411 \
   jaegertracing/all-in-one:latest
 
 # Verify Jaeger is running

--- a/middleware/cache/adapter.go
+++ b/middleware/cache/adapter.go
@@ -23,6 +23,10 @@ func (JSONCodec) Unmarshal(data []byte, v any) error { return json.Unmarshal(dat
 
 // StorageAdapterConfig configures the StorageAdapter.
 type StorageAdapterConfig struct {
+	// KeyPrefix is the prefix for cache keys.
+	// Default: "cache:"
+	KeyPrefix string
+
 	// Codec is the serialization codec for cache records.
 	// Default: JSONCodec
 	Codec Codec
@@ -30,13 +34,15 @@ type StorageAdapterConfig struct {
 
 // DefaultStorageAdapterConfig is the default configuration for StorageAdapter.
 var DefaultStorageAdapterConfig = StorageAdapterConfig{
-	Codec: JSONCodec{},
+	KeyPrefix: "cache:",
+	Codec:     JSONCodec{},
 }
 
 // StorageAdapter wraps a storage.Storage to implement the cache.Store interface.
 type StorageAdapter struct {
-	store storage.Storage
-	codec Codec
+	store     storage.Storage
+	keyPrefix string
+	codec     Codec
 }
 
 // NewStorageAdapter creates a cache.Store from a storage.Storage.
@@ -46,14 +52,19 @@ func NewStorageAdapter(s storage.Storage, cfg ...StorageAdapterConfig) Store {
 		zconfig.Merge(&c, cfg[0])
 	}
 	return &StorageAdapter{
-		store: s,
-		codec: c.Codec,
+		store:     s,
+		keyPrefix: c.KeyPrefix,
+		codec:     c.Codec,
 	}
+}
+
+func (a *StorageAdapter) prefixKey(key string) string {
+	return a.keyPrefix + key
 }
 
 // Get retrieves a cached record by key.
 func (a *StorageAdapter) Get(ctx context.Context, key string) (Record, bool, error) {
-	data, found, err := a.store.Get(ctx, key)
+	data, found, err := a.store.Get(ctx, a.prefixKey(key))
 	if !found || err != nil {
 		return Record{}, false, err
 	}
@@ -73,12 +84,12 @@ func (a *StorageAdapter) Set(ctx context.Context, key string, rec Record, ttl ti
 		return err
 	}
 
-	return a.store.Set(ctx, key, data, ttl)
+	return a.store.Set(ctx, a.prefixKey(key), data, ttl)
 }
 
 // Delete removes a cached record by key.
 func (a *StorageAdapter) Delete(ctx context.Context, key string) error {
-	return a.store.Delete(ctx, key)
+	return a.store.Delete(ctx, a.prefixKey(key))
 }
 
 // Close releases resources associated with the underlying storage.

--- a/middleware/cache/adapter_test.go
+++ b/middleware/cache/adapter_test.go
@@ -79,7 +79,7 @@ func TestStorageAdapter_Get(t *testing.T) {
 	})
 
 	t.Run("invalid json", func(t *testing.T) {
-		s.data["bad"] = []byte("not json")
+		s.data["cache:bad"] = []byte("not json")
 		_, _, err := adapter.Get(ctx, "bad")
 		zhtest.AssertError(t, err)
 	})
@@ -99,15 +99,15 @@ func TestStorageAdapter_Set(t *testing.T) {
 
 	zhtest.AssertNoError(t, adapter.Set(ctx, "key", rec, ttl))
 
-	// Verify raw storage has JSON data
-	data, ok := s.data["key"]
+	// Verify raw storage has JSON data (with prefix)
+	data, ok := s.data["cache:key"]
 	zhtest.AssertTrue(t, ok)
 
 	// Verify it's valid JSON
 	zhtest.AssertGreater(t, len(data), 0)
 
-	// Verify TTL is stored
-	zhtest.AssertEqual(t, ttl, s.ttlVals["key"])
+	// Verify TTL is stored (with prefix)
+	zhtest.AssertEqual(t, ttl, s.ttlVals["cache:key"])
 }
 
 func TestStorageAdapter_Delete(t *testing.T) {
@@ -115,15 +115,15 @@ func TestStorageAdapter_Delete(t *testing.T) {
 	s := newMockStorage()
 	adapter := NewStorageAdapter(s)
 
-	// Store something first
-	s.data["test"] = []byte("value")
-	s.ttlVals["test"] = time.Minute
+	// Store something first (with prefix that adapter will use)
+	s.data["cache:test"] = []byte("value")
+	s.ttlVals["cache:test"] = time.Minute
 
 	zhtest.AssertNoError(t, adapter.Delete(ctx, "test"))
 
-	_, ok := s.data["test"]
+	_, ok := s.data["cache:test"]
 	zhtest.AssertFalse(t, ok)
-	_, ok = s.ttlVals["test"]
+	_, ok = s.ttlVals["cache:test"]
 	zhtest.AssertFalse(t, ok)
 }
 
@@ -181,7 +181,7 @@ func TestStorageAdapter_CustomCodec(t *testing.T) {
 	zhtest.AssertNoError(t, adapter.Set(ctx, "key", rec, time.Minute))
 
 	// Check that custom codec was used (prepends "MOCK:")
-	data := s.data["key"]
+	data := s.data["cache:key"]
 	zhtest.AssertEqual(t, "MOCK:", string(data))
 
 	// Get via adapter - should use custom codec

--- a/middleware/idempotency/adapter.go
+++ b/middleware/idempotency/adapter.go
@@ -23,6 +23,10 @@ func (JSONCodec) Unmarshal(data []byte, v any) error { return json.Unmarshal(dat
 
 // StorageAdapterConfig configures the StorageAdapter.
 type StorageAdapterConfig struct {
+	// KeyPrefix is the prefix for idempotency keys.
+	// Default: "idemp:"
+	KeyPrefix string
+
 	// LockTTL is the TTL for distributed locks.
 	// Default: 30s
 	LockTTL time.Duration
@@ -34,16 +38,18 @@ type StorageAdapterConfig struct {
 
 // DefaultStorageAdapterConfig is the default configuration for StorageAdapter.
 var DefaultStorageAdapterConfig = StorageAdapterConfig{
-	LockTTL: 30 * time.Second,
-	Codec:   JSONCodec{},
+	KeyPrefix: "idemp:",
+	LockTTL:   30 * time.Second,
+	Codec:     JSONCodec{},
 }
 
 // StorageAdapter wraps a storage.Storage to implement the idempotency.Store interface.
 type StorageAdapter struct {
-	store   storage.Storage
-	locker  storage.Locker
-	lockTTL time.Duration
-	codec   Codec
+	store     storage.Storage
+	locker    storage.Locker
+	keyPrefix string
+	lockTTL   time.Duration
+	codec     Codec
 }
 
 // NewStorageAdapter creates an idempotency.Store from a storage.Storage.
@@ -60,16 +66,21 @@ func NewStorageAdapter(s storage.Storage, cfg ...StorageAdapterConfig) (Store, e
 	}
 
 	return &StorageAdapter{
-		store:   s,
-		locker:  locker,
-		lockTTL: c.LockTTL,
-		codec:   c.Codec,
+		store:     s,
+		locker:    locker,
+		keyPrefix: c.KeyPrefix,
+		lockTTL:   c.LockTTL,
+		codec:     c.Codec,
 	}, nil
+}
+
+func (a *StorageAdapter) prefixKey(key string) string {
+	return a.keyPrefix + key
 }
 
 // Get retrieves a cached response by key.
 func (a *StorageAdapter) Get(ctx context.Context, key string) (Record, bool, error) {
-	data, found, err := a.store.Get(ctx, key)
+	data, found, err := a.store.Get(ctx, a.prefixKey(key))
 	if !found || err != nil {
 		return Record{}, false, err
 	}
@@ -89,7 +100,7 @@ func (a *StorageAdapter) Set(ctx context.Context, key string, rec Record, ttl ti
 		return err
 	}
 
-	return a.store.Set(ctx, key, data, ttl)
+	return a.store.Set(ctx, a.prefixKey(key), data, ttl)
 }
 
 // Close releases resources associated with the underlying storage.
@@ -99,10 +110,10 @@ func (a *StorageAdapter) Close() error {
 
 // Lock acquires an exclusive lock for the given key.
 func (a *StorageAdapter) Lock(ctx context.Context, key string) (bool, error) {
-	return a.locker.Lock(ctx, key, a.lockTTL)
+	return a.locker.Lock(ctx, a.prefixKey(key), a.lockTTL)
 }
 
 // Unlock releases the lock for the given key.
 func (a *StorageAdapter) Unlock(ctx context.Context, key string) error {
-	return a.locker.Unlock(ctx, key)
+	return a.locker.Unlock(ctx, a.prefixKey(key))
 }

--- a/middleware/idempotency/adapter_test.go
+++ b/middleware/idempotency/adapter_test.go
@@ -174,7 +174,7 @@ func TestStorageAdapter_CustomCodec(t *testing.T) {
 	zhtest.AssertNoError(t, err)
 
 	// Check that custom codec was used (prepends "MOCK:")
-	data := s.data["key"]
+	data := s.data["idemp:key"]
 	zhtest.AssertEqual(t, "MOCK:", string(data))
 
 	// Get via adapter - should use custom codec
@@ -228,9 +228,9 @@ func TestStorageAdapter_Set(t *testing.T) {
 	err := adapter.Set(ctx, "key", rec, ttl)
 	zhtest.AssertNoError(t, err)
 
-	_, ok := s.data["key"]
+	_, ok := s.data["idemp:key"]
 	zhtest.AssertTrue(t, ok)
-	zhtest.AssertEqual(t, ttl, s.ttlVals["key"])
+	zhtest.AssertEqual(t, ttl, s.ttlVals["idemp:key"])
 }
 
 func TestStorageAdapter_Lock(t *testing.T) {


### PR DESCRIPTION
Add KeyPrefix to cache and idempotency StorageAdapterConfig, matching the existing jwtauth adapter pattern. This ensures keys are properly namespaced when using shared storage backends.

- cache: default key prefix is "cache:"
- idempotency: default key prefix is "idemp:"