### PR TITLE
feat(pagination): add pagination package with offset-based pagination

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -107,6 +107,7 @@ Complete examples with their own `go.mod` files, demonstrating integration with 
 
 - [**`healthcheck/`**](healthcheck/) - Health check endpoints
 - [**`metrics/`**](metrics/) - Prometheus metrics endpoint
+- [**`pagination/`**](pagination/) - Pagination with response headers
 - [**`pprof/`**](pprof/) - Performance profiling endpoints
 - [**`sse/`**](sse/) - Server-Sent Events
 

--- a/examples/pagination/README.md
+++ b/examples/pagination/README.md
@@ -1,0 +1,62 @@
+# Pagination Example
+
+This example demonstrates pagination with the pagination package.
+
+## Features
+
+- Offset-based pagination with standardized response headers
+- Query parameter binding for page and per_page
+- Search functionality with pagination
+- RFC 5988 Link headers for navigation
+
+## Running the Example
+
+```bash
+go run .
+```
+
+The server starts on `http://localhost:8080`.
+
+## Endpoints
+
+| Method | Endpoint              | Description                        |
+|--------|-----------------------|------------------------------------|
+| `GET`  | `/`                   | Index page with documentation      |
+| `GET`  | `/products`           | List products (paginated)          |
+| `GET`  | `/products/search`    | Search products with pagination    |
+
+## Response Headers
+
+The following headers are included in paginated responses:
+
+| Header            | Description                          |
+|-------------------|--------------------------------------|
+| `X-Total`         | Total number of items available      |
+| `X-Total-Pages`   | Total number of pages                |
+| `X-Page`          | Current page number                  |
+| `X-Per-Page`      | Items per page                       |
+| `X-Prev-Page`     | Previous page number (if available)  |
+| `X-Next-Page`     | Next page number (if available)      |
+| `Link`            | RFC 5988 Link header                 |
+
+## Test Commands
+
+### List products (default pagination)
+```bash
+curl -i "http://localhost:8080/products"
+```
+
+### Get page 2 with 10 items per page
+```bash
+curl -i "http://localhost:8080/products?page=2&per_page=10"
+```
+
+### Search products with pagination
+```bash
+curl -i "http://localhost:8080/products/search?q=product%201"
+```
+
+### Search with custom page size
+```bash
+curl -i "http://localhost:8080/products/search?q=product&page=1&per_page=5"
+```

--- a/examples/pagination/main.go
+++ b/examples/pagination/main.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+
+	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/pagination"
+)
+
+// Product represents a product in our store
+type Product struct {
+	ID    int     `json:"id"`
+	Name  string  `json:"name"`
+	Price float64 `json:"price"`
+}
+
+// ProductStore holds our products
+type ProductStore struct {
+	products []Product
+}
+
+func NewProductStore() *ProductStore {
+	// Generate sample products
+	products := make([]Product, 100)
+	for i := 0; i < 100; i++ {
+		products[i] = Product{
+			ID:    i + 1,
+			Name:  "Product " + strconv.Itoa(i+1),
+			Price: float64(i+1) * 10.99,
+		}
+	}
+	return &ProductStore{products: products}
+}
+
+// ListProducts handles GET /products with pagination
+func (s *ProductStore) ListProducts(w http.ResponseWriter, r *http.Request) error {
+	var req struct {
+		pagination.Request
+	}
+
+	if err := zh.B.Query(r, &req); err != nil {
+		return zh.R.ProblemDetail(w, zh.NewProblemDetail(http.StatusBadRequest, err.Error()))
+	}
+
+	params := req.Request.Params().Defaults()
+
+	// Calculate slice bounds
+	start := params.Offset()
+	end := start + params.PerPage
+	if end > len(s.products) {
+		end = len(s.products)
+	}
+
+	// Get the page of products
+	items := s.products[start:end]
+
+	// Write pagination headers
+	params.WriteHeaders(w, r.URL, len(s.products))
+
+	return zh.R.JSON(w, http.StatusOK, items)
+}
+
+// SearchProducts handles GET /products/search with filtering and pagination
+func (s *ProductStore) SearchProducts(w http.ResponseWriter, r *http.Request) error {
+	var req struct {
+		pagination.Request
+		Query string `query:"q"`
+	}
+
+	if err := zh.B.Query(r, &req); err != nil {
+		return zh.R.ProblemDetail(w, zh.NewProblemDetail(http.StatusBadRequest, err.Error()))
+	}
+
+	params := req.Request.Params().Defaults()
+
+	// Filter products by name
+	var filtered []Product
+	if req.Query != "" {
+		for _, p := range s.products {
+			if strings.Contains(strings.ToLower(p.Name), strings.ToLower(req.Query)) {
+				filtered = append(filtered, p)
+			}
+		}
+	} else {
+		filtered = s.products
+	}
+
+	// Calculate slice bounds
+	start := params.Offset()
+	end := start + params.PerPage
+	if end > len(filtered) {
+		end = len(filtered)
+	}
+	if start > len(filtered) {
+		start = len(filtered)
+	}
+
+	// Get the page of products
+	items := filtered[start:end]
+
+	// Write pagination headers
+	params.WriteHeaders(w, r.URL, len(filtered))
+
+	return zh.R.JSON(w, http.StatusOK, zh.M{
+		"query":   req.Query,
+		"results": items,
+		"total":   len(filtered),
+	})
+}
+
+func main() {
+	store := NewProductStore()
+
+	app := zh.New()
+
+	app.GET("/products", zh.HandlerFunc(store.ListProducts))
+	app.GET("/products/search", zh.HandlerFunc(store.SearchProducts))
+
+	log.Fatal(app.Start())
+}

