### PR TITLE
feat(tls): enable HTTP to HTTPS redirect by default

### DIFF
--- a/config.go
+++ b/config.go
@@ -129,7 +129,7 @@ type TLSConfig struct {
 	// RedirectHTTP enables automatic HTTP to HTTPS redirects when both HTTP and
 	// HTTPS servers are running. When enabled, all HTTP traffic is redirected
 	// to HTTPS with a 301 Moved Permanently status.
-	// Default: false
+	// Default: true (for security, redirects to HTTPS by default)
 	RedirectHTTP bool
 }
 
@@ -205,8 +205,9 @@ type ExtensionsConfig struct {
 var DefaultConfig = Config{
 	Addr: "localhost:8080",
 	TLS: TLSConfig{
-		Addr:   "localhost:8443",
-		Server: nil,
+		Addr:         "localhost:8443",
+		Server:       nil,
+		RedirectHTTP: true,
 	},
 	DisableDefaultMiddlewares: false,
 	DefaultMiddlewares:        nil, // means use DefaultMiddlewares

--- a/examples/core/tls/README.md
+++ b/examples/core/tls/README.md
@@ -5,7 +5,6 @@ This example demonstrates configuring HTTPS/TLS with automatic HTTP to HTTPS red
 ## Features
 
 - HTTPS server on port 8443
-- HTTP redirect middleware
 - TLS certificate configuration
 
 ## Prerequisites

--- a/examples/core/tls/main.go
+++ b/examples/core/tls/main.go
@@ -12,10 +12,11 @@ func main() {
 		zh.Config{
 			Addr: "localhost:8080",
 			TLS: zh.TLSConfig{
-				Addr:         "localhost:8443",
-				CertFile:     "cert.pem",
-				KeyFile:      "key.pem",
-				RedirectHTTP: true, // Redirect HTTP to HTTPS
+				Addr:     "localhost:8443",
+				CertFile: "cert.pem",
+				KeyFile:  "key.pem",
+				// RedirectHTTP defaults to true for security.
+				// Set to false to disable automatic HTTP to HTTPS redirect.
 			},
 		},
 	)

--- a/server_test.go
+++ b/server_test.go
@@ -598,9 +598,20 @@ func TestServer_RedirectHTTPConfig(t *testing.T) {
 	zhtest.AssertTrue(t, server.redirectHTTP)
 }
 
-func TestServer_NoRedirectHTTPByDefault(t *testing.T) {
-	// Test that RedirectHTTP is false by default
+func TestServer_RedirectHTTPByDefault(t *testing.T) {
+	// Test that RedirectHTTP is true by default for security
 	server := New()
+
+	zhtest.AssertTrue(t, server.redirectHTTP)
+}
+
+func TestServer_RedirectHTTPCanBeDisabled(t *testing.T) {
+	// Test that RedirectHTTP can be explicitly disabled
+	server := New(Config{
+		TLS: TLSConfig{
+			RedirectHTTP: false,
+		},
+	})
 
 	zhtest.AssertFalse(t, server.redirectHTTP)
 }


### PR DESCRIPTION
Change `TLSConfig.RedirectHTTP` default from `false` to `true` for security. When both HTTP and HTTPS servers are configured, HTTP traffic is now automatically redirected to HTTPS unless explicitly disabled.