### PR TITLE
refactor: add MiddlewareFunc type and standardize config docs

### DIFF
--- a/config.go
+++ b/config.go
@@ -71,7 +71,7 @@ type Config struct {
 
 	// DefaultMiddlewares is a custom list of middlewares to use. If nil, uses the built-in default middleware list.
 	// Default: nil (means use built-in defaults)
-	DefaultMiddlewares []func(http.Handler) http.Handler
+	DefaultMiddlewares []MiddlewareFunc
 
 	// Recover holds the configuration for the panic recovery middleware.
 	Recover recover.Config

--- a/examples/README.md
+++ b/examples/README.md
@@ -54,6 +54,7 @@ Demonstrations of built-in and custom middleware.
 - [**`contenttype/`**](middleware/contenttype/) - Content type validation/middleware
 - [**`cors/`**](middleware/cors/) - CORS handling
 - [**`csrf/`**](middleware/csrf/) - CSRF protection
+- [**`custom/`**](middleware/custom/) - Writing custom middleware
 - [**`etag/`**](middleware/etag/) - ETag generation
 - [**`hmacauth/`**](middleware/hmacauth/) - HMAC request signing
 - [**`hostvalidation/`**](middleware/host/) - Host header validation

--- a/examples/middleware/custom/README.md
+++ b/examples/middleware/custom/README.md
@@ -1,0 +1,60 @@
+# Custom Middleware Example
+
+This example demonstrates how to write custom middleware for zerohttp.
+
+## Features
+
+- Basic middleware pattern
+- Factory function for configurable middleware
+- Global middleware application
+
+## Running the Example
+
+```bash
+go run .
+```
+
+The server starts on `http://localhost:8080`.
+
+## Endpoints
+
+| Endpoint           | Description                     |
+|--------------------|---------------------------------|
+| `GET /`            | Returns a simple message        |
+| `GET /hello/{name}` | Returns a personalized greeting |
+
+## Test Commands
+
+### Basic request
+```bash
+curl -i http://localhost:8080/
+```
+
+Shows response headers:
+```
+X-Custom-Version: 1.0
+```
+
+### Personalized greeting
+```bash
+curl http://localhost:8080/hello/world
+```
+
+Response:
+```json
+{
+  "message": "Hello world"
+}
+```
+
+## How It Works
+
+The example shows two middleware patterns:
+
+1. **Simple Middleware** (`requestTimer`): Logs request timing information
+2. **Factory Function** (`addHeader`): Creates middleware with custom configuration
+
+Both follow the standard Go middleware signature:
+```go
+func(http.Handler) http.Handler
+```

--- a/examples/middleware/custom/main.go
+++ b/examples/middleware/custom/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	zh "github.com/alexferl/zerohttp"
+)
+
+// requestTimer is a custom middleware that adds timing information to responses.
+// This demonstrates the basic pattern for writing your own middleware.
+func requestTimer(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		// Call the next handler
+		next.ServeHTTP(w, r)
+
+		// Log after the request is processed
+		duration := time.Since(start)
+		log.Printf("%s %s took %v", r.Method, r.URL.Path, duration)
+	})
+}
+
+// addHeader is a factory function that creates middleware to add a custom header.
+// This pattern allows configuration of middleware at creation time.
+func addHeader(key, value string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set(key, value)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func main() {
+	app := zh.New()
+
+	// Apply custom middleware globally
+	app.Use(requestTimer)
+	app.Use(addHeader("X-Custom-Version", "1.0"))
+
+	// Routes
+	app.GET("/", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return zh.R.JSON(w, http.StatusOK, map[string]string{
+			"message": "Hello from custom middleware",
+		})
+	}))
+
+	app.GET("/hello/{name}", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		name := zh.Param(r, "name")
+		return zh.R.JSON(w, http.StatusOK, map[string]string{
+			"message": "Hello " + name,
+		})
+	}))
+
+	log.Fatal(app.Start())
+}