--- a/pagination/doc.go
+++ b/pagination/doc.go
@@ -1,0 +1,37 @@
+// Package pagination provides utilities for handling pagination in HTTP APIs.
+//
+// It supports common pagination patterns including offset-based pagination with
+// standardized response headers. The package integrates with zerohttp's query
+// binding and validation for easy use in handlers.
+//
+// Basic usage:
+//
+//	import "github.com/alexferl/zerohttp/pagination"
+//
+//	// In your handler
+//	func ListItems(w http.ResponseWriter, r *http.Request) error {
+//	    var req struct {
+//	        pagination.Request
+//	    }
+//	    if err := zh.B.Query(r, &req); err != nil {
+//	        return err
+//	    }
+//
+//	    params := req.Request.Params().Defaults()
+//	    items, total := fetchItems(params.Offset(), params.PerPage)
+//
+//	    params.WriteHeaders(w, r.URL, total)
+//	    return zh.R.JSON(w, http.StatusOK, items)
+//	}
+//
+// Response Headers:
+//
+// The following headers are set by WriteHeaders:
+//   - X-Total: Total number of items available
+//   - X-Total-Pages: Total number of pages
+//   - X-Page: Current page number
+//   - X-Per-Page: Items per page
+//   - X-Prev-Page: Previous page number (if available)
+//   - X-Next-Page: Next page number (if available)
+//   - Link: RFC 5988 Link header with first, prev, next, last relations
+package pagination

--- a/pagination/pagination.go
+++ b/pagination/pagination.go
@@ -1,0 +1,190 @@
+package pagination
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/alexferl/zerohttp/httpx"
+)
+
+// Request is an embeddable struct for pagination query parameters.
+// Use this in your request structs to automatically bind page and per_page
+// from query strings with validation.
+//
+// Example:
+//
+//	type ListRequest struct {
+//	    pagination.Request
+//	    Search string `query:"search"`
+//	}
+type Request struct {
+	Page    int `query:"page" validate:"omitempty,min=1"`
+	PerPage int `query:"per_page" validate:"omitempty,min=1,max=100"`
+}
+
+// Params returns pagination Params from the request values.
+func (r Request) Params() Params {
+	return Params(r)
+}
+
+// Params holds pagination parameters after binding and validation.
+type Params struct {
+	Page    int
+	PerPage int
+}
+
+// Defaults returns pagination params with defaults applied.
+// If Page is less than 1, it defaults to 1.
+// If PerPage is less than 1, it defaults to 20.
+// If PerPage is greater than 100, it is capped at 100.
+func (p Params) Defaults() Params {
+	result := p
+	if result.Page < 1 {
+		result.Page = 1
+	}
+	if result.PerPage < 1 {
+		result.PerPage = 20
+	}
+	if result.PerPage > 100 {
+		result.PerPage = 100
+	}
+	return result
+}
+
+// Offset calculates the database skip offset for the current page.
+// Returns (Page-1) * PerPage.
+func (p Params) Offset() int {
+	return (p.Page - 1) * p.PerPage
+}
+
+// LimitSkip returns perPage and offset values for database queries.
+// This is a convenience method that returns the common parameters
+// needed for LIMIT/OFFSET style queries.
+func (p Params) LimitSkip() (limit, skip int) {
+	return p.PerPage, p.Offset()
+}
+
+// TotalPages calculates total pages from total items count.
+// Returns at least 1 even for empty results to maintain consistent
+// pagination semantics.
+func (p Params) TotalPages(total int) int {
+	if total == 0 {
+		return 1
+	}
+	pages := (total + p.PerPage - 1) / p.PerPage
+	if pages < 1 {
+		return 1
+	}
+	return pages
+}
+
+// ResponseHeaders contains pagination header values.
+type ResponseHeaders struct {
+	Total      int
+	TotalPages int
+	Page       int
+	PerPage    int
+	HasPrev    bool
+	HasNext    bool
+	PrevPage   int
+	NextPage   int
+}
+
+// Headers calculates pagination headers from params and total.
+// This computes all the values needed for response headers without
+// writing them, allowing inspection or modification before sending.
+func (p Params) Headers(total int) ResponseHeaders {
+	totalPages := p.TotalPages(total)
+	headers := ResponseHeaders{
+		Total:      total,
+		TotalPages: totalPages,
+		Page:       p.Page,
+		PerPage:    p.PerPage,
+	}
+
+	if p.Page > 1 {
+		headers.HasPrev = true
+		headers.PrevPage = p.Page - 1
+	}
+	if p.Page < totalPages {
+		headers.HasNext = true
+		headers.NextPage = p.Page + 1
+	}
+
+	return headers
+}
+
+// WriteHeaders writes all pagination headers to the response.
+// This sets X-Total, X-Total-Pages, X-Page, X-Per-Page, X-Prev-Page,
+// X-Next-Page, and Link headers based on the current pagination state.
+func (p Params) WriteHeaders(w http.ResponseWriter, u *url.URL, total int) {
+	headers := p.Headers(total)
+
+	w.Header().Set(httpx.HeaderXTotal, strconv.Itoa(headers.Total))
+	w.Header().Set(httpx.HeaderXTotalPages, strconv.Itoa(headers.TotalPages))
+	w.Header().Set(httpx.HeaderXPage, strconv.Itoa(headers.Page))
+	w.Header().Set(httpx.HeaderXPerPage, strconv.Itoa(headers.PerPage))
+
+	if headers.HasPrev {
+		w.Header().Set(httpx.HeaderXPrevPage, strconv.Itoa(headers.PrevPage))
+	}
+	if headers.HasNext {
+		w.Header().Set(httpx.HeaderXNextPage, strconv.Itoa(headers.NextPage))
+	}
+
+	links := BuildLinkHeader(u, p.Page, p.PerPage, headers.TotalPages)
+	if links != "" {
+		w.Header().Set(httpx.HeaderLink, links)
+	}
+}
+
+// BuildLinkHeader creates the RFC 5988 Link header for pagination.
+// Returns a string with first, prev, next, and last relations as appropriate.
+// The returned string is empty if totalPages is less than 1.
+func BuildLinkHeader(u *url.URL, page, perPage, totalPages int) string {
+	if totalPages < 1 {
+		return ""
+	}
+
+	var links []string
+
+	// First page
+	first := cloneURLWithParams(u, 1, perPage)
+	links = append(links, fmt.Sprintf("<%s>; rel=\"first\"", first))
+
+	// Previous page
+	if page > 1 {
+		prev := cloneURLWithParams(u, page-1, perPage)
+		links = append(links, fmt.Sprintf("<%s>; rel=\"prev\"", prev))
+	}
+
+	// Next page
+	if page < totalPages {
+		next := cloneURLWithParams(u, page+1, perPage)
+		links = append(links, fmt.Sprintf("<%s>; rel=\"next\"", next))
+	}
+
+	// Last page
+	last := cloneURLWithParams(u, totalPages, perPage)
+	links = append(links, fmt.Sprintf("<%s>; rel=\"last\"", last))
+
+	return strings.Join(links, ", ")
+}
+
+// cloneURLWithParams creates a URL with updated pagination params.
+// Preserves all existing query parameters and updates page and per_page.
+func cloneURLWithParams(original *url.URL, page, perPage int) string {
+	u := &url.URL{
+		Scheme: original.Scheme,
+		Host:   original.Host,
+		Path:   original.Path,
+	}
+	q := original.Query()
+	q.Set("page", strconv.Itoa(page))
+	q.Set("per_page", strconv.Itoa(perPage))
+	u.RawQuery = q.Encode()
+	return u.String()
+}

