### PR TITLE
feat(jwtauth): add cookie support with HttpOnly refresh tokens

### DIFF
--- a/examples/middleware/jwtauth_cookie/README.md
+++ b/examples/middleware/jwtauth_cookie/README.md
@@ -1,0 +1,80 @@
+# JWT Authentication with Cookies Example
+
+This example demonstrates zerohttp's JWT authentication middleware using cookies for refresh tokens.
+
+## Features
+
+- HS256 JWT token signing
+- Access tokens (short-lived) + Refresh tokens (long-lived)
+- Cookie-based refresh token storage (HttpOnly, Secure, SameSite)
+- Token revocation support
+- Automatic token extraction from cookies or headers
+- Required claims validation
+- Exclude paths for public endpoints
+
+## Running the Example
+
+```bash
+go run .
+```
+
+The server starts on `http://localhost:8080`.
+
+### Web Demo
+
+Open `http://localhost:8080` in your browser to see an interactive demo showing:
+- HttpOnly cookies are invisible to JavaScript (protected from XSS)
+- The browser automatically sends cookies with API requests
+- Token refresh and logout flows
+
+## Endpoints
+
+| Endpoint             | Auth Required | Description                           |
+|----------------------|---------------|---------------------------------------|
+| `POST /login`        | No            | Authenticate and get tokens           |
+| `POST /register`     | No            | Registration stub                     |
+| `POST /auth/refresh` | No            | Refresh access token (uses cookie)    |
+| `POST /auth/logout`  | No            | Revoke refresh token and clear cookie |
+| `GET /api/profile`   | Yes           | Get user profile                      |
+| `GET /api/admin`     | Yes + scope   | Admin endpoint (requires admin scope) |
+
+## Credentials
+
+- Username: `alice`
+- Password: `secret`
+
+## Token Flow
+
+1. **Login**: Returns access token in JSON, sets refresh token as HttpOnly cookie
+2. **Access API**: Send access token in `Authorization: Bearer <token>` header
+3. **Refresh**: Hit `/auth/refresh` with the refresh token cookie to get new access token
+4. **Logout**: Hit `/auth/logout` to revoke the refresh token and clear the cookie
+
+## Test Commands
+
+### Login (stores refresh token in cookie file)
+```bash
+curl -c cookies.txt -X POST http://localhost:8080/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"alice","password":"secret"}'
+```
+
+### Access protected endpoint with access token header
+```bash
+curl -H 'Authorization: Bearer <access_token>' http://localhost:8080/api/profile
+```
+
+### Refresh access token (uses cookie)
+```bash
+curl -c cookies.txt -b cookies.txt -X POST http://localhost:8080/auth/refresh
+```
+
+### Logout (revokes token and clears cookie)
+```bash
+curl -b cookies.txt -X POST http://localhost:8080/auth/logout
+```
+
+### Access without token (fails)
+```bash
+curl http://localhost:8080/api/profile
+```

--- a/examples/middleware/jwtauth_cookie/main.go
+++ b/examples/middleware/jwtauth_cookie/main.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/middleware/jwtauth"
+	"github.com/alexferl/zerohttp/middleware/securityheaders"
+)
+
+var jwtSecret = []byte("your-secret-key-change-in-production")
+
+// TokenStore implements jwtauth.Store with HS256 and in-memory revocation.
+// In production, use Redis or database for revocation storage.
+type TokenStore struct {
+	mu      sync.RWMutex
+	revoked map[string]bool // map of jti -> revoked
+	hs256   *jwtauth.HS256Store
+	opts    jwtauth.HS256Config
+}
+
+// NewTokenStore creates a new TokenStore with HS256 and revocation support
+func NewTokenStore(secret []byte, opts jwtauth.HS256Config) *TokenStore {
+	return &TokenStore{
+		revoked: make(map[string]bool),
+		hs256:   jwtauth.NewHS256Store(secret, opts),
+		opts:    opts,
+	}
+}
+
+// Validate parses and validates a JWT token
+func (s *TokenStore) Validate(ctx context.Context, token string) (jwtauth.JWTClaims, error) {
+	return s.hs256.Validate(ctx, token)
+}
+
+// Generate creates a new JWT token
+func (s *TokenStore) Generate(ctx context.Context, claims jwtauth.JWTClaims, tokenType jwtauth.TokenType, ttl time.Duration) (string, error) {
+	return s.hs256.Generate(ctx, claims, tokenType, ttl)
+}
+
+// Revoke invalidates a refresh token by its jti claim
+func (s *TokenStore) Revoke(_ context.Context, claims map[string]any) error {
+	jti := getJTI(claims)
+	if jti != "" {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.revoked[jti] = true
+	}
+	return nil
+}
+
+// IsRevoked checks if a refresh token has been revoked
+func (s *TokenStore) IsRevoked(_ context.Context, claims map[string]any) (bool, error) {
+	jti := getJTI(claims)
+	if jti == "" {
+		return false, nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.revoked[jti], nil
+}
+
+// Close releases resources associated with the store
+func (s *TokenStore) Close() error {
+	return nil
+}
+
+// getJTI extracts the jti claim from claims
+func getJTI(claims map[string]any) string {
+	if jti, ok := claims["jti"].(string); ok {
+		return jti
+	}
+	return ""
+}
+
+//go:embed static/index.html
+var indexHTML string
+
+func main() {
+	app := zh.New()
+
+	// Add security headers with CSP nonce generation
+	app.Use(securityheaders.New(securityheaders.Config{
+		ContentSecurityPolicyNonceEnabled: true,
+		ContentSecurityPolicy: "default-src 'self'; " +
+			"script-src 'nonce-{{nonce}}'; " +
+			"style-src 'nonce-{{nonce}}'; " +
+			"img-src 'self'; " +
+			"connect-src 'self'; " +
+			"frame-ancestors 'none';",
+	}))
+
+	// HS256 configuration
+	hp := jwtauth.HS256Config{
+		Secret: jwtSecret,
+		Issuer: "zerohttp-example",
+	}
+
+	// Create TokenStore with HS256 and revocation support
+	tokenStore := NewTokenStore(jwtSecret, hp)
+
+	jwtCfg := jwtauth.Config{
+		Store:           tokenStore,
+		RequiredClaims:  []string{"sub"},
+		ExcludedPaths:   []string{"/login", "/register", "/auth/refresh", "/auth/logout"},
+		AccessTokenTTL:  15 * time.Minute,
+		RefreshTokenTTL: 7 * 24 * time.Hour,
+		// Enable cookie support
+		// Uses default cookie names: access_token (Path: /) and refresh_token (Path: /auth)
+		Extractor: jwtauth.HeaderOrCookieExtractor("access_token"),
+		Cookie: jwtauth.CookieConfig{
+			Enabled:     true,
+			Path:        "/",
+			RefreshPath: "/auth",
+			Secure:      false, // Set to true in production (HTTPS only)
+			HttpOnly:    true,  // Prevents JavaScript access
+			SameSite:    http.SameSiteStrictMode,
+		},
+	}
+
+	// Serve HTML demo with CSP nonce
+	app.GET("/", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nonce := securityheaders.GetCSPNonce(r)
+		html := strings.ReplaceAll(indexHTML, "{{nonce}}", nonce)
+		return zh.R.HTML(w, http.StatusOK, html)
+	}))
+
+	// Public endpoints
+	app.POST("/login", loginHandler(jwtCfg))
+	app.POST("/register", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return zh.R.JSON(w, http.StatusOK, zh.M{
+			"message": "registration endpoint - implement your logic here",
+		})
+	}))
+
+	// Token refresh and logout endpoints (handle cookies automatically)
+	app.POST("/auth/refresh", jwtauth.RefreshTokenHandler(jwtCfg))
+	app.POST("/auth/logout", jwtauth.LogoutTokenHandler(jwtCfg))
+
+	// Protected endpoints
+	app.Use(jwtauth.New(jwtCfg))
+
+	app.GET("/api/profile", zh.HandlerFunc(profileHandler))
+	app.GET("/api/admin", zh.HandlerFunc(adminHandler))
+
+	log.Fatal(app.Start())
+}
+
+// loginHandler authenticates users and sets JWT tokens
+func loginHandler(cfg jwtauth.Config) zh.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		var req struct {
+			Username string `json:"username"`
+			Password string `json:"password"`
+		}
+
+		if err := zh.B.JSON(r.Body, &req); err != nil {
+			return zh.R.JSON(w, http.StatusBadRequest, zh.M{"error": "invalid request"})
+		}
+
+		// In production, verify against database
+		if req.Username != "alice" || req.Password != "secret" {
+			return zh.R.JSON(w, http.StatusUnauthorized, zh.M{"error": "invalid credentials"})
+		}
+
+		// Create claims with jti for revocation tracking
+		claims := jwtauth.HS256Claims{
+			"sub": req.Username,
+			"jti": fmt.Sprintf("%s-%d", req.Username, time.Now().Unix()),
+		}
+
+		// Generate access token
+		accessToken, err := jwtauth.GenerateAccessToken(r, claims, cfg)
+		if err != nil {
+			return zh.R.JSON(w, http.StatusInternalServerError, zh.M{"error": "failed to generate access token"})
+		}
+
+		// Generate refresh token
+		refreshToken, err := jwtauth.GenerateRefreshToken(r, claims, cfg)
+		if err != nil {
+			return zh.R.JSON(w, http.StatusInternalServerError, zh.M{"error": "failed to generate refresh token"})
+		}
+
+		// Set access token cookie (Path: /) and refresh token cookie (Path: /auth)
+		// Both are HttpOnly - browser handles them automatically
+		jwtauth.SetCookie(w, accessToken, cfg)
+		jwtauth.SetRefreshCookie(w, refreshToken, cfg)
+
+		return zh.R.JSON(w, http.StatusOK, zh.M{
+			"message": "logged in successfully",
+		})
+	}
+}
+
+func profileHandler(w http.ResponseWriter, r *http.Request) error {
+	jwt := jwtauth.GetClaims(r)
+
+	return zh.R.JSON(w, http.StatusOK, zh.M{
+		"subject": jwt.Subject(),
+		"scopes":  jwt.Scopes(),
+		"message": "This is your profile",
+	})
+}
+
+func adminHandler(w http.ResponseWriter, r *http.Request) error {
+	if !jwtauth.GetClaims(r).HasScope("admin") {
+		return zh.R.JSON(w, http.StatusForbidden, zh.M{"error": "admin scope required"})
+	}
+
+	return zh.R.JSON(w, http.StatusOK, zh.M{
+		"message": "Admin access granted",
+	})
+}