--- a/middleware.go
+++ b/middleware.go
@@ -1,8 +1,6 @@
 package zerohttp
 
 import (
-	"net/http"
-
 	"github.com/alexferl/zerohttp/log"
 	"github.com/alexferl/zerohttp/middleware/recover"
 	"github.com/alexferl/zerohttp/middleware/requestbodysize"
@@ -18,12 +16,12 @@ import (
 //   - RequestBodySize: Limits the maximum request body size
 //   - SecurityHeaders: Adds security-related HTTP headers
 //   - RequestLogger: Logs HTTP requests and responses
-func DefaultMiddlewares(cfg Config, logger log.Logger) []func(http.Handler) http.Handler {
+func DefaultMiddlewares(cfg Config, logger log.Logger) []MiddlewareFunc {
 	// Sync RequestID header configuration with Recover config
 	recoverConfig := cfg.Recover
 	recoverConfig.RequestIDHeader = cfg.RequestID.Header
 
-	return []func(http.Handler) http.Handler{
+	return []MiddlewareFunc{
 		requestid.New(cfg.RequestID),
 		recover.New(logger, recoverConfig),
 		requestbodysize.New(cfg.RequestBodySize),

--- a/middleware/basicauth/config.go
+++ b/middleware/basicauth/config.go
@@ -2,7 +2,8 @@ package basicauth
 
 // Config allows customization of basic authentication
 type Config struct {
-	// Realm is the authentication realm (defaults to "Restricted")
+	// Realm is the authentication realm.
+	// Default: "Restricted"
 	Realm string
 
 	// Credentials is a map of username -> password

--- a/middleware/cache/config.go
+++ b/middleware/cache/config.go
@@ -99,7 +99,8 @@ type Config struct {
 	StatusCodes []int
 
 	// CacheStatusHeader adds a header to responses indicating cache hit/miss.
-	// Set to empty string to disable. Default: "X-Cache"
+	// Set to empty string to disable.
+	// Default: "X-Cache"
 	CacheStatusHeader *string
 }
 

--- a/middleware/circuitbreaker/config.go
+++ b/middleware/circuitbreaker/config.go
@@ -7,29 +7,37 @@ import (
 
 // Config allows customization of circuit breaker behavior
 type Config struct {
-	// FailureThreshold is the number of consecutive failures before opening the circuit
+	// FailureThreshold is the number of consecutive failures before opening the circuit.
+	// Default: 5
 	FailureThreshold int
 
-	// RecoveryTimeout is how long to wait before trying to close the circuit
+	// RecoveryTimeout is how long to wait before trying to close the circuit.
+	// Default: 30s
 	RecoveryTimeout time.Duration
 
-	// SuccessThreshold is the number of consecutive successes needed to close the circuit from half-open
+	// SuccessThreshold is the number of consecutive successes needed to close the circuit from half-open.
+	// Default: 3
 	SuccessThreshold int
 
 	// MaxHalfOpenRequests is the maximum number of concurrent requests allowed in half-open state.
-	// This prevents thundering herd when service recovers. Default is 1.
+	// This prevents thundering herd when service recovers.
+	// Default: 1
 	MaxHalfOpenRequests int
 
-	// IsFailure determines if a response should be considered a failure
+	// IsFailure determines if a response should be considered a failure.
+	// Default: 5xx status codes are considered failures
 	IsFailure func(*http.Request, int) bool
 
-	// KeyExtractor extracts the circuit breaker key from the request (for per-endpoint circuits)
+	// KeyExtractor extracts the circuit breaker key from the request (for per-endpoint circuits).
+	// Default: r.URL.Path (per-endpoint circuit breaker)
 	KeyExtractor func(*http.Request) string
 
-	// OpenStatusCode is the status code to return when circuit is open
+	// OpenStatusCode is the status code to return when circuit is open.
+	// Default: 503 (Service Unavailable)
 	OpenStatusCode int
 
-	// OpenMessage is the message to return when circuit is open
+	// OpenMessage is the message to return when circuit is open.
+	// Default: "Service temporarily unavailable"
 	OpenMessage string
 }
 

--- a/middleware/compress/config.go
+++ b/middleware/compress/config.go
@@ -77,13 +77,16 @@ type Provider interface {
 
 // Config allows customization of compression behavior
 type Config struct {
-	// Level is the compression level (1-9 for gzip/deflate)
+	// Level is the compression level (1-9 for gzip/deflate).
+	// Default: 6
 	Level int
 
-	// Types are MIME types to compress (defaults to common text types)
+	// Types are MIME types to compress.
+	// Default: common text types (HTML, CSS, JS, JSON, XML, SVG)
 	Types []string
 
-	// Algorithms are compression algorithms to support (defaults to gzip, deflate).
+	// Algorithms are compression algorithms to support.
+	// Default: [Gzip, Deflate]
 	// The order determines precedence when the client accepts multiple encodings -
 	// earlier algorithms are preferred over later ones.
 	Algorithms []Algorithm

--- a/middleware/contentcharset/config.go
+++ b/middleware/contentcharset/config.go
@@ -2,8 +2,9 @@ package contentcharset
 
 // Config allows customization of allowed charsets
 type Config struct {
-	// Charsets is a list of allowed character encodings
-	// An empty string allows requests with no charset specified
+	// Charsets is a list of allowed character encodings.
+	// An empty string allows requests with no charset specified.
+	// Default: ["utf-8", ""]
 	Charsets []string
 }
 

--- a/middleware/contentencoding/config.go
+++ b/middleware/contentencoding/config.go
@@ -4,7 +4,8 @@ import "github.com/alexferl/zerohttp/httpx"
 
 // Config allows customization of allowed content encodings
 type Config struct {
-	// Encodings is a list of allowed content encodings (gzip, deflate, br, etc.)
+	// Encodings is a list of allowed content encodings (gzip, deflate, br, etc.).
+	// Default: [gzip, deflate]
 	Encodings []string
 
 	// ExcludedPaths contains paths that skip content encoding validation.

--- a/middleware/contenttype/config.go
+++ b/middleware/contenttype/config.go
@@ -4,7 +4,8 @@ import "github.com/alexferl/zerohttp/httpx"
 
 // Config allows customization of allowed content types
 type Config struct {
-	// ContentTypes is a list of allowed content types
+	// ContentTypes is a list of allowed content types.
+	// Default: [application/json, application/x-www-form-urlencoded, multipart/form-data]
 	ContentTypes []string
 
 	// ExcludedPaths contains paths that skip content type validation.

--- a/middleware/cors/config.go
+++ b/middleware/cors/config.go
@@ -12,25 +12,32 @@ type OriginValidator func(origin string) bool
 
 // Config allows customization of CORS behavior
 type Config struct {
-	// AllowedOrigins is a list of allowed origins. Use ["*"] to allow all origins
+	// AllowedOrigins is a list of allowed origins. Use ["*"] to allow all origins.
+	// Default: ["*"]
 	AllowedOrigins []string
 
-	// AllowedMethods is a list of allowed HTTP methods (defaults to common methods)
+	// AllowedMethods is a list of allowed HTTP methods.
+	// Default: [GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS]
 	AllowedMethods []string
 
-	// AllowedHeaders is a list of allowed request headers (defaults to common headers)
+	// AllowedHeaders is a list of allowed request headers.
+	// Default: [Accept, Authorization, Content-Type, X-CSRF-Token, X-Request-Id]
 	AllowedHeaders []string
 
-	// ExposedHeaders is a list of headers exposed to the client
+	// ExposedHeaders is a list of headers exposed to the client.
+	// Default: []
 	ExposedHeaders []string
 
-	// AllowCredentials indicates whether credentials are allowed
+	// AllowCredentials indicates whether credentials are allowed.
+	// Default: false
 	AllowCredentials bool
 
-	// MaxAge indicates how long preflight requests can be cached (in seconds)
+	// MaxAge indicates how long preflight requests can be cached (in seconds).
+	// Default: 86400 (24 hours)
 	MaxAge int
 
-	// OptionsPassthrough allows OPTIONS requests to be passed to the next handler
+	// OptionsPassthrough allows OPTIONS requests to be passed to the next handler.
+	// Default: false
 	OptionsPassthrough bool
 
 	// ExcludedPaths contains paths that skip CORS processing.

--- a/middleware/etag/config.go
+++ b/middleware/etag/config.go
@@ -19,20 +19,25 @@ const (
 
 // Config allows customization of ETag middleware behavior
 type Config struct {
-	// Algorithm selects the hashing function (defaults to FNV)
+	// Algorithm selects the hashing function.
+	// Default: FNV
 	Algorithm Algorithm
 
-	// Weak determines if ETags should be prefixed with "W/" (defaults to true)
-	// Use a pointer to distinguish between "not set" and "explicitly set to false"
+	// Weak determines if ETags should be prefixed with "W/".
+	// Use a pointer to distinguish between "not set" and "explicitly set to false".
+	// Default: false
 	Weak *bool
 
-	// MaxBufferSize is the maximum response body size to buffer for ETag generation (defaults to 1MB)
+	// MaxBufferSize is the maximum response body size to buffer for ETag generation.
+	// Default: 1MB
 	MaxBufferSize int64
 
-	// SkipStatusCodes contains status codes that should not have ETags generated (defaults to error status codes)
+	// SkipStatusCodes contains status codes that should not have ETags generated.
+	// Default: error status codes (4xx, 5xx, redirects)
 	SkipStatusCodes map[int]struct{}
 
-	// SkipContentTypes contains content types that should not have ETags generated
+	// SkipContentTypes contains content types that should not have ETags generated.
+	// Default: [text/event-stream]
 	SkipContentTypes map[string]struct{}
 
 	// ExcludedPaths contains paths to skip ETag generation.

--- a/middleware/host/config.go
+++ b/middleware/host/config.go
@@ -2,30 +2,34 @@ package host
 
 // Config allows customization of Host header validation
 type Config struct {
-	// AllowedHosts is a list of allowed host values (e.g., "api.example.com", "example.com")
-	// If empty, all hosts are allowed (no validation)
+	// AllowedHosts is a list of allowed host values (e.g., "api.example.com", "example.com").
+	// If empty, all hosts are allowed (no validation).
+	// Default: []
 	AllowedHosts []string
 
-	// AllowSubdomains allows any subdomain of the hosts in AllowedHosts
+	// AllowSubdomains allows any subdomain of the hosts in AllowedHosts.
 	// For example, if "example.com" is in AllowedHosts and AllowSubdomains is true,
-	// then "api.example.com", "www.example.com", etc. are all valid
+	// then "api.example.com", "www.example.com", etc. are all valid.
+	// Default: false
 	AllowSubdomains bool
 
 	// StrictPort requires the Host header to include a port if the server is
-	// running on a non-standard port (i.e., not 80 or 443)
-	// Requires Port to be set to the server's port
+	// running on a non-standard port (i.e., not 80 or 443).
+	// Requires Port to be set to the server's port.
+	// Default: false
 	StrictPort bool
 
-	// Port is the port the server is listening on (e.g., 8080)
-	// Used with StrictPort to validate the Host header includes the port
+	// Port is the port the server is listening on (e.g., 8080).
+	// Used with StrictPort to validate the Host header includes the port.
+	// Default: 0
 	Port int
 
-	// StatusCode is the HTTP status code returned for invalid hosts
-	// Defaults to 400 (Bad Request)
+	// StatusCode is the HTTP status code returned for invalid hosts.
+	// Default: 400 (Bad Request)
 	StatusCode int
 
-	// Message is the error message returned for invalid hosts
-	// Defaults to "Invalid Host header"
+	// Message is the error message returned for invalid hosts.
+	// Default: "Invalid Host header"
 	Message string
 
 	// ExcludedPaths contains paths to skip host validation.

--- a/middleware/idempotency/config.go
+++ b/middleware/idempotency/config.go
@@ -87,7 +87,8 @@ type Config struct {
 	IncludedPaths []string
 
 	// MaxKeys limits the number of unique keys stored in the default
-	// in-memory store. Defaults to 10000. Set to 0 for unlimited (not recommended).
+	// in-memory store. Set to 0 for unlimited (not recommended).
+	// Default: 10000
 	MaxKeys int
 
 	// LockRetryInterval is the initial interval between retries when waiting for
@@ -97,11 +98,13 @@ type Config struct {
 
 	// LockMaxRetries is the maximum number of retries when waiting for an
 	// in-flight request to complete. After this is exhausted, a 409 Conflict
-	// is returned. Default: 300 (3 seconds at 10ms intervals)
+	// is returned.
+	// Default: 300 (3 seconds at 10ms intervals)
 	LockMaxRetries int
 
 	// LockMaxInterval is the maximum interval between retries (caps exponential
-	// backoff). Default: 500ms
+	// backoff).
+	// Default: 500ms
 	LockMaxInterval time.Duration
 
 	// LockBackoffMultiplier is the multiplier for exponential backoff.

--- a/middleware/nocache/config.go
+++ b/middleware/nocache/config.go
@@ -27,8 +27,13 @@ var DefaultETagHeaders = []string{
 
 // Config allows customization of the set/deleted headers
 type Config struct {
-	Headers     map[string]string // Headers to set for no-cache; defaults provided
-	ETagHeaders []string          // Headers to delete; defaults provided
+	// Headers to set for no-cache.
+	// Default: no-cache headers (Expires, Cache-Control, Pragma, X-Accel-Expires)
+	Headers map[string]string
+
+	// ETagHeaders are headers to delete.
+	// Default: ETag-related headers
+	ETagHeaders []string
 }
 
 // DefaultConfig contains the default values for no-cache configuration.

--- a/middleware/ratelimit/config.go
+++ b/middleware/ratelimit/config.go
@@ -34,25 +34,32 @@ type KeyExtractor func(*http.Request) string
 
 // Config allows customization of rate limiting behavior
 type Config struct {
-	// Rate is requests per window (defaults to 100)
+	// Rate is requests per window.
+	// Default: 100
 	Rate int
 
-	// Window is the time window duration (defaults to 1 minute)
+	// Window is the time window duration.
+	// Default: 1 minute
 	Window time.Duration
 
-	// Algorithm to use (defaults to TokenBucket)
+	// Algorithm to use.
+	// Default: TokenBucket
 	Algorithm Algorithm
 
-	// KeyExtractor function to get rate limit key (defaults to IP-based)
+	// KeyExtractor function to get rate limit key.
+	// Default: IP-based
 	KeyExtractor KeyExtractor
 
-	// StatusCode to return when rate limited (defaults to 429)
+	// StatusCode to return when rate limited.
+	// Default: 429
 	StatusCode int
 
-	// Message to return when rate limited
+	// Message to return when rate limited.
+	// Default: "Rate limit exceeded"
 	Message string
 
-	// Headers to include in response
+	// Headers to include in response.
+	// Default: true
 	IncludeHeaders bool
 
 	// ExcludedPaths contains paths to skip rate limiting.
@@ -74,7 +81,8 @@ type Config struct {
 	Store Store
 
 	// MaxKeys limits the number of unique keys stored in the default
-	// in-memory store. Defaults to 10000. Set to 0 for unlimited (not recommended).
+	// in-memory store. Set to 0 for unlimited (not recommended).
+	// Default: 10000
 	MaxKeys int
 }
 

--- a/middleware/ratelimit/store.go
+++ b/middleware/ratelimit/store.go
@@ -65,7 +65,7 @@ func NewMemoryStore(algorithm Algorithm, window time.Duration, rate, maxKeys int
 }
 
 // CheckAndRecord implements Store.
-func (s *MemoryStore) CheckAndRecord(ctx context.Context, key string, now time.Time) (bool, int, time.Time) {
+func (s *MemoryStore) CheckAndRecord(_ context.Context, key string, now time.Time) (bool, int, time.Time) {
 	switch s.algorithm {
 	case TokenBucket:
 		return s.checkTokenBucket(key, now)

--- a/middleware/realip/config.go
+++ b/middleware/realip/config.go
@@ -13,7 +13,8 @@ type IPExtractor func(*http.Request) string
 
 // Config allows customization of real IP extraction
 type Config struct {
-	// IPExtractor function to extract real client IP (defaults to DefaultIPExtractor)
+	// IPExtractor function to extract real client IP.
+	// Default: DefaultIPExtractor
 	IPExtractor IPExtractor
 }
 

--- a/middleware/recover/config.go
+++ b/middleware/recover/config.go
@@ -2,14 +2,17 @@ package recover
 
 // Config allows customization of panic recovery
 type Config struct {
-	// StackSize is the maximum size of the stack trace in bytes (defaults to 4KB)
+	// StackSize is the maximum size of the stack trace in bytes.
+	// Default: 4KB
 	StackSize int64
 
-	// EnableStackTrace determines if stack traces should be included (defaults to true)
+	// EnableStackTrace determines if stack traces should be included.
+	// Default: true
 	EnableStackTrace bool
 
-	// RequestIDHeader is the header name for the request ID (defaults to "X-Request-Id")
-	// This should match the header configured in RequestIDConfig
+	// RequestIDHeader is the header name for the request ID.
+	// This should match the header configured in RequestIDConfig.
+	// Default: "X-Request-Id"
 	RequestIDHeader string
 }
 

--- a/middleware/requestbodysize/config.go
+++ b/middleware/requestbodysize/config.go
@@ -3,6 +3,7 @@ package requestbodysize
 // Config allows customization of request size limiting.
 type Config struct {
 	// MaxBytes is the maximum request body size in bytes.
+	// Default: 1MB
 	MaxBytes int64
 
 	// ExcludedPaths contains paths that skip body size limiting.

--- a/middleware/requestid/config.go
+++ b/middleware/requestid/config.go
@@ -13,15 +13,17 @@ var ContextKey = contextKey{}
 
 // Config allows customization of request ID generation.
 type Config struct {
-	// Header is the header name for the request ID (defaults to "X-Request-Id").
+	// Header is the header name for the request ID.
+	// Default: "X-Request-Id"
 	Header string
 
 	// Generator is a custom function to generate request IDs.
 	// The default generator uses crypto/rand (CSPRNG) for 128 bits of entropy.
+	// Default: GenerateRequestID
 	Generator func() string
 
 	// ContextKey is the key to store the request ID in context.
-	// Defaults to the package-provided ContextKey.
+	// Default: package-provided ContextKey
 	ContextKey any
 }
 

--- a/middleware/requestlogger/config.go
+++ b/middleware/requestlogger/config.go
@@ -36,10 +36,12 @@ type Config struct {
 	// Default: true
 	Enabled *bool
 
-	// LogErrors determines if errors should be logged (defaults to true).
+	// LogErrors determines if errors should be logged.
+	// Default: true
 	LogErrors bool
 
-	// Fields to include in logs (defaults to all fields).
+	// Fields to include in logs.
+	// Default: all fields
 	Fields []LogField
 
 	// ExcludedPaths contains paths to skip logging (e.g., health checks).
@@ -55,22 +57,25 @@ type Config struct {
 	// Default: []
 	IncludedPaths []string
 
-	// LogRequestBody enables logging of request bodies (defaults to false).
+	// LogRequestBody enables logging of request bodies.
 	// This is opt-in due to performance and security considerations.
+	// Default: false
 	LogRequestBody bool
 
-	// LogResponseBody enables logging of response bodies (defaults to false).
+	// LogResponseBody enables logging of response bodies.
 	// This is opt-in due to performance and security considerations.
+	// Default: false
 	LogResponseBody bool
 
 	// MaxBodySize is the maximum number of bytes to log for request/response bodies.
-	// If 0, body logging is disabled (default for safety).
+	// If 0, body logging is disabled.
 	// Must be a positive value to enable body logging.
+	// Default: 1024 (1KB)
 	MaxBodySize int
 
 	// SensitiveFields contains field names (case-insensitive) whose values should be
 	// masked in request/response body logs (e.g., "password", "token", "secret").
-	// Defaults to common sensitive field names if nil.
+	// Default: common sensitive field names
 	SensitiveFields []string
 
 	// CustomFields allows adding arbitrary fields to request logs.

--- a/middleware/reverseproxy/config.go
+++ b/middleware/reverseproxy/config.go
@@ -22,10 +22,12 @@ type Backend struct {
 	// Target is the upstream URL (e.g., "http://localhost:8081")
 	Target string
 
-	// Weight is used for weighted load balancing (defaults to 1)
+	// Weight is used for weighted load balancing.
+	// Default: 1
 	Weight int
 
-	// Healthy indicates if the backend is currently healthy
+	// Healthy indicates if the backend is currently healthy.
+	// Default: true
 	Healthy bool
 }
 
@@ -41,71 +43,89 @@ type RewriteRule struct {
 
 // Config allows customization of reverse proxy behavior
 type Config struct {
-	// Target is a single upstream URL (use this OR Targets, not both)
+	// Target is a single upstream URL (use this OR Targets, not both).
 	// Example: "http://localhost:8081"
+	// Default: ""
 	Target string
 
-	// Targets is a list of backends for load balancing (use this OR Target, not both)
+	// Targets is a list of backends for load balancing (use this OR Target, not both).
+	// Default: []
 	Targets []Backend
 
-	// LoadBalancer specifies the algorithm for multiple targets (defaults to RoundRobin)
+	// LoadBalancer specifies the algorithm for multiple targets.
+	// Default: RoundRobin
 	LoadBalancer LoadBalancerAlgorithm
 
-	// HealthCheckInterval is how often to check backend health (0 = disabled)
+	// HealthCheckInterval is how often to check backend health (0 = disabled).
+	// Default: 0 (disabled)
 	HealthCheckInterval time.Duration
 
-	// HealthCheckTimeout is the timeout for health check requests
+	// HealthCheckTimeout is the timeout for health check requests.
+	// Default: 0 (uses http.DefaultTransport timeout)
 	HealthCheckTimeout time.Duration
 
-	// HealthCheckPath is the path to use for health checks (defaults to "/")
+	// HealthCheckPath is the path to use for health checks.
+	// Default: "/"
 	HealthCheckPath string
 
-	// StripPrefix removes this prefix from the request path before proxying
-	// Example: "/api/v1" -> request to "/api/v1/users" becomes "/users"
+	// StripPrefix removes this prefix from the request path before proxying.
+	// Example: "/api/v1" -> request to "/api/v1/users" becomes "/users".
+	// Default: "" (no stripping)
 	StripPrefix string
 
-	// AddPrefix adds this prefix to the request path after stripping
-	// Example: "/v2" -> request to "/users" becomes "/v2/users"
+	// AddPrefix adds this prefix to the request path after stripping.
+	// Example: "/v2" -> request to "/users" becomes "/v2/users".
+	// Default: "" (no prefix added)
 	AddPrefix string
 
-	// Rewrites is a list of path rewrite rules
-	// Example: [{Pattern: "/old/*", Replacement: "/new/$1"}]
+	// Rewrites is a list of path rewrite rules.
+	// Example: [{Pattern: "/old/*", Replacement: "/new/$1"}].
+	// Default: []
 	Rewrites []RewriteRule
 
-	// SetHeaders are headers to add/set on the outgoing request
+	// SetHeaders are headers to add/set on the outgoing request.
+	// Default: {}
 	SetHeaders map[string]string
 
-	// RemoveHeaders are header names to remove from the outgoing request
+	// RemoveHeaders are header names to remove from the outgoing request.
+	// Default: []
 	RemoveHeaders []string
 
-	// ForwardHeaders automatically adds X-Forwarded-* headers
+	// ForwardHeaders automatically adds X-Forwarded-* headers.
 	// X-Forwarded-For: Client IP
 	// X-Forwarded-Proto: Original protocol (http/https)
-	// X-Forwarded-Host: Original host header
+	// X-Forwarded-Host: Original host header.
+	// Default: true
 	ForwardHeaders bool
 
-	// ErrorHandler is called when the proxy encounters an error
-	// If nil, a default error handler is used
+	// ErrorHandler is called when the proxy encounters an error.
+	// If nil, a default error handler is used.
+	// Default: nil (uses default error handler)
 	ErrorHandler func(http.ResponseWriter, *http.Request, error)
 
-	// FallbackHandler is called when all backends are unavailable
-	// If nil, the ErrorHandler is used with a "Service Unavailable" error
+	// FallbackHandler is called when all backends are unavailable.
+	// If nil, the ErrorHandler is used with a "Service Unavailable" error.
+	// Default: nil
 	FallbackHandler http.Handler
 
-	// Transport allows customizing the HTTP transport
-	// If nil, http.DefaultTransport is used
+	// Transport allows customizing the HTTP transport.
+	// If nil, http.DefaultTransport is used.
+	// Default: nil (uses http.DefaultTransport)
 	Transport http.RoundTripper
 
-	// FlushInterval specifies the flush interval for streaming responses
-	// If 0, the default is used (no periodic flushing)
+	// FlushInterval specifies the flush interval for streaming responses.
+	// If 0, no periodic flushing.
+	// Default: 0
 	FlushInterval time.Duration
 
-	// ModifyRequest allows customizing the outgoing request
-	// Called after all other modifications (strip/add prefix, headers, etc.)
+	// ModifyRequest allows customizing the outgoing request.
+	// Called after all other modifications (strip/add prefix, headers, etc.).
+	// Default: nil
 	ModifyRequest func(*http.Request)
 
-	// ModifyResponse allows customizing the response before it's written
-	// Return an error to trigger the error handler
+	// ModifyResponse allows customizing the response before it's written.
+	// Return an error to trigger the error handler.
+	// Default: nil
 	ModifyResponse func(*http.Response) error
 
 	// ExcludedPaths contains paths that skip reverse proxying.

--- a/middleware/securityheaders/config.go
+++ b/middleware/securityheaders/config.go
@@ -31,12 +31,15 @@ var permissionPolicyFeatures = []string{
 type StrictTransportSecurity struct {
 	// MaxAge sets the time, in seconds, that the browser should remember that a site is only to be accessed using HTTPS.
 	// A value of 0 disables HSTS.
+	// Default: 0 (disabled)
 	MaxAge int
 
 	// ExcludeSubdomains specifies whether the HSTS policy applies to all subdomains.
+	// Default: false
 	ExcludeSubdomains bool
 
 	// PreloadEnabled adds the preload directive to the header.
+	// Default: false
 	PreloadEnabled bool
 }
 
@@ -61,44 +64,57 @@ const (
 // Config allows customization of security headers
 type Config struct {
 	// ContentSecurityPolicy sets the `Content-Security-Policy` header.
-	// Use "{{nonce}}" placeholder to enable nonce generation (e.g., script-src 'nonce-{{nonce}}')
+	// Use "{{nonce}}" placeholder to enable nonce generation (e.g., script-src 'nonce-{{nonce}}').
+	// Default: "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; frame-ancestors 'self'; form-action 'self';"
 	ContentSecurityPolicy string
 
-	// ContentSecurityPolicyReportOnly sets the policy in report-only mode
+	// ContentSecurityPolicyReportOnly sets the policy in report-only mode.
+	// Default: false
 	ContentSecurityPolicyReportOnly bool
 
 	// ContentSecurityPolicyNonceEnabled generates a unique nonce per request when true.
 	// The nonce replaces "{{nonce}}" in the CSP header and is stored in context.
+	// Default: false
 	ContentSecurityPolicyNonceEnabled bool
 
-	// ContentSecurityPolicyNonceContextKey overrides the default context key for storing the nonce
+	// ContentSecurityPolicyNonceContextKey overrides the default context key for storing the nonce.
+	// Default: CSPNonceContextKey
 	ContentSecurityPolicyNonceContextKey any
 
-	// CrossOriginEmbedderPolicy sets the `Cross-Origin-Embedder-Policy` header
+	// CrossOriginEmbedderPolicy sets the `Cross-Origin-Embedder-Policy` header.
+	// Default: "require-corp"
 	CrossOriginEmbedderPolicy string
 
-	// CrossOriginOpenerPolicy sets the `Cross-Origin-Opener-Policy` header
+	// CrossOriginOpenerPolicy sets the `Cross-Origin-Opener-Policy` header.
+	// Default: "same-origin"
 	CrossOriginOpenerPolicy string
 
-	// CrossOriginResourcePolicy sets the `Cross-Origin-Resource-Policy` header
+	// CrossOriginResourcePolicy sets the `Cross-Origin-Resource-Policy` header.
+	// Default: "same-origin"
 	CrossOriginResourcePolicy string
 
-	// PermissionsPolicy sets the `Permissions-Policy` header
+	// PermissionsPolicy sets the `Permissions-Policy` header.
+	// Default: permission policy features (accelerometer, camera, geolocation, etc.)
 	PermissionsPolicy string
 
-	// ReferrerPolicy sets the `Referrer-Policy` header
+	// ReferrerPolicy sets the `Referrer-Policy` header.
+	// Default: "no-referrer"
 	ReferrerPolicy string
 
-	// Server sets the `Server` header (empty string to hide server info)
+	// Server sets the `Server` header. Use empty string to hide server info.
+	// Default: "" (hidden)
 	Server string
 
-	// StrictTransportSecurity configures HSTS header
+	// StrictTransportSecurity configures HSTS header.
+	// Default: MaxAge=0 (disabled), ExcludeSubdomains=false, PreloadEnabled=false
 	StrictTransportSecurity StrictTransportSecurity
 
-	// XContentTypeOptions sets the `X-Content-Type-Options` header
+	// XContentTypeOptions sets the `X-Content-Type-Options` header.
+	// Default: "nosniff"
 	XContentTypeOptions string
 
-	// XFrameOptions sets the `X-Frame-Options` header
+	// XFrameOptions sets the `X-Frame-Options` header.
+	// Default: "DENY"
 	XFrameOptions string
 
 	// ExcludedPaths contains paths to skip security headers.

--- a/middleware/setheader/config.go
+++ b/middleware/setheader/config.go
@@ -2,7 +2,8 @@ package setheader
 
 // Config allows customization of response headers
 type Config struct {
-	// Headers is a map of header key-value pairs to set
+	// Headers is a map of header key-value pairs to set.
+	// Default: {} (empty map)
 	Headers map[string]string
 }
 

--- a/middleware/timeout/config.go
+++ b/middleware/timeout/config.go
@@ -7,13 +7,16 @@ import (
 
 // Config allows customization of request timeout behavior
 type Config struct {
-	// Duration for the request (defaults to 30 seconds)
+	// Duration for the request.
+	// Default: 30 seconds
 	Duration time.Duration
 
-	// StatusCode to return on timeout (defaults to 504 Gateway Duration)
+	// StatusCode to return on timeout.
+	// Default: 504 (Gateway Timeout)
 	StatusCode int
 
-	// Message to write on timeout (optional)
+	// Message to write on timeout.
+	// Default: "" (empty)
 	Message string
 
 	// ExcludedPaths contains paths that skip timeout enforcement.

--- a/middleware/trailingslash/config.go
+++ b/middleware/trailingslash/config.go
@@ -16,13 +16,16 @@ const (
 
 // Config allows customization of trailing slash handling
 type Config struct {
-	// Action to take when trailing slash doesn't match preference (defaults to redirect)
+	// Action to take when trailing slash doesn't match preference.
+	// Default: RedirectAction
 	Action Action
 
-	// PreferTrailingSlash determines if URLs should have trailing slashes (defaults to false)
+	// PreferTrailingSlash determines if URLs should have trailing slashes.
+	// Default: false
 	PreferTrailingSlash bool
 
-	// RedirectCode for redirects (defaults to 301 Moved Permanently)
+	// RedirectCode for redirects.
+	// Default: 301 (Moved Permanently)
 	RedirectCode int
 }
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -63,7 +63,7 @@ func TestDefaultMiddlewares_NilInputs(t *testing.T) {
 	t.Run("nil logger", func(t *testing.T) {
 		cfg := Config{}
 
-		var middlewares []func(http.Handler) http.Handler
+		var middlewares []MiddlewareFunc
 		zhtest.AssertNoPanic(t, func() {
 			middlewares = DefaultMiddlewares(cfg, nil)
 		})

--- a/router.go
+++ b/router.go
@@ -68,7 +68,10 @@ func init() {
 //	    }
 //	    return zh.Render.JSON(w, http.StatusOK, user)
 //	}))
-type HandlerFunc func(w http.ResponseWriter, r *http.Request) error
+type (
+	HandlerFunc    func(w http.ResponseWriter, r *http.Request) error
+	MiddlewareFunc func(http.Handler) http.Handler
+)
 
 // ServeHTTP implements http.Handler interface.
 // It handles all errors directly; no panic propagation is used.
@@ -209,40 +212,40 @@ func (h *headResponseWriter) Unwrap() http.ResponseWriter {
 type Router interface {
 	// DELETE registers a handler for HTTP DELETE requests to the specified path.
 	// Additional middleware can be provided that will be applied only to this route.
-	DELETE(path string, h http.Handler, mw ...func(http.Handler) http.Handler)
+	DELETE(path string, h http.Handler, mw ...MiddlewareFunc)
 
 	// GET registers a handler for HTTP GET requests to the specified path.
 	// Additional middleware can be provided that will be applied only to this route.
-	GET(path string, h http.Handler, mw ...func(http.Handler) http.Handler)
+	GET(path string, h http.Handler, mw ...MiddlewareFunc)
 
 	// HEAD registers a handler for HTTP HEAD requests to the specified path.
 	// Additional middleware can be provided that will be applied only to this route.
-	HEAD(path string, h http.Handler, mw ...func(http.Handler) http.Handler)
+	HEAD(path string, h http.Handler, mw ...MiddlewareFunc)
 
 	// OPTIONS registers a handler for HTTP OPTIONS requests to the specified path.
 	// Additional middleware can be provided that will be applied only to this route.
-	OPTIONS(path string, h http.Handler, mw ...func(http.Handler) http.Handler)
+	OPTIONS(path string, h http.Handler, mw ...MiddlewareFunc)
 
 	// PATCH registers a handler for HTTP PATCH requests to the specified path.
 	// Additional middleware can be provided that will be applied only to this route.
-	PATCH(path string, h http.Handler, mw ...func(http.Handler) http.Handler)
+	PATCH(path string, h http.Handler, mw ...MiddlewareFunc)
 
 	// POST registers a handler for HTTP POST requests to the specified path.
 	// Additional middleware can be provided that will be applied only to this route.
-	POST(path string, h http.Handler, mw ...func(http.Handler) http.Handler)
+	POST(path string, h http.Handler, mw ...MiddlewareFunc)
 
 	// PUT registers a handler for HTTP PUT requests to the specified path.
 	// Additional middleware can be provided that will be applied only to this route.
-	PUT(path string, h http.Handler, mw ...func(http.Handler) http.Handler)
+	PUT(path string, h http.Handler, mw ...MiddlewareFunc)
 
 	// CONNECT registers a handler for HTTP CONNECT requests to the specified path.
 	// Additional middleware can be provided that will be applied only to this route.
 	// CONNECT is typically used for WebSocket and WebTransport upgrades.
-	CONNECT(path string, h http.Handler, mw ...func(http.Handler) http.Handler)
+	CONNECT(path string, h http.Handler, mw ...MiddlewareFunc)
 
 	// Use adds middleware to the router's global middleware chain.
 	// Middleware is applied to all routes registered after this call.
-	Use(mw ...func(http.Handler) http.Handler)
+	Use(mw ...MiddlewareFunc)
 
 	// Group creates a new router scope that inherits the current middleware chain.
 	// This allows for organizing routes and applying middleware to specific groups.
@@ -316,7 +319,7 @@ type defaultRouter struct {
 	mux *http.ServeMux
 
 	// chain contains the middleware functions that will be applied to all routes
-	chain []func(http.Handler) http.Handler
+	chain []MiddlewareFunc
 
 	// handlerMu protects notFoundHandler and methodNotAllowedHandler.
 	// These handlers can be changed at runtime via NotFound() and MethodNotAllowed().
@@ -355,7 +358,7 @@ type defaultRouter struct {
 // Example:
 //
 //	router := NewRouter(loggingMiddleware, authMiddleware)
-func NewRouter(mw ...func(http.Handler) http.Handler) Router {
+func NewRouter(mw ...MiddlewareFunc) Router {
 	cfg := DefaultConfig
 	logger := log.NewDefaultLogger()
 
@@ -382,7 +385,7 @@ func NewRouter(mw ...func(http.Handler) http.Handler) Router {
 // Example:
 //
 //	router.Use(loggingMiddleware, corsMiddleware)
-func (r *defaultRouter) Use(mw ...func(http.Handler) http.Handler) {
+func (r *defaultRouter) Use(mw ...MiddlewareFunc) {
 	r.chain = append(r.chain, mw...)
 }
 
@@ -418,50 +421,50 @@ func (r *defaultRouter) Group(fn func(Router)) {
 
 // DELETE registers a handler for HTTP DELETE requests to the specified path.
 // Additional route-specific middleware can be provided.
-func (r *defaultRouter) DELETE(path string, h http.Handler, mw ...func(http.Handler) http.Handler) {
+func (r *defaultRouter) DELETE(path string, h http.Handler, mw ...MiddlewareFunc) {
 	r.handle(http.MethodDelete, path, h, mw)
 }
 
 // GET registers a handler for HTTP GET requests to the specified path.
 // Additional route-specific middleware can be provided.
-func (r *defaultRouter) GET(path string, h http.Handler, mw ...func(http.Handler) http.Handler) {
+func (r *defaultRouter) GET(path string, h http.Handler, mw ...MiddlewareFunc) {
 	r.handle(http.MethodGet, path, h, mw)
 }
 
 // HEAD registers a handler for HTTP HEAD requests to the specified path.
 // Additional route-specific middleware can be provided.
-func (r *defaultRouter) HEAD(path string, h http.Handler, mw ...func(http.Handler) http.Handler) {
+func (r *defaultRouter) HEAD(path string, h http.Handler, mw ...MiddlewareFunc) {
 	r.handle(http.MethodHead, path, h, mw)
 }
 
 // OPTIONS registers a handler for HTTP OPTIONS requests to the specified path.
 // Additional route-specific middleware can be provided.
-func (r *defaultRouter) OPTIONS(path string, h http.Handler, mw ...func(http.Handler) http.Handler) {
+func (r *defaultRouter) OPTIONS(path string, h http.Handler, mw ...MiddlewareFunc) {
 	r.handle(http.MethodOptions, path, h, mw)
 }
 
 // PATCH registers a handler for HTTP PATCH requests to the specified path.
 // Additional route-specific middleware can be provided.
-func (r *defaultRouter) PATCH(path string, h http.Handler, mw ...func(http.Handler) http.Handler) {
+func (r *defaultRouter) PATCH(path string, h http.Handler, mw ...MiddlewareFunc) {
 	r.handle(http.MethodPatch, path, h, mw)
 }
 
 // POST registers a handler for HTTP POST requests to the specified path.
 // Additional route-specific middleware can be provided.
-func (r *defaultRouter) POST(path string, h http.Handler, mw ...func(http.Handler) http.Handler) {
+func (r *defaultRouter) POST(path string, h http.Handler, mw ...MiddlewareFunc) {
 	r.handle(http.MethodPost, path, h, mw)
 }
 
 // PUT registers a handler for HTTP PUT requests to the specified path.
 // Additional route-specific middleware can be provided.
-func (r *defaultRouter) PUT(path string, h http.Handler, mw ...func(http.Handler) http.Handler) {
+func (r *defaultRouter) PUT(path string, h http.Handler, mw ...MiddlewareFunc) {
 	r.handle(http.MethodPut, path, h, mw)
 }
 
 // CONNECT registers a handler for HTTP CONNECT requests to the specified path.
 // Additional route-specific middleware can be provided.
 // CONNECT is typically used for WebSocket and WebTransport upgrades.
-func (r *defaultRouter) CONNECT(path string, h http.Handler, mw ...func(http.Handler) http.Handler) {
+func (r *defaultRouter) CONNECT(path string, h http.Handler, mw ...MiddlewareFunc) {
 	r.handle(http.MethodConnect, path, h, mw)
 }
 
@@ -709,7 +712,7 @@ func (r *defaultRouter) SetConfig(cfg Config) {
 // It combines the router's global middleware chain with route-specific middleware.
 // Middleware is applied in reverse order so that the first middleware added
 // is the outermost (executed first).
-func (r *defaultRouter) wrap(fn http.Handler, mw []func(http.Handler) http.Handler) (out http.Handler) {
+func (r *defaultRouter) wrap(fn http.Handler, mw []MiddlewareFunc) (out http.Handler) {
 	out = fn
 
 	// Combine global and route-specific middleware
@@ -727,7 +730,7 @@ func (r *defaultRouter) wrap(fn http.Handler, mw []func(http.Handler) http.Handl
 
 // handle is the internal method that registers a handler for a specific HTTP method and path.
 // It tracks registered routes for proper 404/405 handling and registers the handler with ServeMux.
-func (r *defaultRouter) handle(method, path string, fn http.Handler, mw []func(http.Handler) http.Handler) {
+func (r *defaultRouter) handle(method, path string, fn http.Handler, mw []MiddlewareFunc) {
 	// Track the route and method for 404/405 determination
 	r.routesMu.Lock()
 	if r.registeredRoutes[path] == nil {

--- a/router_bench_test.go
+++ b/router_bench_test.go
@@ -277,7 +277,7 @@ func BenchmarkRouter_MiddlewareOverhead(b *testing.B) {
 	})
 
 	b.Run("Zerohttp_5Middleware", func(b *testing.B) {
-		middlewares := make([]func(http.Handler) http.Handler, 5)
+		middlewares := make([]MiddlewareFunc, 5)
 		for i := range 5 {
 			middlewares[i] = simpleMiddleware
 		}

--- a/server.go
+++ b/server.go
@@ -920,7 +920,7 @@ func createMetricsServer(c Config, registry metrics.Registry, logger log.Logger)
 
 // setupMiddleware configures the middleware chain on the server.
 func setupMiddleware(s *Server, c Config, registry metrics.Registry) {
-	var middlewares []func(http.Handler) http.Handler
+	var middlewares []MiddlewareFunc
 
 	// Add metrics middleware first so it will be innermost after reverse,
 	// running inside Recover and able to capture status codes written by other middleware

--- a/server_test.go
+++ b/server_test.go
@@ -135,14 +135,14 @@ func TestNew_MiddlewareScenarios(t *testing.T) {
 
 	server := New(Config{
 		DisableDefaultMiddlewares: true,
-		DefaultMiddlewares:        []func(http.Handler) http.Handler{customMiddleware},
+		DefaultMiddlewares:        []MiddlewareFunc{customMiddleware},
 	})
 
 	zhtest.AssertNotNil(t, server)
 
 	// Test with custom default middlewares combined with defaults
 	server2 := New(Config{
-		DefaultMiddlewares: []func(http.Handler) http.Handler{customMiddleware},
+		DefaultMiddlewares: []MiddlewareFunc{customMiddleware},
 	})
 
 	zhtest.AssertNotNil(t, server2)


### PR DESCRIPTION
- Add MiddlewareFunc type alias for func(http.Handler) http.Handler
- Update Router interface and implementation to use MiddlewareFunc consistently
- Standardize all middleware config comments to use "// Default:" format
- Add custom middleware example in examples/middleware/custom/