--- a/pagination/pagination_test.go
+++ b/pagination/pagination_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/alexferl/zerohttp/httpx"
+	"github.com/alexferl/zerohttp/zhtest"
 )
 
 func TestRequest_Params(t *testing.T) {
@@ -39,12 +40,8 @@ func TestRequest_Params(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tt.request.Params()
-			if result.Page != tt.expected.Page {
-				t.Errorf("expected Page %d, got %d", tt.expected.Page, result.Page)
-			}
-			if result.PerPage != tt.expected.PerPage {
-				t.Errorf("expected PerPage %d, got %d", tt.expected.PerPage, result.PerPage)
-			}
+			zhtest.AssertEqual(t, tt.expected.Page, result.Page)
+			zhtest.AssertEqual(t, tt.expected.PerPage, result.PerPage)
 		})
 	}
 }
@@ -95,12 +92,8 @@ func TestParams_Defaults(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tt.input.Defaults()
-			if result.Page != tt.expected.Page {
-				t.Errorf("expected Page %d, got %d", tt.expected.Page, result.Page)
-			}
-			if result.PerPage != tt.expected.PerPage {
-				t.Errorf("expected PerPage %d, got %d", tt.expected.PerPage, result.PerPage)
-			}
+			zhtest.AssertEqual(t, tt.expected.Page, result.Page)
+			zhtest.AssertEqual(t, tt.expected.PerPage, result.PerPage)
 		})
 	}
 }
@@ -136,9 +129,7 @@ func TestParams_Offset(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tt.params.Offset()
-			if result != tt.expected {
-				t.Errorf("expected offset %d, got %d", tt.expected, result)
-			}
+			zhtest.AssertEqual(t, tt.expected, result)
 		})
 	}
 }
@@ -147,12 +138,8 @@ func TestParams_LimitSkip(t *testing.T) {
 	params := Params{Page: 3, PerPage: 25}
 	limit, skip := params.LimitSkip()
 
-	if limit != 25 {
-		t.Errorf("expected limit 25, got %d", limit)
-	}
-	if skip != 50 {
-		t.Errorf("expected skip 50, got %d", skip)
-	}
+	zhtest.AssertEqual(t, 25, limit)
+	zhtest.AssertEqual(t, 50, skip)
 }
 
 func TestParams_TotalPages(t *testing.T) {
@@ -215,9 +202,7 @@ func TestParams_TotalPages(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tt.params.TotalPages(tt.total)
-			if result != tt.expected {
-				t.Errorf("expected %d pages, got %d", tt.expected, result)
-			}
+			zhtest.AssertEqual(t, tt.expected, result)
 		})
 	}
 }