--- a/examples/middleware/jwtauth_cookie/static/index.html
+++ b/examples/middleware/jwtauth_cookie/static/index.html
@@ -1,0 +1,233 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>JWT Cookie Auth Demo</title>
+    <style nonce="{{nonce}}">
+        * { box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            background: #f5f5f5;
+        }
+        .container {
+            background: white;
+            padding: 30px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        h1 { color: #333; margin-top: 0; }
+        .section {
+            margin: 20px 0;
+            padding: 15px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+        }
+        .section h3 { margin-top: 0; color: #555; }
+        input[type="text"], input[type="password"] {
+            width: 100%;
+            padding: 10px;
+            margin: 5px 0;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+        }
+        button {
+            background: #007bff;
+            color: white;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 4px;
+            cursor: pointer;
+            margin: 5px 5px 5px 0;
+        }
+        button:hover { background: #0056b3; }
+        button:disabled {
+            background: #ccc;
+            cursor: not-allowed;
+        }
+        .success { color: #28a745; }
+        .error { color: #dc3545; }
+        .info { color: #17a2b8; }
+        pre {
+            background: #f8f9fa;
+            padding: 10px;
+            border-radius: 4px;
+            overflow-x: auto;
+        }
+        .cookie-info {
+            font-size: 0.9em;
+            color: #666;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>JWT Cookie Authentication Demo</h1>
+        <p class="cookie-info">
+            This demo shows how HttpOnly cookies protect the refresh token from JavaScript access.
+            The browser automatically sends cookies with requests.
+        </p>
+
+        <div class="section">
+            <h3>Login</h3>
+            <input type="text" id="username" placeholder="Username (alice)" value="alice">
+            <input type="password" id="password" placeholder="Password (secret)" value="secret">
+            <button id="login-btn">Login</button>
+            <div id="login-result"></div>
+        </div>
+
+        <div class="section">
+            <h3>API Calls</h3>
+            <button id="profile-btn">Get Profile</button>
+            <button id="refresh-btn">Refresh Token</button>
+            <button id="logout-btn">Logout</button>
+            <div id="api-result"></div>
+        </div>
+
+        <div class="section">
+            <h3>Cookies (Document.cookie)</h3>
+            <p class="cookie-info">
+                Both cookies are <strong>HttpOnly</strong> and cannot be accessed by JavaScript.
+                This protects them from XSS attacks. The browser automatically sends them with requests.
+            </p>
+            <pre id="cookies">Not logged in</pre>
+            <button id="cookies-btn">Show Visible Cookies</button>
+        </div>
+
+        <div class="section">
+            <h3>Current User</h3>
+            <p class="cookie-info">Call /api/profile to see who you're logged in as</p>
+            <pre id="user-info">No user info loaded</pre>
+        </div>
+    </div>
+
+    <script nonce="{{nonce}}">
+        const API_BASE = 'http://localhost:8080';
+
+        // Add event listeners for buttons
+        document.addEventListener('DOMContentLoaded', function() {
+            document.getElementById('login-btn').addEventListener('click', login);
+            document.getElementById('profile-btn').addEventListener('click', getProfile);
+            document.getElementById('refresh-btn').addEventListener('click', refreshToken);
+            document.getElementById('logout-btn').addEventListener('click', logout);
+            document.getElementById('cookies-btn').addEventListener('click', showCookies);
+        });
+
+        async function login() {
+            const username = document.getElementById('username').value;
+            const password = document.getElementById('password').value;
+            const resultDiv = document.getElementById('login-result');
+
+            try {
+                const response = await fetch(`${API_BASE}/login`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    credentials: 'include',
+                    body: JSON.stringify({ username, password })
+                });
+
+                const data = await response.json();
+
+                if (response.ok) {
+                    resultDiv.innerHTML = `<p class="success">Login successful!</p>`;
+                    showCookies();
+                    getProfile();
+                } else {
+                    resultDiv.innerHTML = `<p class="error">Login failed: ${data.error || 'Unknown error'}</p>`;
+                }
+            } catch (err) {
+                resultDiv.innerHTML = `<p class="error">Error: ${err.message}</p>`;
+            }
+        }
+
+        async function getProfile() {
+            const resultDiv = document.getElementById('api-result');
+            const userInfoDiv = document.getElementById('user-info');
+
+            try {
+                // The browser automatically sends the access_token cookie
+                const response = await fetch(`${API_BASE}/api/profile`, {
+                    method: 'GET',
+                    credentials: 'include'
+                });
+
+                const data = await response.json();
+
+                if (response.ok) {
+                    resultDiv.innerHTML = `<p class="success">Profile loaded:</p><pre>${JSON.stringify(data, null, 2)}</pre>`;
+                    userInfoDiv.textContent = JSON.stringify(data, null, 2);
+                } else {
+                    resultDiv.innerHTML = `<p class="error">Failed: ${data.error || response.statusText}</p>`;
+                    userInfoDiv.textContent = 'Not authenticated';
+                }
+            } catch (err) {
+                resultDiv.innerHTML = `<p class="error">Error: ${err.message}</p>`;
+            }
+        }
+
+        async function refreshToken() {
+            const resultDiv = document.getElementById('api-result');
+
+            try {
+                // The browser automatically sends the refresh_token cookie
+                const response = await fetch(`${API_BASE}/auth/refresh`, {
+                    method: 'POST',
+                    credentials: 'include',
+                    headers: { 'Content-Type': 'application/json' }
+                });
+
+                const data = await response.json();
+
+                if (response.ok) {
+                    resultDiv.innerHTML = `<p class="success">Token refreshed successfully!</p>`;
+                    showCookies();
+                } else {
+                    resultDiv.innerHTML = `<p class="error">Refresh failed: ${JSON.stringify(data)}</p>`;
+                }
+            } catch (err) {
+                resultDiv.innerHTML = `<p class="error">Error: ${err.message}</p>`;
+            }
+        }
+
+        async function logout() {
+            const resultDiv = document.getElementById('api-result');
+
+            try {
+                // The browser automatically sends the refresh_token cookie for revocation
+                const response = await fetch(`${API_BASE}/auth/logout`, {
+                    method: 'POST',
+                    credentials: 'include',
+                    headers: { 'Content-Type': 'application/json' }
+                });
+
+                const data = await response.json();
+
+                if (response.ok) {
+                    resultDiv.innerHTML = `<p class="success">${data.message}</p>`;
+                    document.getElementById('user-info').textContent = 'Logged out';
+                    showCookies();
+                } else {
+                    resultDiv.innerHTML = `<p class="error">Logout failed: ${JSON.stringify(data)}</p>`;
+                }
+            } catch (err) {
+                resultDiv.innerHTML = `<p class="error">Error: ${err.message}</p>`;
+            }
+        }
+
+        function showCookies() {
+            const cookieDisplay = document.getElementById('cookies');
+            const cookies = document.cookie;
+
+            if (!cookies) {
+                cookieDisplay.textContent = 'No cookies visible to JavaScript.\n\nBoth access_token and refresh_token are HttpOnly cookies, so they are protected from XSS attacks. The browser automatically sends them with requests.';
+            } else {
+                cookieDisplay.textContent = 'Visible cookies:\n' + cookies.split(';').map(c => c.trim()).join('\n') +
+                    '\n\nNote: access_token and refresh_token are HttpOnly and not visible here.';
+            }
+        }
+    </script>
+</body>
+</html>

--- a/middleware/jwtauth/config.go
+++ b/middleware/jwtauth/config.go
@@ -63,8 +63,13 @@ type Store interface {
 // Config configures JWT authentication middleware
 type Config struct {
 	// Extractor extracts the JWT token from the request.
-	// Default: extracts from "Authorization: Bearer <token>" header
+	// Default: extracts from "Authorization: Bearer <token>" header, then checks CookieName
 	Extractor func(r *http.Request) string
+
+	// Cookie configures JWT cookie settings.
+	// Used by SetCookie and DeleteCookie helpers.
+	// Default: sensible defaults with HttpOnly, Secure, SameSite=Strict
+	Cookie CookieConfig
 
 	// Store handles all token operations (validate, generate, revoke).
 	// This is the PLUGGABLE INTERFACE - users implement this with their JWT library.
@@ -111,9 +116,71 @@ type Config struct {
 	RefreshTokenTTL time.Duration
 }
 
+// CookieConfig configures JWT cookie settings
+type CookieConfig struct {
+	// Enabled enables cookie support in the middleware and handlers.
+	// When enabled, the middleware can read tokens from cookies and handlers
+	// will set/delete cookies automatically.
+	// Default: false
+	Enabled bool
+
+	// Name is the cookie name for storing the JWT token.
+	// Default: "jwt_token"
+	Name string
+
+	// Path is the cookie path.
+	// Default: "/"
+	Path string
+
+	// Domain is the cookie domain.
+	// Default: "" (current domain)
+	Domain string
+
+	// MaxAge is the cookie max age in seconds.
+	// If 0, uses the token's expiration.
+	// Default: 0
+	MaxAge int
+
+	// Secure indicates if the cookie should only be sent over HTTPS.
+	// Default: true (recommended for production)
+	Secure bool
+
+	// HttpOnly indicates if the cookie should be inaccessible to JavaScript.
+	// Default: true (highly recommended for security)
+	HttpOnly bool
+
+	// SameSite sets the SameSite attribute for the cookie.
+	// Valid values: "Strict", "Lax", "None".
+	// Default: "Strict"
+	SameSite http.SameSite
+
+	// RefreshPath is the path for the refresh token cookie.
+	// The refresh token cookie will only be sent to requests matching this path prefix.
+	// Use this to restrict the refresh token to only the refresh/logout endpoints.
+	// Example: "/auth" will match "/auth/refresh" and "/auth/logout"
+	// Default: "/auth"
+	RefreshPath string
+
+	// RefreshName is the cookie name for the refresh token.
+	// Default: "refresh_token"
+	RefreshName string
+}
+
+// DefaultCookieConfig provides sensible defaults for cookies
+var DefaultCookieConfig = CookieConfig{
+	Name:        "access_token",
+	Path:        "/",
+	Secure:      true,
+	HttpOnly:    true,
+	SameSite:    http.SameSiteStrictMode,
+	RefreshPath: "/auth",
+	RefreshName: "refresh_token",
+}
+
 // DefaultConfig provides sensible defaults
 var DefaultConfig = Config{
 	Extractor:       extractBearerToken,
+	Cookie:          DefaultCookieConfig,
 	ExcludedPaths:   []string{},
 	IncludedPaths:   []string{},
 	ExcludedMethods: []string{},

--- a/middleware/jwtauth/jwt_auth.go
+++ b/middleware/jwtauth/jwt_auth.go
@@ -391,6 +391,129 @@ func GenerateRefreshToken(r *http.Request, claims JWTClaims, cfg Config) (string
 	return cfg.Store.Generate(r.Context(), claims, RefreshToken, ttl)
 }
 
+// SetCookie sets the JWT token as a cookie with the configured cookie settings.
+// Uses Config.Cookie for cookie attributes. MaxAge defaults to AccessTokenTTL if not set.
+func SetCookie(w http.ResponseWriter, token string, cfg Config) {
+	cookieCfg := cfg.Cookie
+	if cookieCfg.Name == "" {
+		cookieCfg.Name = DefaultCookieConfig.Name
+	}
+	if cookieCfg.Path == "" {
+		cookieCfg.Path = DefaultCookieConfig.Path
+	}
+
+	maxAge := cookieCfg.MaxAge
+	if maxAge == 0 {
+		ttl := cfg.AccessTokenTTL
+		if ttl == 0 {
+			ttl = DefaultConfig.AccessTokenTTL
+		}
+		maxAge = int(ttl.Seconds())
+	}
+
+	cookie := &http.Cookie{
+		Name:     cookieCfg.Name,
+		Value:    token,
+		Path:     cookieCfg.Path,
+		Domain:   cookieCfg.Domain,
+		MaxAge:   maxAge,
+		Secure:   cookieCfg.Secure,
+		HttpOnly: cookieCfg.HttpOnly,
+		SameSite: cookieCfg.SameSite,
+	}
+	http.SetCookie(w, cookie)
+}
+
+// DeleteCookie deletes the JWT cookie by setting MaxAge to -1.
+func DeleteCookie(w http.ResponseWriter, cfg Config) {
+	cookieCfg := cfg.Cookie
+	if cookieCfg.Name == "" {
+		cookieCfg.Name = DefaultCookieConfig.Name
+	}
+	if cookieCfg.Path == "" {
+		cookieCfg.Path = DefaultCookieConfig.Path
+	}
+
+	cookie := &http.Cookie{
+		Name:     cookieCfg.Name,
+		Value:    "",
+		Path:     cookieCfg.Path,
+		Domain:   cookieCfg.Domain,
+		MaxAge:   -1,
+		Secure:   cookieCfg.Secure,
+		HttpOnly: cookieCfg.HttpOnly,
+		SameSite: cookieCfg.SameSite,
+	}
+	http.SetCookie(w, cookie)
+}
+
+// SetRefreshCookie sets the refresh token as a cookie with RefreshPath and RefreshName.
+// Uses Config.Cookie.RefreshPath for the cookie path. MaxAge defaults to RefreshTokenTTL.
+func SetRefreshCookie(w http.ResponseWriter, token string, cfg Config) {
+	cookieCfg := cfg.Cookie
+	name := cookieCfg.RefreshName
+	if name == "" {
+		name = DefaultCookieConfig.RefreshName
+	}
+	path := cookieCfg.RefreshPath
+	if path == "" {
+		path = DefaultCookieConfig.RefreshPath
+	}
+
+	maxAge := cookieCfg.MaxAge
+	if maxAge == 0 {
+		ttl := cfg.RefreshTokenTTL
+		if ttl == 0 {
+			ttl = DefaultConfig.RefreshTokenTTL
+		}
+		maxAge = int(ttl.Seconds())
+	}
+
+	cookie := &http.Cookie{
+		Name:     name,
+		Value:    token,
+		Path:     path,
+		Domain:   cookieCfg.Domain,
+		MaxAge:   maxAge,
+		Secure:   cookieCfg.Secure,
+		HttpOnly: cookieCfg.HttpOnly,
+		SameSite: cookieCfg.SameSite,
+	}
+	http.SetCookie(w, cookie)
+}
+
+// CookieExtractor returns an extractor that extracts the JWT token from a cookie.
+// Use this as the Extractor in Config to enable cookie-only authentication.
+func CookieExtractor(cookieName string) func(r *http.Request) string {
+	return func(r *http.Request) string {
+		cookie, err := r.Cookie(cookieName)
+		if err == nil && cookie.Value != "" {
+			return cookie.Value
+		}
+		return ""
+	}
+}
+
+// HeaderOrCookieExtractor returns an extractor that first checks the Authorization header,
+// then falls back to the specified cookie name.
+func HeaderOrCookieExtractor(cookieName string) func(r *http.Request) string {
+	return func(r *http.Request) string {
+		// First try Authorization header
+		token := extractBearerToken(r)
+		if token != "" {
+			return token
+		}
+
+		// Fall back to cookie
+		cookie, err := r.Cookie(cookieName)
+		if err == nil && cookie.Value != "" {
+			return cookie.Value
+		}
+
+		return ""
+	}
+}
+
 // writeJWTError writes a AuthError response
 func writeJWTError(w http.ResponseWriter, r *http.Request, jwtErr *AuthError) {
 	detail := problem.NewDetail(jwtErr.Status, jwtErr.Detail)
@@ -413,20 +536,28 @@ func tokenHandlerRequest(w http.ResponseWriter, r *http.Request, cfg Config) (JW
 		return nil, false
 	}
 
+	refreshToken := ""
+
+	// First try to read from request body
 	var req struct {
 		RefreshToken string `json:"refresh_token"`
 	}
-
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJWTError(w, r, &AuthError{
-			Title:  "Invalid Request",
-			Status: http.StatusBadRequest,
-			Detail: "Request body must contain refresh_token",
-		})
-		return nil, false
+	if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
+		refreshToken = req.RefreshToken
 	}
 
-	if req.RefreshToken == "" {
+	// Fall back to refresh token cookie if body didn't have it and cookies are enabled
+	if refreshToken == "" && cfg.Cookie.Enabled {
+		cookieName := cfg.Cookie.RefreshName
+		if cookieName == "" {
+			cookieName = DefaultCookieConfig.RefreshName
+		}
+		if cookie, err := r.Cookie(cookieName); err == nil {
+			refreshToken = cookie.Value
+		}
+	}
+
+	if refreshToken == "" {
 		writeJWTError(w, r, &AuthError{
 			Title:  "Missing Refresh Token",
 			Status: http.StatusUnprocessableEntity,
@@ -435,7 +566,7 @@ func tokenHandlerRequest(w http.ResponseWriter, r *http.Request, cfg Config) (JW
 		return nil, false
 	}
 
-	claims, err := cfg.Store.Validate(r.Context(), req.RefreshToken)
+	claims, err := cfg.Store.Validate(r.Context(), refreshToken)
 	if err != nil {
 		writeJWTError(w, r, errInvalidToken)
 		return nil, false
@@ -484,8 +615,9 @@ func tokenHandlerRequest(w http.ResponseWriter, r *http.Request, cfg Config) (JW
 }
 
 // RefreshTokenHandler returns an http.HandlerFunc that handles token refresh.
-// Accepts: { "refresh_token": "..." }
+// Accepts: { "refresh_token": "..." } or reads from cookie if Cookie.Enabled is true
 // Returns: { "access_token": "...", "refresh_token": "...", "token_type": httpx.AuthSchemeBearer, "expires_in": 900 }
+// Also sets the new refresh token as a cookie when Cookie.Enabled is true.
 // Users mount this at their chosen path: app.POST("/auth/refresh", jwtauth.RefreshTokenHandler(cfg))
 func RefreshTokenHandler(cfg Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -494,13 +626,18 @@ func RefreshTokenHandler(cfg Config) http.HandlerFunc {
 			return
 		}
 
-		accessToken, err := GenerateAccessToken(r, claims, cfg)
+		// Extract subject to identify user - in production, fetch fresh claims from database here
+		subject := extractSubject(claims)
+		accessClaims := map[string]any{"sub": subject}
+
+		accessToken, err := GenerateAccessToken(r, accessClaims, cfg)
 		if err != nil {
 			writeJWTError(w, r, errTokenGeneratorNotConfigured)
 			return
 		}
 
-		refreshToken, err := GenerateRefreshToken(r, claims, cfg)
+		// Use same user claims but GenerateRefreshToken will add new jti and type
+		refreshToken, err := GenerateRefreshToken(r, accessClaims, cfg)
 		if err != nil {
 			writeJWTError(w, r, errTokenGeneratorNotConfigured)
 			return
@@ -509,6 +646,60 @@ func RefreshTokenHandler(cfg Config) http.HandlerFunc {
 		expiresIn := cfg.AccessTokenTTL
 		if expiresIn == 0 {
 			expiresIn = DefaultConfig.AccessTokenTTL
+		}
+
+		// Set both cookies if enabled (access token with Path: /, refresh token with RefreshPath)
+		if cfg.Cookie.Enabled {
+			cookieCfg := cfg.Cookie
+			if cookieCfg.Name == "" {
+				cookieCfg.Name = DefaultCookieConfig.Name
+			}
+
+			// Access token cookie with Path: /
+			accessTTL := cfg.AccessTokenTTL
+			if accessTTL == 0 {
+				accessTTL = DefaultConfig.AccessTokenTTL
+			}
+			accessPath := cookieCfg.Path
+			if accessPath == "" {
+				accessPath = DefaultCookieConfig.Path
+			}
+			accessCookie := &http.Cookie{
+				Name:     cookieCfg.Name,
+				Value:    accessToken,
+				Path:     accessPath,
+				Domain:   cookieCfg.Domain,
+				MaxAge:   int(accessTTL.Seconds()),
+				Secure:   cookieCfg.Secure,
+				HttpOnly: cookieCfg.HttpOnly,
+				SameSite: cookieCfg.SameSite,
+			}
+			http.SetCookie(w, accessCookie)
+
+			// Refresh token cookie with RefreshPath
+			refreshTTL := cfg.RefreshTokenTTL
+			if refreshTTL == 0 {
+				refreshTTL = DefaultConfig.RefreshTokenTTL
+			}
+			refreshPath := cookieCfg.RefreshPath
+			if refreshPath == "" {
+				refreshPath = DefaultCookieConfig.RefreshPath
+			}
+			refreshName := cookieCfg.RefreshName
+			if refreshName == "" {
+				refreshName = DefaultCookieConfig.RefreshName
+			}
+			refreshCookie := &http.Cookie{
+				Name:     refreshName,
+				Value:    refreshToken,
+				Path:     refreshPath,
+				Domain:   cookieCfg.Domain,
+				MaxAge:   int(refreshTTL.Seconds()),
+				Secure:   cookieCfg.Secure,
+				HttpOnly: cookieCfg.HttpOnly,
+				SameSite: cookieCfg.SameSite,
+			}
+			http.SetCookie(w, refreshCookie)
 		}
 
 		w.Header().Set(httpx.HeaderContentType, httpx.MIMEApplicationJSON)
@@ -523,8 +714,9 @@ func RefreshTokenHandler(cfg Config) http.HandlerFunc {
 }
 
 // LogoutTokenHandler returns an http.HandlerFunc that handles token revocation (logout).
-// Accepts: { "refresh_token": "..." }
+// Accepts: { "refresh_token": "..." } or reads from cookie if Cookie.Enabled is true
 // Returns: { "message": "logged out successfully" }
+// Also deletes the cookie when Cookie.Enabled is true.
 // Users mount this at their chosen path: app.POST("/auth/logout", jwtauth.LogoutTokenHandler(cfg))
 // Requires Store to be configured in Config.
 func LogoutTokenHandler(cfg Config) http.HandlerFunc {
@@ -532,6 +724,52 @@ func LogoutTokenHandler(cfg Config) http.HandlerFunc {
 		_, ok := tokenHandlerRequest(w, r, cfg)
 		if !ok {
 			return
+		}
+
+		// Delete both cookies if enabled (access token with Path: /, refresh token with RefreshPath)
+		if cfg.Cookie.Enabled {
+			cookieCfg := cfg.Cookie
+			if cookieCfg.Name == "" {
+				cookieCfg.Name = DefaultCookieConfig.Name
+			}
+
+			// Delete access token cookie with Path: /
+			accessPath := cookieCfg.Path
+			if accessPath == "" {
+				accessPath = DefaultCookieConfig.Path
+			}
+			accessCookie := &http.Cookie{
+				Name:     cookieCfg.Name,
+				Value:    "",
+				Path:     accessPath,
+				Domain:   cookieCfg.Domain,
+				MaxAge:   -1,
+				Secure:   cookieCfg.Secure,
+				HttpOnly: cookieCfg.HttpOnly,
+				SameSite: cookieCfg.SameSite,
+			}
+			http.SetCookie(w, accessCookie)
+
+			// Delete refresh token cookie with RefreshPath
+			refreshPath := cookieCfg.RefreshPath
+			if refreshPath == "" {
+				refreshPath = DefaultCookieConfig.RefreshPath
+			}
+			refreshName := cookieCfg.RefreshName
+			if refreshName == "" {
+				refreshName = DefaultCookieConfig.RefreshName
+			}
+			refreshCookie := &http.Cookie{
+				Name:     refreshName,
+				Value:    "",
+				Path:     refreshPath,
+				Domain:   cookieCfg.Domain,
+				MaxAge:   -1,
+				Secure:   cookieCfg.Secure,
+				HttpOnly: cookieCfg.HttpOnly,
+				SameSite: cookieCfg.SameSite,
+			}
+			http.SetCookie(w, refreshCookie)
 		}
 
 		w.Header().Set(httpx.HeaderContentType, httpx.MIMEApplicationJSON)
@@ -765,4 +1003,10 @@ func addTypeToClaims(claims JWTClaims, tokenType string) JWTClaims {
 	default:
 		return claims
 	}
+}
+
+// extractSubject extracts the subject (sub) claim from claims
+// Used during token refresh to identify the user for fetching fresh claims from database
+func extractSubject(claims JWTClaims) string {
+	return getStringClaim(claims, JWTClaimSubject)
 }

--- a/middleware/jwtauth/jwt_auth_test.go
+++ b/middleware/jwtauth/jwt_auth_test.go
@@ -2134,6 +2134,17 @@ func TestSetCookie_Defaults(t *testing.T) {
 	zhtest.AssertEqual(t, int(30*time.Minute.Seconds()), cookie.MaxAge)
 }
 
+func TestSetCookie_DefaultTTL(t *testing.T) {
+	cfg := Config{} // AccessTokenTTL defaults to 15 minutes
+
+	rr := httptest.NewRecorder()
+	SetCookie(rr, "my-jwt-token", cfg)
+
+	zhtest.AssertWith(t, rr).CookieExists("access_token")
+	cookie := rr.Result().Cookies()[0]
+	zhtest.AssertEqual(t, int(15*time.Minute.Seconds()), cookie.MaxAge)
+}
+
 func TestSetRefreshCookie(t *testing.T) {
 	cfg := Config{
 		RefreshTokenTTL: 7 * 24 * time.Hour,
@@ -2173,6 +2184,17 @@ func TestSetRefreshCookie_Defaults(t *testing.T) {
 	zhtest.AssertEqual(t, int(30*24*time.Hour.Seconds()), cookie.MaxAge)
 }
 
+func TestSetRefreshCookie_DefaultTTL(t *testing.T) {
+	cfg := Config{} // RefreshTokenTTL defaults to 7 days
+
+	rr := httptest.NewRecorder()
+	SetRefreshCookie(rr, "my-refresh-token", cfg)
+
+	zhtest.AssertWith(t, rr).CookieExists("refresh_token")
+	cookie := rr.Result().Cookies()[0]
+	zhtest.AssertEqual(t, int(7*24*time.Hour.Seconds()), cookie.MaxAge)
+}
+
 func TestDeleteCookie(t *testing.T) {
 	cfg := Config{
 		Cookie: CookieConfig{
@@ -2190,6 +2212,18 @@ func TestDeleteCookie(t *testing.T) {
 	cookie := rr.Result().Cookies()[0]
 	zhtest.AssertEqual(t, "", cookie.Value)
 	zhtest.AssertEqual(t, "/api", cookie.Path)
+	zhtest.AssertEqual(t, -1, cookie.MaxAge)
+}
+
+func TestDeleteCookie_Defaults(t *testing.T) {
+	cfg := Config{}
+
+	rr := httptest.NewRecorder()
+	DeleteCookie(rr, cfg)
+
+	zhtest.AssertWith(t, rr).CookieExists("access_token")
+	cookie := rr.Result().Cookies()[0]
+	zhtest.AssertEqual(t, "/", cookie.Path)
 	zhtest.AssertEqual(t, -1, cookie.MaxAge)
 }
 

--- a/middleware/jwtauth/jwt_auth_test.go
+++ b/middleware/jwtauth/jwt_auth_test.go
@@ -2094,3 +2094,406 @@ func TestJWTAuth_BothExcludedAndIncludedPathsPanics(t *testing.T) {
 		})
 	})
 }
+
+func TestSetCookie(t *testing.T) {
+	cfg := Config{
+		AccessTokenTTL: 15 * time.Minute,
+		Cookie: CookieConfig{
+			Name:     "auth_token",
+			Path:     "/api",
+			Secure:   true,
+			HttpOnly: true,
+			SameSite: http.SameSiteStrictMode,
+		},
+	}
+
+	rr := httptest.NewRecorder()
+	SetCookie(rr, "my-jwt-token", cfg)
+
+	zhtest.AssertWith(t, rr).CookieExists("auth_token")
+	cookie := rr.Result().Cookies()[0]
+	zhtest.AssertEqual(t, "my-jwt-token", cookie.Value)
+	zhtest.AssertEqual(t, "/api", cookie.Path)
+	zhtest.AssertEqual(t, true, cookie.Secure)
+	zhtest.AssertEqual(t, true, cookie.HttpOnly)
+	zhtest.AssertEqual(t, http.SameSiteStrictMode, cookie.SameSite)
+	zhtest.AssertEqual(t, int(15*time.Minute.Seconds()), cookie.MaxAge)
+}
+
+func TestSetCookie_Defaults(t *testing.T) {
+	cfg := Config{
+		AccessTokenTTL: 30 * time.Minute,
+	}
+
+	rr := httptest.NewRecorder()
+	SetCookie(rr, "my-jwt-token", cfg)
+
+	zhtest.AssertWith(t, rr).CookieExists("access_token")
+	cookie := rr.Result().Cookies()[0]
+	zhtest.AssertEqual(t, "/", cookie.Path)
+	zhtest.AssertEqual(t, int(30*time.Minute.Seconds()), cookie.MaxAge)
+}
+
+func TestDeleteCookie(t *testing.T) {
+	cfg := Config{
+		Cookie: CookieConfig{
+			Name:     "auth_token",
+			Path:     "/api",
+			Secure:   true,
+			HttpOnly: true,
+		},
+	}
+
+	rr := httptest.NewRecorder()
+	DeleteCookie(rr, cfg)
+
+	zhtest.AssertWith(t, rr).CookieExists("auth_token")
+	cookie := rr.Result().Cookies()[0]
+	zhtest.AssertEqual(t, "", cookie.Value)
+	zhtest.AssertEqual(t, "/api", cookie.Path)
+	zhtest.AssertEqual(t, -1, cookie.MaxAge)
+}
+
+func TestCookieExtractor(t *testing.T) {
+	extractor := CookieExtractor("jwt_token")
+
+	t.Run("cookie present", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.AddCookie(&http.Cookie{Name: "jwt_token", Value: "cookie-token"})
+
+		token := extractor(req)
+		zhtest.AssertEqual(t, "cookie-token", token)
+	})
+
+	t.Run("cookie missing", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+		token := extractor(req)
+		zhtest.AssertEqual(t, "", token)
+	})
+
+	t.Run("wrong cookie name", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.AddCookie(&http.Cookie{Name: "other_cookie", Value: "other-token"})
+
+		token := extractor(req)
+		zhtest.AssertEqual(t, "", token)
+	})
+}
+
+func TestHeaderOrCookieExtractor(t *testing.T) {
+	extractor := HeaderOrCookieExtractor("jwt_token")
+
+	t.Run("header takes precedence", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Authorization", "Bearer header-token")
+		req.AddCookie(&http.Cookie{Name: "jwt_token", Value: "cookie-token"})
+
+		token := extractor(req)
+		zhtest.AssertEqual(t, "header-token", token)
+	})
+
+	t.Run("falls back to cookie", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.AddCookie(&http.Cookie{Name: "jwt_token", Value: "cookie-token"})
+
+		token := extractor(req)
+		zhtest.AssertEqual(t, "cookie-token", token)
+	})
+
+	t.Run("no header no cookie", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+		token := extractor(req)
+		zhtest.AssertEqual(t, "", token)
+	})
+}
+
+func TestJWTAuth_WithCookieExtractor(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(ctx context.Context, token string) (JWTClaims, error) {
+			if token == "cookie-token" {
+				return map[string]any{"sub": "user123"}, nil
+			}
+			return nil, errors.New("invalid token")
+		},
+	}
+
+	mw := New(Config{
+		Store:     store,
+		Extractor: CookieExtractor("jwt_token"),
+	})
+
+	t.Run("valid cookie", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.AddCookie(&http.Cookie{Name: "jwt_token", Value: "cookie-token"})
+		rr := httptest.NewRecorder()
+
+		var claims Claims
+		mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			claims = GetClaims(r)
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rr, req)
+
+		zhtest.AssertEqual(t, http.StatusOK, rr.Code)
+		zhtest.AssertEqual(t, "user123", claims.Subject())
+	})
+
+	t.Run("missing cookie", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rr := httptest.NewRecorder()
+
+		mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rr, req)
+
+		zhtest.AssertEqual(t, http.StatusUnauthorized, rr.Code)
+	})
+}
+
+func TestJWTAuth_WithHeaderOrCookieExtractor(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(ctx context.Context, token string) (JWTClaims, error) {
+			return map[string]any{"sub": "user123"}, nil
+		},
+	}
+
+	mw := New(Config{
+		Store:     store,
+		Extractor: HeaderOrCookieExtractor("jwt_token"),
+	})
+
+	t.Run("header auth works", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Authorization", "Bearer header-token")
+		rr := httptest.NewRecorder()
+
+		mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rr, req)
+
+		zhtest.AssertEqual(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("cookie auth works when no header", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.AddCookie(&http.Cookie{Name: "jwt_token", Value: "cookie-token"})
+		rr := httptest.NewRecorder()
+
+		mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rr, req)
+
+		zhtest.AssertEqual(t, http.StatusOK, rr.Code)
+	})
+}
+
+func TestRefreshTokenHandler_WithCookieEnabled(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(ctx context.Context, token string) (JWTClaims, error) {
+			if token == "cookie-refresh-token" {
+				return map[string]any{
+					"sub":  "user123",
+					"type": TokenTypeRefresh,
+				}, nil
+			}
+			return nil, errors.New("invalid token")
+		},
+		generateFunc: func(ctx context.Context, claims JWTClaims, tokenType TokenType, ttl time.Duration) (string, error) {
+			if tokenType == AccessToken {
+				return "new-access-token", nil
+			}
+			return "new-refresh-token", nil
+		},
+	}
+
+	cfg := Config{
+		Store:          store,
+		AccessTokenTTL: 15 * time.Minute,
+		Cookie: CookieConfig{
+			Enabled:     true,
+			Name:        "access_token",
+			Path:        "/",
+			RefreshPath: "/auth",
+			RefreshName: "refresh_token",
+			Secure:      true,
+			HttpOnly:    true,
+		},
+	}
+
+	handler := RefreshTokenHandler(cfg)
+
+	t.Run("reads refresh token from cookie when body empty", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader("{}"))
+		req.Header.Set(httpx.HeaderContentType, httpx.MIMEApplicationJSON)
+		req.AddCookie(&http.Cookie{Name: "refresh_token", Value: "cookie-refresh-token"})
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		zhtest.AssertEqual(t, http.StatusOK, rr.Code)
+
+		var resp map[string]any
+		zhtest.AssertNoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+		zhtest.AssertEqual(t, "new-access-token", resp["access_token"])
+		zhtest.AssertEqual(t, "new-refresh-token", resp["refresh_token"])
+
+		// Verify both cookies are set
+		cookies := rr.Result().Cookies()
+		zhtest.AssertEqual(t, 2, len(cookies))
+
+		// Find access_token cookie (Path: /) and refresh_token cookie (Path: /auth)
+		var accessCookie, refreshCookie *http.Cookie
+		for _, c := range cookies {
+			if c.Name == "access_token" && c.Path == "/" {
+				accessCookie = c
+			}
+			if c.Name == "refresh_token" && c.Path == "/auth" {
+				refreshCookie = c
+			}
+		}
+
+		zhtest.AssertTrue(t, accessCookie != nil)
+		zhtest.AssertEqual(t, "new-access-token", accessCookie.Value)
+
+		zhtest.AssertTrue(t, refreshCookie != nil)
+		zhtest.AssertEqual(t, "new-refresh-token", refreshCookie.Value)
+	})
+
+	t.Run("body takes precedence over cookie", func(t *testing.T) {
+		store.validateFunc = func(ctx context.Context, token string) (JWTClaims, error) {
+			if token == "body-refresh-token" {
+				return map[string]any{
+					"sub":  "user456",
+					"type": TokenTypeRefresh,
+				}, nil
+			}
+			return nil, errors.New("invalid token")
+		}
+
+		body := `{"refresh_token":"body-refresh-token"}`
+		req := httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader(body))
+		req.Header.Set(httpx.HeaderContentType, httpx.MIMEApplicationJSON)
+		req.AddCookie(&http.Cookie{Name: "jwt_token", Value: "cookie-refresh-token"})
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		zhtest.AssertEqual(t, http.StatusOK, rr.Code)
+	})
+}
+
+func TestLogoutTokenHandler_WithCookieEnabled(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(ctx context.Context, token string) (JWTClaims, error) {
+			if token == "cookie-refresh-token" {
+				return map[string]any{
+					"sub":  "user123",
+					"type": TokenTypeRefresh,
+				}, nil
+			}
+			return nil, errors.New("invalid token")
+		},
+	}
+
+	cfg := Config{
+		Store: store,
+		Cookie: CookieConfig{
+			Enabled:     true,
+			Name:        "access_token",
+			Path:        "/",
+			RefreshPath: "/auth",
+			RefreshName: "refresh_token",
+			Secure:      true,
+			HttpOnly:    true,
+		},
+	}
+
+	handler := LogoutTokenHandler(cfg)
+
+	t.Run("reads refresh token from cookie and deletes cookie", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/auth/logout", strings.NewReader("{}"))
+		req.Header.Set(httpx.HeaderContentType, httpx.MIMEApplicationJSON)
+		req.AddCookie(&http.Cookie{Name: "refresh_token", Value: "cookie-refresh-token"})
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		zhtest.AssertEqual(t, http.StatusOK, rr.Code)
+
+		var resp map[string]any
+		zhtest.AssertNoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+		zhtest.AssertEqual(t, "logged out successfully", resp["message"])
+
+		// Verify both cookies are deleted
+		cookies := rr.Result().Cookies()
+		zhtest.AssertEqual(t, 2, len(cookies))
+
+		// Find deleted access_token cookie (Path: /) and refresh_token cookie (Path: /auth)
+		var accessCookie, refreshCookie *http.Cookie
+		for _, c := range cookies {
+			if c.Name == "access_token" && c.Path == "/" {
+				accessCookie = c
+			}
+			if c.Name == "refresh_token" && c.Path == "/auth" {
+				refreshCookie = c
+			}
+		}
+
+		zhtest.AssertTrue(t, accessCookie != nil)
+		zhtest.AssertEqual(t, "", accessCookie.Value)
+		zhtest.AssertEqual(t, -1, accessCookie.MaxAge)
+
+		zhtest.AssertTrue(t, refreshCookie != nil)
+		zhtest.AssertEqual(t, "", refreshCookie.Value)
+		zhtest.AssertEqual(t, -1, refreshCookie.MaxAge)
+	})
+}
+
+func TestRefreshTokenHandler_CookieDisabled(t *testing.T) {
+	store := &mockTokenStore{
+		validateFunc: func(ctx context.Context, token string) (JWTClaims, error) {
+			return map[string]any{
+				"sub":  "user123",
+				"type": TokenTypeRefresh,
+			}, nil
+		},
+		generateFunc: func(ctx context.Context, claims JWTClaims, tokenType TokenType, ttl time.Duration) (string, error) {
+			return "token", nil
+		},
+	}
+
+	cfg := Config{
+		Store:          store,
+		AccessTokenTTL: 15 * time.Minute,
+		// Cookie.Enabled defaults to false
+	}
+
+	handler := RefreshTokenHandler(cfg)
+
+	t.Run("does not read from cookie when disabled", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader("{}"))
+		req.Header.Set(httpx.HeaderContentType, httpx.MIMEApplicationJSON)
+		req.AddCookie(&http.Cookie{Name: "jwt_token", Value: "cookie-token"})
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		// Should fail because cookie reading is disabled
+		zhtest.AssertEqual(t, http.StatusUnprocessableEntity, rr.Code)
+	})
+
+	t.Run("does not set cookie when disabled", func(t *testing.T) {
+		body := `{"refresh_token":"valid-refresh-token"}`
+		req := httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader(body))
+		req.Header.Set(httpx.HeaderContentType, httpx.MIMEApplicationJSON)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		zhtest.AssertEqual(t, http.StatusOK, rr.Code)
+
+		// Verify no cookie was set
+		zhtest.AssertWith(t, rr).CookieNotExists("jwt_token")
+	})
+}

