### PR TITLE
feat(validator): add anyof validator for slices

### DIFF
--- a/validator/builtins.go
+++ b/validator/builtins.go
@@ -261,6 +261,60 @@ func (v *defaultValidator) registerBuiltins() {
 		}
 	}
 
+	// anyof - for slices/arrays, at least one element must match one of the specified options
+	validators["anyof"] = func(value reflect.Value, tag string) error {
+		options := strings.Fields(tag)
+		if len(options) == 0 {
+			return nil
+		}
+
+		if value.Kind() != reflect.Slice && value.Kind() != reflect.Array {
+			return fmt.Errorf("anyof only supports slices and arrays")
+		}
+
+		if value.Len() == 0 {
+			return fmt.Errorf("must have at least one element matching: %s", tag)
+		}
+
+		// Determine the element kind
+		elemKind := value.Type().Elem().Kind()
+
+		switch elemKind {
+		case reflect.String:
+			for i := 0; i < value.Len(); i++ {
+				s := value.Index(i).String()
+				for _, opt := range options {
+					if s == opt {
+						return nil
+					}
+				}
+			}
+			return fmt.Errorf("must have at least one element matching: %s", tag)
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			for i := 0; i < value.Len(); i++ {
+				n := value.Index(i).Int()
+				for _, opt := range options {
+					if i, err := strconv.ParseInt(opt, 10, 64); err == nil && n == i {
+						return nil
+					}
+				}
+			}
+			return fmt.Errorf("must have at least one element matching: %s", tag)
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			for i := 0; i < value.Len(); i++ {
+				n := value.Index(i).Uint()
+				for _, opt := range options {
+					if i, err := strconv.ParseUint(opt, 10, 64); err == nil && n == i {
+						return nil
+					}
+				}
+			}
+			return fmt.Errorf("must have at least one element matching: %s", tag)
+		default:
+			return fmt.Errorf("anyof not supported for element type %s", elemKind)
+		}
+	}
+
 	// eq - equal to value
 	validators["eq"] = func(value reflect.Value, tag string) error {
 		switch value.Kind() {

--- a/validator/doc.go
+++ b/validator/doc.go
@@ -64,6 +64,7 @@
 //
 //	unique - Unique elements in slice
 //	each   - Validate each element
+//	anyof  - At least one element matches (space-separated, for slices/arrays)
 //
 // # Usage
 //

--- a/validator/validator_core_test.go
+++ b/validator/validator_core_test.go
@@ -1028,6 +1028,96 @@ func TestOneOfUnsupportedType(t *testing.T) {
 	zhtest.AssertError(t, err)
 }
 
+func TestAnyOfValidator(t *testing.T) {
+	type TestAnyOf struct {
+		Tags   []string `validate:"anyof=red green blue"`
+		Levels []int    `validate:"anyof=1 2 3"`
+	}
+
+	tests := []struct {
+		name    string
+		input   TestAnyOf
+		wantErr bool
+	}{
+		{"one match in strings", TestAnyOf{Tags: []string{"red"}, Levels: []int{1}}, false},
+		{"multiple matches in strings", TestAnyOf{Tags: []string{"red", "green"}, Levels: []int{1}}, false},
+		{"match in middle", TestAnyOf{Tags: []string{"yellow", "green", "orange"}, Levels: []int{1}}, false},
+		{"last element matches", TestAnyOf{Tags: []string{"yellow", "blue"}, Levels: []int{1}}, false},
+		{"no match in strings", TestAnyOf{Tags: []string{"yellow", "orange"}, Levels: []int{1}}, true},
+		{"no match in ints", TestAnyOf{Tags: []string{"red"}, Levels: []int{4, 5}}, true},
+		{"empty slice fails", TestAnyOf{Tags: []string{}, Levels: []int{1}}, true},
+		{"nil slice fails", TestAnyOf{Tags: nil, Levels: []int{1}}, true},
+		{"both valid", TestAnyOf{Tags: []string{"red"}, Levels: []int{2}}, false},
+		{"both invalid", TestAnyOf{Tags: []string{"pink"}, Levels: []int{99}}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := New().Struct(&tt.input)
+			if tt.wantErr {
+				zhtest.AssertError(t, err)
+			} else {
+				zhtest.AssertNoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAnyOfUint(t *testing.T) {
+	type TestAnyOfUint struct {
+		Codes []uint `validate:"anyof=1 2 3"`
+	}
+
+	tests := []struct {
+		name    string
+		codes   []uint
+		wantErr bool
+	}{
+		{"valid match", []uint{1, 4}, false},
+		{"no match", []uint{4, 5}, true},
+		{"empty slice", []uint{}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := TestAnyOfUint{Codes: tt.codes}
+			err := New().Struct(&input)
+			if tt.wantErr {
+				zhtest.AssertError(t, err)
+			} else {
+				zhtest.AssertNoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAnyOfEmptyOptions(t *testing.T) {
+	type TestAnyOfEmpty struct {
+		Values []string `validate:"anyof="`
+	}
+	input := TestAnyOfEmpty{Values: []string{"anything"}}
+	err := New().Struct(&input)
+	zhtest.AssertNoError(t, err)
+}
+
+func TestAnyOfUnsupportedType(t *testing.T) {
+	type TestAnyOfFloat struct {
+		Values []float64 `validate:"anyof=1.5 2.5"`
+	}
+	input := TestAnyOfFloat{Values: []float64{1.5}}
+	err := New().Struct(&input)
+	zhtest.AssertError(t, err)
+}
+
+func TestAnyOfOnNonSlice(t *testing.T) {
+	type TestAnyOfString struct {
+		Value string `validate:"anyof=a b c"`
+	}
+	input := TestAnyOfString{Value: "a"}
+	err := New().Struct(&input)
+	zhtest.AssertError(t, err)
+}
+
 func TestUUIDValidator(t *testing.T) {
 	type TestUUID struct {
 		ID string `validate:"uuid"`


### PR DESCRIPTION
Add anyof validator that checks if at least one element in a slice/array matches one of the specified options. Supports string, int, and uint slices.

Example: `validate:"anyof=red green blue"` ensures at least one element in the slice equals "red", "green", or "blue".