@@ -325,30 +310,14 @@ func TestParams_Headers(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tt.params.Headers(tt.total)
 
-			if result.Total != tt.expected.Total {
-				t.Errorf("expected Total %d, got %d", tt.expected.Total, result.Total)
-			}
-			if result.TotalPages != tt.expected.TotalPages {
-				t.Errorf("expected TotalPages %d, got %d", tt.expected.TotalPages, result.TotalPages)
-			}
-			if result.Page != tt.expected.Page {
-				t.Errorf("expected Page %d, got %d", tt.expected.Page, result.Page)
-			}
-			if result.PerPage != tt.expected.PerPage {
-				t.Errorf("expected PerPage %d, got %d", tt.expected.PerPage, result.PerPage)
-			}
-			if result.HasPrev != tt.expected.HasPrev {
-				t.Errorf("expected HasPrev %v, got %v", tt.expected.HasPrev, result.HasPrev)
-			}
-			if result.HasNext != tt.expected.HasNext {
-				t.Errorf("expected HasNext %v, got %v", tt.expected.HasNext, result.HasNext)
-			}
-			if result.PrevPage != tt.expected.PrevPage {
-				t.Errorf("expected PrevPage %d, got %d", tt.expected.PrevPage, result.PrevPage)
-			}
-			if result.NextPage != tt.expected.NextPage {
-				t.Errorf("expected NextPage %d, got %d", tt.expected.NextPage, result.NextPage)
-			}
+			zhtest.AssertEqual(t, tt.expected.Total, result.Total)
+			zhtest.AssertEqual(t, tt.expected.TotalPages, result.TotalPages)
+			zhtest.AssertEqual(t, tt.expected.Page, result.Page)
+			zhtest.AssertEqual(t, tt.expected.PerPage, result.PerPage)
+			zhtest.AssertEqual(t, tt.expected.HasPrev, result.HasPrev)
+			zhtest.AssertEqual(t, tt.expected.HasNext, result.HasNext)
+			zhtest.AssertEqual(t, tt.expected.PrevPage, result.PrevPage)
+			zhtest.AssertEqual(t, tt.expected.NextPage, result.NextPage)
 		})
 	}
 }
@@ -362,27 +331,13 @@ func TestParams_WriteHeaders(t *testing.T) {
 
 	headers := rec.Header()
 
-	if headers.Get(httpx.HeaderXTotal) != "50" {
-		t.Errorf("expected X-Total header '50', got '%s'", headers.Get(httpx.HeaderXTotal))
-	}
-	if headers.Get(httpx.HeaderXTotalPages) != "3" {
-		t.Errorf("expected X-Total-Pages header '3', got '%s'", headers.Get(httpx.HeaderXTotalPages))
-	}
-	if headers.Get(httpx.HeaderXPage) != "2" {
-		t.Errorf("expected X-Page header '2', got '%s'", headers.Get(httpx.HeaderXPage))
-	}
-	if headers.Get(httpx.HeaderXPerPage) != "20" {
-		t.Errorf("expected X-Per-Page header '20', got '%s'", headers.Get(httpx.HeaderXPerPage))
-	}
-	if headers.Get(httpx.HeaderXPrevPage) != "1" {
-		t.Errorf("expected X-Prev-Page header '1', got '%s'", headers.Get(httpx.HeaderXPrevPage))
-	}
-	if headers.Get(httpx.HeaderXNextPage) != "3" {
-		t.Errorf("expected X-Next-Page header '3', got '%s'", headers.Get(httpx.HeaderXNextPage))
-	}
-	if headers.Get("Link") == "" {
-		t.Error("expected Link header to be set")
-	}
+	zhtest.AssertEqual(t, "50", headers.Get(httpx.HeaderXTotal))
+	zhtest.AssertEqual(t, "3", headers.Get(httpx.HeaderXTotalPages))
+	zhtest.AssertEqual(t, "2", headers.Get(httpx.HeaderXPage))
+	zhtest.AssertEqual(t, "20", headers.Get(httpx.HeaderXPerPage))
+	zhtest.AssertEqual(t, "1", headers.Get(httpx.HeaderXPrevPage))
+	zhtest.AssertEqual(t, "3", headers.Get(httpx.HeaderXNextPage))
+	zhtest.AssertNotEmpty(t, headers.Get("Link"))
 }
 
 func TestParams_WriteHeaders_FirstPage(t *testing.T) {
@@ -394,12 +349,8 @@ func TestParams_WriteHeaders_FirstPage(t *testing.T) {
 
 	headers := rec.Header()
 
-	if headers.Get(httpx.HeaderXPrevPage) != "" {
-		t.Errorf("expected no X-Prev-Page header on first page, got '%s'", headers.Get(httpx.HeaderXPrevPage))
-	}
-	if headers.Get(httpx.HeaderXNextPage) != "2" {
-		t.Errorf("expected X-Next-Page header '2', got '%s'", headers.Get(httpx.HeaderXNextPage))
-	}
+	zhtest.AssertEmpty(t, headers.Get(httpx.HeaderXPrevPage))
+	zhtest.AssertEqual(t, "2", headers.Get(httpx.HeaderXNextPage))
 }
 
 func TestParams_WriteHeaders_LastPage(t *testing.T) {
@@ -411,12 +362,8 @@ func TestParams_WriteHeaders_LastPage(t *testing.T) {
 
 	headers := rec.Header()
 
-	if headers.Get(httpx.HeaderXPrevPage) != "2" {
-		t.Errorf("expected X-Prev-Page header '2', got '%s'", headers.Get(httpx.HeaderXPrevPage))
-	}
-	if headers.Get(httpx.HeaderXNextPage) != "" {
-		t.Errorf("expected no X-Next-Page header on last page, got '%s'", headers.Get(httpx.HeaderXNextPage))
-	}
+	zhtest.AssertEqual(t, "2", headers.Get(httpx.HeaderXPrevPage))
+	zhtest.AssertEmpty(t, headers.Get(httpx.HeaderXNextPage))
 }
 
 func TestParams_WriteHeaders_SinglePage(t *testing.T) {
@@ -428,12 +375,8 @@ func TestParams_WriteHeaders_SinglePage(t *testing.T) {
 
 	headers := rec.Header()
 
-	if headers.Get(httpx.HeaderXPrevPage) != "" {
-		t.Errorf("expected no X-Prev-Page header for single page, got '%s'", headers.Get(httpx.HeaderXPrevPage))
-	}
-	if headers.Get(httpx.HeaderXNextPage) != "" {
-		t.Errorf("expected no X-Next-Page header for single page, got '%s'", headers.Get(httpx.HeaderXNextPage))
-	}
+	zhtest.AssertEmpty(t, headers.Get(httpx.HeaderXPrevPage))
+	zhtest.AssertEmpty(t, headers.Get(httpx.HeaderXNextPage))
 }
 
 func TestBuildLinkHeader(t *testing.T) {
@@ -507,9 +450,7 @@ func TestBuildLinkHeader(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			u, _ := url.Parse(tt.url)
 			result := BuildLinkHeader(u, tt.page, tt.perPage, tt.totalPages)
-			if result != tt.expected {
-				t.Errorf("expected:\n%s\ngot:\n%s", tt.expected, result)
-			}
+			zhtest.AssertEqual(t, tt.expected, result)
 		})
 	}
 }
@@ -563,9 +504,7 @@ func TestCloneURLWithParams(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			u, _ := url.Parse(tt.url)
 			result := cloneURLWithParams(u, tt.page, tt.perPage)
-			if result != tt.expected {
-				t.Errorf("expected '%s', got '%s'", tt.expected, result)
-			}
+			zhtest.AssertEqual(t, tt.expected, result)
 		})
 	}
 }

