### PR TITLE
feat(tls): add built-in HTTP to HTTPS redirect and default server hel…

### DIFF
--- a/config.go
+++ b/config.go
@@ -125,6 +125,12 @@ type TLSConfig struct {
 	// KeyFile is the file path to the TLS private key (PEM) when serving HTTPS.
 	// Default: "" (no key loaded unless specified)
 	KeyFile string
+
+	// RedirectHTTP enables automatic HTTP to HTTPS redirects when both HTTP and
+	// HTTPS servers are running. When enabled, all HTTP traffic is redirected
+	// to HTTPS with a 301 Moved Permanently status.
+	// Default: false
+	RedirectHTTP bool
 }
 
 type LifecycleConfig struct {

--- a/examples/core/tls/main.go
+++ b/examples/core/tls/main.go
@@ -2,45 +2,23 @@ package main
 
 import (
 	"log"
-	"net"
 	"net/http"
 
 	zh "github.com/alexferl/zerohttp"
 )
-
-func httpsRedirectMiddleware(httpsPort string) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.TLS == nil {
-				host, _, err := net.SplitHostPort(r.Host)
-				if err != nil {
-					// No port in Host, use as-is
-					host = r.Host
-				}
-
-				target := "https://" + host + ":" + httpsPort + r.RequestURI
-				http.Redirect(w, r, target, http.StatusMovedPermanently)
-				return
-			}
-			next.ServeHTTP(w, r)
-		})
-	}
-}
 
 func main() {
 	app := zh.New(
 		zh.Config{
 			Addr: "localhost:8080",
 			TLS: zh.TLSConfig{
-				Addr:     "localhost:8443",
-				CertFile: "cert.pem",
-				KeyFile:  "key.pem",
+				Addr:         "localhost:8443",
+				CertFile:     "cert.pem",
+				KeyFile:      "key.pem",
+				RedirectHTTP: true, // Redirect HTTP to HTTPS
 			},
 		},
 	)
-
-	// Add redirect middleware with custom HTTPS port
-	app.Use(httpsRedirectMiddleware("8443"))
 
 	app.GET("/", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 		return zh.R.JSON(w, 200, zh.M{

--- a/server.go
+++ b/server.go
@@ -21,13 +21,64 @@ import (
 	"github.com/alexferl/zerohttp/sse"
 )
 
-// Default server timeout constants
 const (
 	DefaultReadTimeout       = 10 * time.Second
 	DefaultReadHeaderTimeout = 5 * time.Second
 	DefaultWriteTimeout      = 15 * time.Second
-	DefaultIdleTimeout       = 60 * time.Second
+	// DefaultIdleTimeout is explicitly set to 60s.
+	// Note: If IdleTimeout is 0, Go falls back to ReadTimeout. We set this
+	// explicitly to avoid confusion and ensure the intended timeout is used.
+	DefaultIdleTimeout    = 60 * time.Second
+	DefaultMaxHeaderBytes = 16 * 1024 // 16 KB -> actual limit is ~20 KB (Go adds +4096)
 )
+
+// DefaultHTTPServer returns a new http.Server with sensible defaults.
+// Use this as a base when you need to customize only specific server fields
+// while keeping the other defaults.
+//
+// Example:
+//
+//	srv := zerohttp.DefaultHTTPServer()
+//	srv.ReadTimeout = 30 * time.Second
+//	app := zerohttp.New(zerohttp.Config{
+//	    Server: srv,
+//	})
+func DefaultHTTPServer() *http.Server {
+	return &http.Server{
+		ReadTimeout:       DefaultReadTimeout,
+		ReadHeaderTimeout: DefaultReadHeaderTimeout,
+		WriteTimeout:      DefaultWriteTimeout,
+		IdleTimeout:       DefaultIdleTimeout,
+		MaxHeaderBytes:    DefaultMaxHeaderBytes,
+	}
+}
+
+// DefaultTLSServer returns a new http.Server with sensible defaults for TLS.
+// Use this as a base when you need to customize only specific TLS server fields
+// while keeping the other defaults.
+//
+// Example:
+//
+//	srv := zerohttp.DefaultTLSServer()
+//	srv.ReadTimeout = 30 * time.Second
+//	app := zerohttp.New(zerohttp.Config{
+//	    TLS: TLSConfig{
+//	        Server: srv,
+//	    },
+//	})
+func DefaultTLSServer() *http.Server {
+	return &http.Server{
+		ReadTimeout:       DefaultReadTimeout,
+		ReadHeaderTimeout: DefaultReadHeaderTimeout,
+		WriteTimeout:      DefaultWriteTimeout,
+		IdleTimeout:       DefaultIdleTimeout,
+		MaxHeaderBytes:    DefaultMaxHeaderBytes,
+		TLSConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			NextProtos: []string{"h2", "http/1.1"},
+		},
+	}
+}
 
 // Server represents a zerohttp server instance that wraps Go's standard HTTP server
 // with additional functionality including middleware support, TLS configuration,
@@ -74,6 +125,10 @@ type Server struct {
 	// keyFile is the file path to the TLS private key in PEM format.
 	// Used when serving HTTPS traffic with certificate files.
 	keyFile string
+
+	// redirectHTTP enables automatic HTTP to HTTPS redirects when both HTTP and
+	// HTTPS servers are configured and running.
+	redirectHTTP bool
 
 	// logger is the structured logger used by the server and its middleware
 	// for recording HTTP requests, errors, and server lifecycle events.
@@ -165,13 +220,24 @@ type Server struct {
 // Example - With custom configuration:
 //
 //	app := zh.New(Config{
-//	    Addr:         ":8080",
-//	    ReadTimeout:  10 * time.Second,
-//	    WriteTimeout: 15 * time.Second,
-//	    Logger:       myLogger,
-//	    Metrics: MetricsConfig{
+//	    Addr: ":8080",
+//	    Server: &http.Server{
+//	        ReadTimeout:  10 * time.Second,
+//	        WriteTimeout: 15 * time.Second,
+//	    },
+//	    Logger: myLogger,
+//	    Metrics: metrics.Config{
 //	        Enabled: config.Bool(false), // Disable metrics
 //	    },
+//	})
+//
+// Example - Customizing only specific server fields (keeps other defaults):
+//
+//	srv := zh.DefaultHTTPServer()
+//	srv.ReadTimeout = 30 * time.Second
+//	app := zh.New(Config{
+//	    Addr:   ":8080",
+//	    Server: srv,
 //	})
 //
 // Example - With pluggable validator:
@@ -202,6 +268,7 @@ func New(cfg ...Config) *Server {
 		tlsListener:        c.TLS.Listener,
 		certFile:           c.TLS.CertFile,
 		keyFile:            c.TLS.KeyFile,
+		redirectHTTP:       c.TLS.RedirectHTTP,
 		autocertManager:    c.Extensions.AutocertManager,
 		http3Server:        c.Extensions.HTTP3Server,
 		webTransportServer: c.Extensions.WebTransportServer,
@@ -353,7 +420,13 @@ func (s *Server) Start() error {
 
 	// Start HTTP server
 	if s.server != nil {
-		s.server.Handler = handler
+		// Use redirect handler if configured and TLS is enabled
+		if s.redirectHTTP && shouldStartTLS {
+			s.server.Handler = s.createHTTPSRedirectHandler()
+			s.logger.Info("HTTP to HTTPS redirect enabled", log.F("https_addr", s.tlsServer.Addr))
+		} else {
+			s.server.Handler = handler
+		}
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -764,7 +837,7 @@ func createLogger(c Config) log.Logger {
 	return log.NewDefaultLogger()
 }
 
-// createHTTPServer creates the HTTP server from
+// createHTTPServer creates the HTTP server from config.
 func createHTTPServer(c Config, logger log.Logger) *http.Server {
 	if c.Server != nil {
 		if c.Server.ErrorLog == nil {
@@ -772,15 +845,10 @@ func createHTTPServer(c Config, logger log.Logger) *http.Server {
 		}
 		return c.Server
 	}
-	return &http.Server{
-		Addr:              c.Addr,
-		ReadTimeout:       DefaultReadTimeout,
-		ReadHeaderTimeout: DefaultReadHeaderTimeout,
-		WriteTimeout:      DefaultWriteTimeout,
-		IdleTimeout:       DefaultIdleTimeout,
-		MaxHeaderBytes:    1 << 20, // 1 MB
-		ErrorLog:          log.StdLogger(logger),
-	}
+	srv := DefaultHTTPServer()
+	srv.Addr = c.Addr
+	srv.ErrorLog = log.StdLogger(logger)
+	return srv
 }
 
 // createTLSServer creates the TLS server from config if TLS is configured.
@@ -794,19 +862,10 @@ func createTLSServer(c Config, logger log.Logger) *http.Server {
 	if !needsTLSServer(c) {
 		return nil
 	}
-	return &http.Server{
-		Addr:              c.TLS.Addr,
-		ReadTimeout:       DefaultReadTimeout,
-		ReadHeaderTimeout: DefaultReadHeaderTimeout,
-		WriteTimeout:      DefaultWriteTimeout,
-		IdleTimeout:       DefaultIdleTimeout,
-		MaxHeaderBytes:    1 << 20, // 1 MB
-		ErrorLog:          log.StdLogger(logger),
-		TLSConfig: &tls.Config{
-			MinVersion: tls.VersionTLS12,
-			NextProtos: []string{"h2", "http/1.1"},
-		},
-	}
+	srv := DefaultTLSServer()
+	srv.Addr = c.TLS.Addr
+	srv.ErrorLog = log.StdLogger(logger)
+	return srv
 }
 
 // needsTLSServer returns true if the config requires a TLS server to be created.

--- a/server_http3_test.go
+++ b/server_http3_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -331,18 +330,7 @@ func TestServer_ListenAndServeTLS_WithHTTP3(t *testing.T) {
 	mockH3 := &mockHTTP3Server{}
 	server.SetHTTP3Server(mockH3)
 
-	certFile := "/tmp/test_cert_h3.pem"
-	keyFile := "/tmp/test_key_h3.pem"
-
-	if err := os.WriteFile(certFile, []byte(testCertPEM), 0o644); err != nil {
-		t.Skipf("Cannot write cert file: %v", err)
-	}
-	defer func() { _ = os.Remove(certFile) }()
-
-	if err := os.WriteFile(keyFile, []byte(testKeyPEM), 0o600); err != nil {
-		t.Skipf("Cannot write key file: %v", err)
-	}
-	defer func() { _ = os.Remove(keyFile) }()
+	certFile, keyFile := writeTestCertFiles(t)
 
 	server.tlsServer = &http.Server{Addr: "127.0.0.1:0"}
 
@@ -379,18 +367,7 @@ func TestServer_ListenAndServeTLS_HTTP3Error(t *testing.T) {
 	mockH3 := &mockHTTP3ServerWithError{shouldErr: true, errMsg: "h3 error"}
 	server.SetHTTP3Server(mockH3)
 
-	certFile := "/tmp/test_cert_h3_err.pem"
-	keyFile := "/tmp/test_key_h3_err.pem"
-
-	if err := os.WriteFile(certFile, []byte(testCertPEM), 0o644); err != nil {
-		t.Skipf("Cannot write cert file: %v", err)
-	}
-	defer func() { _ = os.Remove(certFile) }()
-
-	if err := os.WriteFile(keyFile, []byte(testKeyPEM), 0o600); err != nil {
-		t.Skipf("Cannot write key file: %v", err)
-	}
-	defer func() { _ = os.Remove(keyFile) }()
+	certFile, keyFile := writeTestCertFiles(t)
 
 	server.tlsServer = &http.Server{Addr: "127.0.0.1:0"}
 
@@ -427,18 +404,7 @@ func TestServer_Start_WithHTTP3(t *testing.T) {
 	mockH3 := &mockHTTP3Server{}
 	server.SetHTTP3Server(mockH3)
 
-	certFile := "/tmp/test_cert_h3_start.pem"
-	keyFile := "/tmp/test_key_h3_start.pem"
-
-	if err := os.WriteFile(certFile, []byte(testCertPEM), 0o644); err != nil {
-		t.Skipf("Cannot write cert file: %v", err)
-	}
-	defer func() { _ = os.Remove(certFile) }()
-
-	if err := os.WriteFile(keyFile, []byte(testKeyPEM), 0o600); err != nil {
-		t.Skipf("Cannot write key file: %v", err)
-	}
-	defer func() { _ = os.Remove(keyFile) }()
+	certFile, keyFile := writeTestCertFiles(t)
 
 	server.certFile = certFile
 	server.keyFile = keyFile

--- a/server_test.go
+++ b/server_test.go
@@ -2,6 +2,7 @@ package zerohttp
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"net"
 	"net/http"
@@ -63,6 +64,25 @@ xzKGQgvxYl3wxq3D3J3tQR3KsZ4ueGmATp7F/AkpBJdk1TJFDdWr9/OsdPyNiIcu
 VrZYW+DzdGqEaVYWCIzyw6CykDvUG9eq3AgHJK3Li87o0jJ9GvvOX1YuiE7/FHY3
 O6lBO0Onq9vJGuITYJtl/t+6
 -----END PRIVATE KEY-----`
+
+// writeTestCertFiles creates temporary certificate and key files for testing.
+// Returns the paths to the cert and key files.
+func writeTestCertFiles(t *testing.T) (certFile, keyFile string) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	certFile = tmpDir + "/test.crt"
+	keyFile = tmpDir + "/test.key"
+
+	if err := os.WriteFile(certFile, []byte(testCertPEM), 0o644); err != nil {
+		t.Fatalf("Failed to write cert file: %v", err)
+	}
+	if err := os.WriteFile(keyFile, []byte(testKeyPEM), 0o600); err != nil {
+		t.Fatalf("Failed to write key file: %v", err)
+	}
+
+	return certFile, keyFile
+}
 
 // Mock logger for testing
 type mockServerLogger struct {
@@ -444,18 +464,7 @@ func TestServer_Start_WithCertLoading(t *testing.T) {
 	server := New()
 	server.server = nil // Disable HTTP server
 
-	certFile := "/tmp/test_cert_start.pem"
-	keyFile := "/tmp/test_key_start.pem"
-
-	if err := os.WriteFile(certFile, []byte(testCertPEM), 0o644); err != nil {
-		t.Skipf("Cannot write cert file: %v", err)
-	}
-	defer func() { _ = os.Remove(certFile) }()
-
-	if err := os.WriteFile(keyFile, []byte(testKeyPEM), 0o600); err != nil {
-		t.Skipf("Cannot write key file: %v", err)
-	}
-	defer func() { _ = os.Remove(keyFile) }()
+	certFile, keyFile := writeTestCertFiles(t)
 
 	server.certFile = certFile
 	server.keyFile = keyFile
@@ -576,4 +585,59 @@ func TestServer_DefaultTimeoutsApplied(t *testing.T) {
 	zhtest.AssertEqual(t, DefaultReadTimeout, server.server.ReadTimeout)
 	zhtest.AssertEqual(t, DefaultWriteTimeout, server.server.WriteTimeout)
 	zhtest.AssertEqual(t, DefaultIdleTimeout, server.server.IdleTimeout)
+}
+
+func TestServer_RedirectHTTPConfig(t *testing.T) {
+	// Test that RedirectHTTP is stored correctly
+	server := New(Config{
+		TLS: TLSConfig{
+			RedirectHTTP: true,
+		},
+	})
+
+	zhtest.AssertTrue(t, server.redirectHTTP)
+}
+
+func TestServer_NoRedirectHTTPByDefault(t *testing.T) {
+	// Test that RedirectHTTP is false by default
+	server := New()
+
+	zhtest.AssertFalse(t, server.redirectHTTP)
+}
+
+func TestDefaultHTTPServer(t *testing.T) {
+	srv := DefaultHTTPServer()
+
+	zhtest.AssertEqual(t, DefaultReadTimeout, srv.ReadTimeout)
+	zhtest.AssertEqual(t, DefaultReadHeaderTimeout, srv.ReadHeaderTimeout)
+	zhtest.AssertEqual(t, DefaultWriteTimeout, srv.WriteTimeout)
+	zhtest.AssertEqual(t, DefaultIdleTimeout, srv.IdleTimeout)
+	zhtest.AssertEqual(t, DefaultMaxHeaderBytes, srv.MaxHeaderBytes)
+
+	// Test that modifying the returned server doesn't affect subsequent calls
+	srv.ReadTimeout = 30 * time.Second
+	srv2 := DefaultHTTPServer()
+	zhtest.AssertEqual(t, DefaultReadTimeout, srv2.ReadTimeout)
+}
+
+func TestDefaultTLSServer(t *testing.T) {
+	srv := DefaultTLSServer()
+
+	zhtest.AssertEqual(t, DefaultReadTimeout, srv.ReadTimeout)
+	zhtest.AssertEqual(t, DefaultReadHeaderTimeout, srv.ReadHeaderTimeout)
+	zhtest.AssertEqual(t, DefaultWriteTimeout, srv.WriteTimeout)
+	zhtest.AssertEqual(t, DefaultIdleTimeout, srv.IdleTimeout)
+	zhtest.AssertEqual(t, DefaultMaxHeaderBytes, srv.MaxHeaderBytes)
+
+	// TLS-specific defaults
+	zhtest.AssertNotNil(t, srv.TLSConfig)
+	zhtest.AssertEqual(t, uint16(tls.VersionTLS12), srv.TLSConfig.MinVersion)
+	zhtest.AssertEqual(t, []string{"h2", "http/1.1"}, srv.TLSConfig.NextProtos)
+
+	// Test that modifying the returned server doesn't affect subsequent calls
+	srv.ReadTimeout = 30 * time.Second
+	srv.TLSConfig.MinVersion = tls.VersionTLS13
+	srv2 := DefaultTLSServer()
+	zhtest.AssertEqual(t, DefaultReadTimeout, srv2.ReadTimeout)
+	zhtest.AssertEqual(t, uint16(tls.VersionTLS12), srv2.TLSConfig.MinVersion)
 }

--- a/server_tls.go
+++ b/server_tls.go
@@ -306,10 +306,26 @@ func (s *Server) ListenerTLSAddr() string {
 // Returns an http.Handler that performs permanent redirects (301) to HTTPS.
 func (s *Server) createHTTPSRedirectHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Extract host from the request (without port)
+		host, _, err := net.SplitHostPort(r.Host)
+		if err != nil {
+			// No port in Host, use as-is
+			host = r.Host
+		}
+
+		// Get the HTTPS port from the TLS server config
+		httpsPort := ""
+		if s.tlsServer != nil && s.tlsServer.Addr != "" {
+			_, port, err := net.SplitHostPort(s.tlsServer.Addr)
+			if err == nil && port != "" && port != "443" {
+				httpsPort = ":" + port
+			}
+		}
+
 		// Build HTTPS URL by copying the URL and changing scheme
 		target := *r.URL
 		target.Scheme = "https"
-		target.Host = r.Host
+		target.Host = host + httpsPort
 
 		httpsURL := target.String()
 		s.logger.Debug("Redirecting HTTP to HTTPS",

--- a/server_tls_test.go
+++ b/server_tls_test.go
@@ -34,18 +34,68 @@ func TestServer_ListenerTLSAddr(t *testing.T) {
 }
 
 func TestServer_CreateHTTPSRedirectHandler(t *testing.T) {
-	server := New()
-	handler := server.createHTTPSRedirectHandler()
+	t.Run("default port 443", func(t *testing.T) {
+		server := New()
+		handler := server.createHTTPSRedirectHandler()
 
-	req := httptest.NewRequest(http.MethodGet, "http://example.com/path?query=value", nil)
-	req.Host = "example.com"
-	w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/path?query=value", nil)
+		req.Host = "example.com"
+		w := httptest.NewRecorder()
 
-	handler.ServeHTTP(w, req)
+		handler.ServeHTTP(w, req)
 
-	zhtest.AssertWith(t, w).
-		Status(http.StatusMovedPermanently).
-		Header(httpx.HeaderLocation, "https://example.com/path?query=value")
+		zhtest.AssertWith(t, w).
+			Status(http.StatusMovedPermanently).
+			Header(httpx.HeaderLocation, "https://example.com/path?query=value")
+	})
+
+	t.Run("custom https port", func(t *testing.T) {
+		certFile, keyFile := writeTestCertFiles(t)
+
+		server := New(Config{
+			TLS: TLSConfig{
+				Addr:     "localhost:8443",
+				CertFile: certFile,
+				KeyFile:  keyFile,
+			},
+		})
+		handler := server.createHTTPSRedirectHandler()
+
+		req := httptest.NewRequest(http.MethodGet, "http://example.com:8080/path?query=value", nil)
+		req.Host = "example.com:8080"
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		// Should redirect to https with port 8443 (not 8080)
+		zhtest.AssertWith(t, w).
+			Status(http.StatusMovedPermanently).
+			Header(httpx.HeaderLocation, "https://example.com:8443/path?query=value")
+	})
+
+	t.Run("port 443 omitted", func(t *testing.T) {
+		certFile, keyFile := writeTestCertFiles(t)
+
+		server := New(Config{
+			TLS: TLSConfig{
+				Addr:     "example.com:443",
+				CertFile: certFile,
+				KeyFile:  keyFile,
+			},
+		})
+		handler := server.createHTTPSRedirectHandler()
+
+		req := httptest.NewRequest(http.MethodGet, "http://example.com:8080/path", nil)
+		req.Host = "example.com:8080"
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		// Port 443 should be omitted from the URL
+		zhtest.AssertWith(t, w).
+			Status(http.StatusMovedPermanently).
+			Header(httpx.HeaderLocation, "https://example.com/path")
+	})
 }
 
 func TestServer_StartAutoTLS_NoManager(t *testing.T) {

--- a/server_webtransport_test.go
+++ b/server_webtransport_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -123,18 +122,7 @@ func TestServer_ListenAndServeTLS_WithWebTransport(t *testing.T) {
 	mockWT := &mockWebTransportServer{}
 	server.SetWebTransportServer(mockWT)
 
-	certFile := "/tmp/test_cert_wt.pem"
-	keyFile := "/tmp/test_key_wt.pem"
-
-	if err := os.WriteFile(certFile, []byte(testCertPEM), 0o644); err != nil {
-		t.Skipf("Cannot write cert file: %v", err)
-	}
-	defer func() { _ = os.Remove(certFile) }()
-
-	if err := os.WriteFile(keyFile, []byte(testKeyPEM), 0o600); err != nil {
-		t.Skipf("Cannot write key file: %v", err)
-	}
-	defer func() { _ = os.Remove(keyFile) }()
+	certFile, keyFile := writeTestCertFiles(t)
 
 	server.tlsServer = &http.Server{Addr: "127.0.0.1:0"}
 
@@ -171,18 +159,7 @@ func TestServer_Start_WithWebTransport(t *testing.T) {
 	mockWT := &mockWebTransportServer{}
 	server.SetWebTransportServer(mockWT)
 
-	certFile := "/tmp/test_cert_wt_start.pem"
-	keyFile := "/tmp/test_key_wt_start.pem"
-
-	if err := os.WriteFile(certFile, []byte(testCertPEM), 0o644); err != nil {
-		t.Skipf("Cannot write cert file: %v", err)
-	}
-	defer func() { _ = os.Remove(certFile) }()
-
-	if err := os.WriteFile(keyFile, []byte(testKeyPEM), 0o600); err != nil {
-		t.Skipf("Cannot write key file: %v", err)
-	}
-	defer func() { _ = os.Remove(keyFile) }()
+	certFile, keyFile := writeTestCertFiles(t)
 
 	server.certFile = certFile
 	server.keyFile = keyFile


### PR DESCRIPTION
…pers

Add `RedirectHTTP` option to `TLSConfig` that automatically redirects all HTTP traffic to HTTPS when both servers are running. The redirect handler correctly uses the configured HTTPS port (omitting port 443).

Add `DefaultHTTPServer()` and `DefaultTLSServer()` functions for customizing specific server fields while keeping other defaults. Both are now used internally when creating servers.

Also includes:
- Add `DefaultMaxHeaderBytes` constant (16 KB)
- Add comment explaining IdleTimeout fallback behavior
- Fix doc example (correct `metrics.Config` type, timeouts in `Server`)
- Add `writeTestCertFiles()` test helper and refactor all TLS tests
- Update TLS example to demonstrate the new built-in redirect