--- a/middleware/jwtauth/jwt_auth_test.go
+++ b/middleware/jwtauth/jwt_auth_test.go
@@ -2134,6 +2134,45 @@ func TestSetCookie_Defaults(t *testing.T) {
 	zhtest.AssertEqual(t, int(30*time.Minute.Seconds()), cookie.MaxAge)
 }
 
+func TestSetRefreshCookie(t *testing.T) {
+	cfg := Config{
+		RefreshTokenTTL: 7 * 24 * time.Hour,
+		Cookie: CookieConfig{
+			RefreshName: "refresh_token",
+			RefreshPath: "/auth",
+			Secure:      true,
+			HttpOnly:    true,
+			SameSite:    http.SameSiteStrictMode,
+		},
+	}
+
+	rr := httptest.NewRecorder()
+	SetRefreshCookie(rr, "my-refresh-token", cfg)
+
+	zhtest.AssertWith(t, rr).CookieExists("refresh_token")
+	cookie := rr.Result().Cookies()[0]
+	zhtest.AssertEqual(t, "my-refresh-token", cookie.Value)
+	zhtest.AssertEqual(t, "/auth", cookie.Path)
+	zhtest.AssertEqual(t, true, cookie.Secure)
+	zhtest.AssertEqual(t, true, cookie.HttpOnly)
+	zhtest.AssertEqual(t, http.SameSiteStrictMode, cookie.SameSite)
+	zhtest.AssertEqual(t, int(7*24*time.Hour.Seconds()), cookie.MaxAge)
+}
+
+func TestSetRefreshCookie_Defaults(t *testing.T) {
+	cfg := Config{
+		RefreshTokenTTL: 30 * 24 * time.Hour,
+	}
+
+	rr := httptest.NewRecorder()
+	SetRefreshCookie(rr, "my-refresh-token", cfg)
+
+	zhtest.AssertWith(t, rr).CookieExists("refresh_token")
+	cookie := rr.Result().Cookies()[0]
+	zhtest.AssertEqual(t, "/auth", cookie.Path)
+	zhtest.AssertEqual(t, int(30*24*time.Hour.Seconds()), cookie.MaxAge)
+}
+
 func TestDeleteCookie(t *testing.T) {
 	cfg := Config{
 		Cookie: CookieConfig{


### PR DESCRIPTION
Add CookieConfig with secure defaults (HttpOnly, Secure, SameSite=Strict). Add SetCookie/SetRefreshCookie/DeleteCookie helpers and cookie extractors. Fix RefreshTokenHandler to not copy refresh token claims to access tokens.

Add jwtauth_cookie example demonstrating:
- HttpOnly cookies for XSS protection
- Separate access_token (Path: /) and refresh_token (Path: /auth) cookies
- CSP nonce integration for inline scripts/styles
- Token refresh and logout flows with automatic cookie handling