--- a/pagination/pagination_test.go
+++ b/pagination/pagination_test.go
@@ -1,0 +1,571 @@
+package pagination
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/alexferl/zerohttp/httpx"
+)
+
+func TestRequest_Params(t *testing.T) {
+	tests := []struct {
+		name     string
+		request  Request
+		expected Params
+	}{
+		{
+			name:     "zero values",
+			request:  Request{},
+			expected: Params{Page: 0, PerPage: 0},
+		},
+		{
+			name:     "with page only",
+			request:  Request{Page: 5},
+			expected: Params{Page: 5, PerPage: 0},
+		},
+		{
+			name:     "with per_page only",
+			request:  Request{PerPage: 25},
+			expected: Params{Page: 0, PerPage: 25},
+		},
+		{
+			name:     "with both values",
+			request:  Request{Page: 3, PerPage: 50},
+			expected: Params{Page: 3, PerPage: 50},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.request.Params()
+			if result.Page != tt.expected.Page {
+				t.Errorf("expected Page %d, got %d", tt.expected.Page, result.Page)
+			}
+			if result.PerPage != tt.expected.PerPage {
+				t.Errorf("expected PerPage %d, got %d", tt.expected.PerPage, result.PerPage)
+			}
+		})
+	}
+}
+
+func TestParams_Defaults(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    Params
+		expected Params
+	}{
+		{
+			name:     "zero values get defaults",
+			input:    Params{},
+			expected: Params{Page: 1, PerPage: 20},
+		},
+		{
+			name:     "negative page gets default",
+			input:    Params{Page: -1, PerPage: 10},
+			expected: Params{Page: 1, PerPage: 10},
+		},
+		{
+			name:     "negative per_page gets default",
+			input:    Params{Page: 5, PerPage: -5},
+			expected: Params{Page: 5, PerPage: 20},
+		},
+		{
+			name:     "per_page over max gets capped",
+			input:    Params{Page: 1, PerPage: 200},
+			expected: Params{Page: 1, PerPage: 100},
+		},
+		{
+			name:     "per_page at max is allowed",
+			input:    Params{Page: 1, PerPage: 100},
+			expected: Params{Page: 1, PerPage: 100},
+		},
+		{
+			name:     "valid values unchanged",
+			input:    Params{Page: 3, PerPage: 25},
+			expected: Params{Page: 3, PerPage: 25},
+		},
+		{
+			name:     "page 1 is valid",
+			input:    Params{Page: 1, PerPage: 20},
+			expected: Params{Page: 1, PerPage: 20},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.input.Defaults()
+			if result.Page != tt.expected.Page {
+				t.Errorf("expected Page %d, got %d", tt.expected.Page, result.Page)
+			}
+			if result.PerPage != tt.expected.PerPage {
+				t.Errorf("expected PerPage %d, got %d", tt.expected.PerPage, result.PerPage)
+			}
+		})
+	}
+}
+
+func TestParams_Offset(t *testing.T) {
+	tests := []struct {
+		name     string
+		params   Params
+		expected int
+	}{
+		{
+			name:     "page 1 has offset 0",
+			params:   Params{Page: 1, PerPage: 20},
+			expected: 0,
+		},
+		{
+			name:     "page 2 with per_page 20 has offset 20",
+			params:   Params{Page: 2, PerPage: 20},
+			expected: 20,
+		},
+		{
+			name:     "page 3 with per_page 10 has offset 20",
+			params:   Params{Page: 3, PerPage: 10},
+			expected: 20,
+		},
+		{
+			name:     "page 5 with per_page 50 has offset 200",
+			params:   Params{Page: 5, PerPage: 50},
+			expected: 200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.params.Offset()
+			if result != tt.expected {
+				t.Errorf("expected offset %d, got %d", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestParams_LimitSkip(t *testing.T) {
+	params := Params{Page: 3, PerPage: 25}
+	limit, skip := params.LimitSkip()
+
+	if limit != 25 {
+		t.Errorf("expected limit 25, got %d", limit)
+	}
+	if skip != 50 {
+		t.Errorf("expected skip 50, got %d", skip)
+	}
+}
+
+func TestParams_TotalPages(t *testing.T) {
+	tests := []struct {
+		name     string
+		params   Params
+		total    int
+		expected int
+	}{
+		{
+			name:     "zero total returns 1",
+			params:   Params{PerPage: 20},
+			total:    0,
+			expected: 1,
+		},
+		{
+			name:     "total less than per_page returns 1",
+			params:   Params{PerPage: 20},
+			total:    15,
+			expected: 1,
+		},
+		{
+			name:     "total equal to per_page returns 1",
+			params:   Params{PerPage: 20},
+			total:    20,
+			expected: 1,
+		},
+		{
+			name:     "total slightly more than per_page returns 2",
+			params:   Params{PerPage: 20},
+			total:    21,
+			expected: 2,
+		},
+		{
+			name:     "exact multiple",
+			params:   Params{PerPage: 10},
+			total:    100,
+			expected: 10,
+		},
+		{
+			name:     "large total",
+			params:   Params{PerPage: 25},
+			total:    1000,
+			expected: 40,
+		},
+		{
+			name:     "single item",
+			params:   Params{PerPage: 20},
+			total:    1,
+			expected: 1,
+		},
+		{
+			name:     "negative total returns 1",
+			params:   Params{PerPage: 20},
+			total:    -5,
+			expected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.params.TotalPages(tt.total)
+			if result != tt.expected {
+				t.Errorf("expected %d pages, got %d", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestParams_Headers(t *testing.T) {
+	tests := []struct {
+		name     string
+		params   Params
+		total    int
+		expected ResponseHeaders
+	}{
+		{
+			name:   "first page of many",
+			params: Params{Page: 1, PerPage: 20},
+			total:  100,
+			expected: ResponseHeaders{
+				Total:      100,
+				TotalPages: 5,
+				Page:       1,
+				PerPage:    20,
+				HasPrev:    false,
+				HasNext:    true,
+				PrevPage:   0,
+				NextPage:   2,
+			},
+		},
+		{
+			name:   "middle page",
+			params: Params{Page: 3, PerPage: 20},
+			total:  100,
+			expected: ResponseHeaders{
+				Total:      100,
+				TotalPages: 5,
+				Page:       3,
+				PerPage:    20,
+				HasPrev:    true,
+				HasNext:    true,
+				PrevPage:   2,
+				NextPage:   4,
+			},
+		},
+		{
+			name:   "last page",
+			params: Params{Page: 5, PerPage: 20},
+			total:  100,
+			expected: ResponseHeaders{
+				Total:      100,
+				TotalPages: 5,
+				Page:       5,
+				PerPage:    20,
+				HasPrev:    true,
+				HasNext:    false,
+				PrevPage:   4,
+				NextPage:   0,
+			},
+		},
+		{
+			name:   "single page no navigation",
+			params: Params{Page: 1, PerPage: 20},
+			total:  15,
+			expected: ResponseHeaders{
+				Total:      15,
+				TotalPages: 1,
+				Page:       1,
+				PerPage:    20,
+				HasPrev:    false,
+				HasNext:    false,
+				PrevPage:   0,
+				NextPage:   0,
+			},
+		},
+		{
+			name:   "empty result",
+			params: Params{Page: 1, PerPage: 20},
+			total:  0,
+			expected: ResponseHeaders{
+				Total:      0,
+				TotalPages: 1,
+				Page:       1,
+				PerPage:    20,
+				HasPrev:    false,
+				HasNext:    false,
+				PrevPage:   0,
+				NextPage:   0,
+			},
+		},
+		{
+			name:   "page 2 of 2",
+			params: Params{Page: 2, PerPage: 10},
+			total:  15,
+			expected: ResponseHeaders{
+				Total:      15,
+				TotalPages: 2,
+				Page:       2,
+				PerPage:    10,
+				HasPrev:    true,
+				HasNext:    false,
+				PrevPage:   1,
+				NextPage:   0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.params.Headers(tt.total)
+
+			if result.Total != tt.expected.Total {
+				t.Errorf("expected Total %d, got %d", tt.expected.Total, result.Total)
+			}
+			if result.TotalPages != tt.expected.TotalPages {
+				t.Errorf("expected TotalPages %d, got %d", tt.expected.TotalPages, result.TotalPages)
+			}
+			if result.Page != tt.expected.Page {
+				t.Errorf("expected Page %d, got %d", tt.expected.Page, result.Page)
+			}
+			if result.PerPage != tt.expected.PerPage {
+				t.Errorf("expected PerPage %d, got %d", tt.expected.PerPage, result.PerPage)
+			}
+			if result.HasPrev != tt.expected.HasPrev {
+				t.Errorf("expected HasPrev %v, got %v", tt.expected.HasPrev, result.HasPrev)
+			}
+			if result.HasNext != tt.expected.HasNext {
+				t.Errorf("expected HasNext %v, got %v", tt.expected.HasNext, result.HasNext)
+			}
+			if result.PrevPage != tt.expected.PrevPage {
+				t.Errorf("expected PrevPage %d, got %d", tt.expected.PrevPage, result.PrevPage)
+			}
+			if result.NextPage != tt.expected.NextPage {
+				t.Errorf("expected NextPage %d, got %d", tt.expected.NextPage, result.NextPage)
+			}
+		})
+	}
+}
+
+func TestParams_WriteHeaders(t *testing.T) {
+	u, _ := url.Parse("http://example.com/api/items?page=2&per_page=20")
+	rec := httptest.NewRecorder()
+
+	params := Params{Page: 2, PerPage: 20}
+	params.WriteHeaders(rec, u, 50)
+
+	headers := rec.Header()
+
+	if headers.Get(httpx.HeaderXTotal) != "50" {
+		t.Errorf("expected X-Total header '50', got '%s'", headers.Get(httpx.HeaderXTotal))
+	}
+	if headers.Get(httpx.HeaderXTotalPages) != "3" {
+		t.Errorf("expected X-Total-Pages header '3', got '%s'", headers.Get(httpx.HeaderXTotalPages))
+	}
+	if headers.Get(httpx.HeaderXPage) != "2" {
+		t.Errorf("expected X-Page header '2', got '%s'", headers.Get(httpx.HeaderXPage))
+	}
+	if headers.Get(httpx.HeaderXPerPage) != "20" {
+		t.Errorf("expected X-Per-Page header '20', got '%s'", headers.Get(httpx.HeaderXPerPage))
+	}
+	if headers.Get(httpx.HeaderXPrevPage) != "1" {
+		t.Errorf("expected X-Prev-Page header '1', got '%s'", headers.Get(httpx.HeaderXPrevPage))
+	}
+	if headers.Get(httpx.HeaderXNextPage) != "3" {
+		t.Errorf("expected X-Next-Page header '3', got '%s'", headers.Get(httpx.HeaderXNextPage))
+	}
+	if headers.Get("Link") == "" {
+		t.Error("expected Link header to be set")
+	}
+}
+
+func TestParams_WriteHeaders_FirstPage(t *testing.T) {
+	u, _ := url.Parse("http://example.com/api/items?page=1&per_page=20")
+	rec := httptest.NewRecorder()
+
+	params := Params{Page: 1, PerPage: 20}
+	params.WriteHeaders(rec, u, 50)
+
+	headers := rec.Header()
+
+	if headers.Get(httpx.HeaderXPrevPage) != "" {
+		t.Errorf("expected no X-Prev-Page header on first page, got '%s'", headers.Get(httpx.HeaderXPrevPage))
+	}
+	if headers.Get(httpx.HeaderXNextPage) != "2" {
+		t.Errorf("expected X-Next-Page header '2', got '%s'", headers.Get(httpx.HeaderXNextPage))
+	}
+}
+
+func TestParams_WriteHeaders_LastPage(t *testing.T) {
+	u, _ := url.Parse("http://example.com/api/items?page=3&per_page=20")
+	rec := httptest.NewRecorder()
+
+	params := Params{Page: 3, PerPage: 20}
+	params.WriteHeaders(rec, u, 50)
+
+	headers := rec.Header()
+
+	if headers.Get(httpx.HeaderXPrevPage) != "2" {
+		t.Errorf("expected X-Prev-Page header '2', got '%s'", headers.Get(httpx.HeaderXPrevPage))
+	}
+	if headers.Get(httpx.HeaderXNextPage) != "" {
+		t.Errorf("expected no X-Next-Page header on last page, got '%s'", headers.Get(httpx.HeaderXNextPage))
+	}
+}
+
+func TestParams_WriteHeaders_SinglePage(t *testing.T) {
+	u, _ := url.Parse("http://example.com/api/items?page=1&per_page=20")
+	rec := httptest.NewRecorder()
+
+	params := Params{Page: 1, PerPage: 20}
+	params.WriteHeaders(rec, u, 10)
+
+	headers := rec.Header()
+
+	if headers.Get(httpx.HeaderXPrevPage) != "" {
+		t.Errorf("expected no X-Prev-Page header for single page, got '%s'", headers.Get(httpx.HeaderXPrevPage))
+	}
+	if headers.Get(httpx.HeaderXNextPage) != "" {
+		t.Errorf("expected no X-Next-Page header for single page, got '%s'", headers.Get(httpx.HeaderXNextPage))
+	}
+}
+
+func TestBuildLinkHeader(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		page       int
+		perPage    int
+		totalPages int
+		expected   string
+	}{
+		{
+			name:       "first page includes first, next, last",
+			url:        "http://example.com/api/items",
+			page:       1,
+			perPage:    20,
+			totalPages: 5,
+			expected:   `<http://example.com/api/items?page=1&per_page=20>; rel="first", <http://example.com/api/items?page=2&per_page=20>; rel="next", <http://example.com/api/items?page=5&per_page=20>; rel="last"`,
+		},
+		{
+			name:       "middle page includes all links",
+			url:        "http://example.com/api/items",
+			page:       3,
+			perPage:    20,
+			totalPages: 5,
+			expected:   `<http://example.com/api/items?page=1&per_page=20>; rel="first", <http://example.com/api/items?page=2&per_page=20>; rel="prev", <http://example.com/api/items?page=4&per_page=20>; rel="next", <http://example.com/api/items?page=5&per_page=20>; rel="last"`,
+		},
+		{
+			name:       "last page includes first, prev, last",
+			url:        "http://example.com/api/items",
+			page:       5,
+			perPage:    20,
+			totalPages: 5,
+			expected:   `<http://example.com/api/items?page=1&per_page=20>; rel="first", <http://example.com/api/items?page=4&per_page=20>; rel="prev", <http://example.com/api/items?page=5&per_page=20>; rel="last"`,
+		},
+		{
+			name:       "preserves existing query params",
+			url:        "http://example.com/api/items?search=test&category=books",
+			page:       2,
+			perPage:    10,
+			totalPages: 3,
+			expected:   `<http://example.com/api/items?category=books&page=1&per_page=10&search=test>; rel="first", <http://example.com/api/items?category=books&page=1&per_page=10&search=test>; rel="prev", <http://example.com/api/items?category=books&page=3&per_page=10&search=test>; rel="next", <http://example.com/api/items?category=books&page=3&per_page=10&search=test>; rel="last"`,
+		},
+		{
+			name:       "single page has no prev or next",
+			url:        "http://example.com/api/items",
+			page:       1,
+			perPage:    20,
+			totalPages: 1,
+			expected:   `<http://example.com/api/items?page=1&per_page=20>; rel="first", <http://example.com/api/items?page=1&per_page=20>; rel="last"`,
+		},
+		{
+			name:       "with path",
+			url:        "http://example.com/v2/resources",
+			page:       2,
+			perPage:    50,
+			totalPages: 10,
+			expected:   `<http://example.com/v2/resources?page=1&per_page=50>; rel="first", <http://example.com/v2/resources?page=1&per_page=50>; rel="prev", <http://example.com/v2/resources?page=3&per_page=50>; rel="next", <http://example.com/v2/resources?page=10&per_page=50>; rel="last"`,
+		},
+		{
+			name:       "zero total pages returns empty",
+			url:        "http://example.com/api/items",
+			page:       1,
+			perPage:    20,
+			totalPages: 0,
+			expected:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, _ := url.Parse(tt.url)
+			result := BuildLinkHeader(u, tt.page, tt.perPage, tt.totalPages)
+			if result != tt.expected {
+				t.Errorf("expected:\n%s\ngot:\n%s", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestCloneURLWithParams(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		page     int
+		perPage  int
+		expected string
+	}{
+		{
+			name:     "simple URL",
+			url:      "http://example.com/api/items",
+			page:     2,
+			perPage:  20,
+			expected: "http://example.com/api/items?page=2&per_page=20",
+		},
+		{
+			name:     "URL with existing params",
+			url:      "http://example.com/api/items?search=test",
+			page:     3,
+			perPage:  10,
+			expected: "http://example.com/api/items?page=3&per_page=10&search=test",
+		},
+		{
+			name:     "URL with pagination params to be replaced",
+			url:      "http://example.com/api/items?page=1&per_page=5&search=test",
+			page:     2,
+			perPage:  10,
+			expected: "http://example.com/api/items?page=2&per_page=10&search=test",
+		},
+		{
+			name:     "HTTPS URL",
+			url:      "https://api.example.com/v1/users",
+			page:     1,
+			perPage:  25,
+			expected: "https://api.example.com/v1/users?page=1&per_page=25",
+		},
+		{
+			name:     "URL with port",
+			url:      "http://localhost:8080/api/items",
+			page:     5,
+			perPage:  50,
+			expected: "http://localhost:8080/api/items?page=5&per_page=50",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, _ := url.Parse(tt.url)
+			result := cloneURLWithParams(u, tt.page, tt.perPage)
+			if result != tt.expected {
+				t.Errorf("expected '%s', got '%s'", tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add pagination package supporting:
- Offset-based pagination with page/per_page query params
- Standardized response headers (X-Total, X-Page, X-Per-Page, etc.)
- RFC 5988 Link header generation
- Example app and documentation