### PR TITLE
fix: change bool fields with true defaults to *bool

### DIFF
--- a/examples/middleware/cache/main.go
+++ b/examples/middleware/cache/main.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
 	"github.com/alexferl/zerohttp/httpx"
 	"github.com/alexferl/zerohttp/middleware/cache"
 )
@@ -27,8 +28,8 @@ func main() {
 		cache.New(cache.Config{
 			CacheControl: "public, max-age=30",
 			DefaultTTL:   30 * time.Second,
-			ETag:         true,
-			LastModified: true,
+			ETag:         config.Bool(true),
+			LastModified: config.Bool(true),
 		}),
 	)
 
@@ -47,7 +48,7 @@ func main() {
 		cache.New(cache.Config{
 			CacheControl: "private, max-age=60",
 			DefaultTTL:   time.Minute,
-			ETag:         true,
+			ETag:         config.Bool(true),
 			Vary:         []string{httpx.HeaderAccept, httpx.HeaderAcceptEncoding},
 		}),
 	)

--- a/examples/middleware/ratelimit/main.go
+++ b/examples/middleware/ratelimit/main.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
 	"github.com/alexferl/zerohttp/httpx"
 	"github.com/alexferl/zerohttp/middleware/ratelimit"
 )
@@ -25,7 +26,7 @@ func main() {
 		Rate:           10,
 		Window:         time.Second,
 		Algorithm:      ratelimit.SlidingWindow,
-		IncludeHeaders: true,
+		IncludeHeaders: config.Bool(true),
 	}))
 
 	// Example 3: Per-user rate limiting (using header)
@@ -34,7 +35,7 @@ func main() {
 	}), ratelimit.New(ratelimit.Config{
 		Rate:           5,
 		Window:         time.Minute,
-		IncludeHeaders: true,
+		IncludeHeaders: config.Bool(true),
 		KeyExtractor: func(r *http.Request) string {
 			userID := r.Header.Get("X-User-ID")
 			if userID == "" {
@@ -51,7 +52,7 @@ func main() {
 		Rate:           1000,
 		Window:         time.Minute,
 		MaxKeys:        100000,
-		IncludeHeaders: true,
+		IncludeHeaders: config.Bool(true),
 	}))
 
 	// Example 5: Exclude health check from rate limiting
@@ -61,7 +62,7 @@ func main() {
 		Rate:           10,
 		Window:         time.Second,
 		ExcludedPaths:  []string{"/health", "/metrics"},
-		IncludeHeaders: true,
+		IncludeHeaders: config.Bool(true),
 	}))
 
 	log.Fatal(app.Start())

--- a/examples/middleware/ratelimit_redis/main.go
+++ b/examples/middleware/ratelimit_redis/main.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
 	"github.com/alexferl/zerohttp/httpx"
 	"github.com/alexferl/zerohttp/middleware/ratelimit"
 	"github.com/redis/go-redis/v9"
@@ -108,7 +109,7 @@ func main() {
 		Store:          store,
 		Rate:           rate,
 		Window:         window,
-		IncludeHeaders: true,
+		IncludeHeaders: config.Bool(true),
 	}))
 
 	app.GET("/", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {

--- a/examples/middleware/recover/main.go
+++ b/examples/middleware/recover/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
 	"github.com/alexferl/zerohttp/middleware/recover"
 )
 
@@ -42,8 +43,8 @@ func main() {
 	// Example with custom recover configuration
 	customApp := zh.New()
 	customApp.Use(recover.New(customApp.Logger(), recover.Config{
-		EnableStackTrace: false, // Disable stack traces
-		StackSize:        1024,  // Smaller stack buffer
+		EnableStackTrace: config.Bool(false), // Disable stack traces
+		StackSize:        1024,               // Smaller stack buffer
 	}))
 
 	customApp.GET("/no-stack", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {

--- a/examples/middleware/reverseproxy/main.go
+++ b/examples/middleware/reverseproxy/main.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/config"
 	"github.com/alexferl/zerohttp/middleware/reverseproxy"
 )
 
@@ -27,8 +28,8 @@ func main() {
 	app.Group(func(lb zh.Router) {
 		rp, cleanup := reverseproxy.New(reverseproxy.Config{
 			Targets: []reverseproxy.Backend{
-				{Target: "http://localhost:8081", Weight: 1, Healthy: true},
-				{Target: "http://localhost:8082", Weight: 1, Healthy: true},
+				{Target: "http://localhost:8081", Weight: 1, Healthy: config.Bool(true)},
+				{Target: "http://localhost:8082", Weight: 1, Healthy: config.Bool(true)},
 			},
 			LoadBalancer:        reverseproxy.RoundRobin,
 			HealthCheckInterval: 10 * time.Second,

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -146,7 +146,7 @@ func New(cfg ...Config) func(http.Handler) http.Handler {
 					VaryHeaders:  extractVaryHeaders(r, c.Vary),
 				}
 
-				if c.ETag {
+				if config.BoolOrDefault(c.ETag, true) {
 					hash := sha256.Sum256(record.Body)
 					eTag = fmt.Sprintf(`"%s"`, hex.EncodeToString(hash[:]))
 					record.ETag = eTag
@@ -160,7 +160,7 @@ func New(cfg ...Config) func(http.Handler) http.Handler {
 			}
 
 			// Finalize writes the response with proper headers
-			recorder.Finalize(eTag, c.CacheControl, c.ETag, c.LastModified, lastModified)
+			recorder.Finalize(eTag, c.CacheControl, config.BoolOrDefault(c.ETag, true), config.BoolOrDefault(c.LastModified, true), lastModified)
 		})
 	}
 }

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -132,7 +132,7 @@ func TestCache_ConditionalRequests(t *testing.T) {
 
 		cacheMiddleware := New(Config{
 			DefaultTTL: time.Minute,
-			ETag:       true,
+			ETag:       config.Bool(true),
 		})
 
 		// First request to cache
@@ -161,7 +161,7 @@ func TestCache_ConditionalRequests(t *testing.T) {
 
 		cacheMiddleware := New(Config{
 			DefaultTTL:   time.Minute,
-			LastModified: true,
+			LastModified: config.Bool(true),
 		})
 
 		// First request

--- a/middleware/cache/config.go
+++ b/middleware/cache/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/alexferl/zerohttp/config"
 	"github.com/alexferl/zerohttp/httpx"
 )
 
@@ -64,12 +65,14 @@ type Config struct {
 	MaxEntries int
 
 	// ETag enables automatic ETag generation (SHA256 hash of body).
+	// Use a pointer to distinguish between "not set" and "explicitly false".
 	// Default: true
-	ETag bool
+	ETag *bool
 
 	// LastModified enables automatic Last-Modified timestamp.
+	// Use a pointer to distinguish between "not set" and "explicitly false".
 	// Default: true
-	LastModified bool
+	LastModified *bool
 
 	// Vary headers that should be included in the cache key.
 	// Default: ["Accept", "Accept-Encoding", "Accept-Language"]
@@ -110,8 +113,8 @@ var DefaultConfig = Config{
 	DefaultTTL:    time.Minute,
 	MaxBodySize:   10 * 1024 * 1024,
 	MaxEntries:    10000,
-	ETag:          true,
-	LastModified:  true,
+	ETag:          config.Bool(true),
+	LastModified:  config.Bool(true),
 	Vary:          []string{httpx.HeaderAccept, httpx.HeaderAcceptEncoding, httpx.HeaderAcceptLanguage},
 	ExcludedPaths: []string{},
 	IncludedPaths: []string{},

--- a/middleware/cache/config_test.go
+++ b/middleware/cache/config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alexferl/zerohttp/config"
 	"github.com/alexferl/zerohttp/zhtest"
 )
 
@@ -16,8 +17,8 @@ func TestDefaultCacheConfig(t *testing.T) {
 		zhtest.AssertEqual(t, time.Minute, cfg.DefaultTTL)
 		zhtest.AssertEqual(t, 10*1024*1024, cfg.MaxBodySize)
 		zhtest.AssertEqual(t, 10000, cfg.MaxEntries)
-		zhtest.AssertTrue(t, cfg.ETag)
-		zhtest.AssertTrue(t, cfg.LastModified)
+		zhtest.AssertTrue(t, *cfg.ETag)
+		zhtest.AssertTrue(t, *cfg.LastModified)
 
 		expectedVary := []string{"Accept", "Accept-Encoding", "Accept-Language"}
 		zhtest.AssertEqual(t, len(expectedVary), len(cfg.Vary))
@@ -57,8 +58,8 @@ func TestCacheConfigCustomization(t *testing.T) {
 			DefaultTTL:    time.Hour,
 			MaxBodySize:   5 * 1024 * 1024,
 			MaxEntries:    5000,
-			ETag:          false,
-			LastModified:  false,
+			ETag:          config.Bool(false),
+			LastModified:  config.Bool(false),
 			Vary:          []string{"Accept"},
 			Store:         customStore,
 			ExcludedPaths: []string{"/api/live", "/health"},
@@ -69,8 +70,8 @@ func TestCacheConfigCustomization(t *testing.T) {
 		zhtest.AssertEqual(t, time.Hour, cfg.DefaultTTL)
 		zhtest.AssertEqual(t, 5*1024*1024, cfg.MaxBodySize)
 		zhtest.AssertEqual(t, 5000, cfg.MaxEntries)
-		zhtest.AssertFalse(t, cfg.ETag)
-		zhtest.AssertFalse(t, cfg.LastModified)
+		zhtest.AssertFalse(t, *cfg.ETag)
+		zhtest.AssertFalse(t, *cfg.LastModified)
 		zhtest.AssertEqual(t, customStore, cfg.Store)
 		zhtest.AssertEqual(t, 2, len(cfg.ExcludedPaths))
 	})

--- a/middleware/ratelimit/config.go
+++ b/middleware/ratelimit/config.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"time"
+
+	"github.com/alexferl/zerohttp/config"
 )
 
 // Store defines the interface for rate limit storage backends.
@@ -58,9 +60,10 @@ type Config struct {
 	// Default: "Rate limit exceeded"
 	Message string
 
-	// Headers to include in response.
+	// IncludeHeaders adds rate limit headers (X-RateLimit-Limit, X-RateLimit-Remaining, etc.)
+	// to responses. Use a pointer to distinguish between "not set" and "explicitly false".
 	// Default: true
-	IncludeHeaders bool
+	IncludeHeaders *bool
 
 	// ExcludedPaths contains paths to skip rate limiting.
 	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
@@ -95,7 +98,7 @@ var DefaultConfig = Config{
 	KeyExtractor:   nil, // Uses ratelimit.IPKeyExtractor() by default
 	StatusCode:     http.StatusTooManyRequests,
 	Message:        "Rate limit exceeded",
-	IncludeHeaders: true,
+	IncludeHeaders: config.Bool(true),
 	ExcludedPaths:  []string{},
 	IncludedPaths:  []string{},
 }

--- a/middleware/ratelimit/config_test.go
+++ b/middleware/ratelimit/config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alexferl/zerohttp/config"
 	"github.com/alexferl/zerohttp/httpx"
 	"github.com/alexferl/zerohttp/zhtest"
 )
@@ -17,7 +18,7 @@ func TestRateLimitConfig_DefaultValues(t *testing.T) {
 	zhtest.AssertNil(t, cfg.KeyExtractor)
 	zhtest.AssertEqual(t, http.StatusTooManyRequests, cfg.StatusCode)
 	zhtest.AssertEqual(t, "Rate limit exceeded", cfg.Message)
-	zhtest.AssertTrue(t, cfg.IncludeHeaders)
+	zhtest.AssertTrue(t, *cfg.IncludeHeaders)
 	zhtest.AssertEqual(t, 0, len(cfg.ExcludedPaths))
 	zhtest.AssertEqual(t, 0, len(cfg.IncludedPaths))
 }
@@ -30,14 +31,14 @@ func TestRateLimitConfig_StructAssignment(t *testing.T) {
 			Algorithm:      SlidingWindow,
 			StatusCode:     http.StatusServiceUnavailable,
 			Message:        "Too many requests, please try again later",
-			IncludeHeaders: false,
+			IncludeHeaders: config.Bool(false),
 		}
 		zhtest.AssertEqual(t, 50, cfg.Rate)
 		zhtest.AssertEqual(t, 30*time.Second, cfg.Window)
 		zhtest.AssertEqual(t, SlidingWindow, cfg.Algorithm)
 		zhtest.AssertEqual(t, http.StatusServiceUnavailable, cfg.StatusCode)
 		zhtest.AssertEqual(t, "Too many requests, please try again later", cfg.Message)
-		zhtest.AssertFalse(t, cfg.IncludeHeaders)
+		zhtest.AssertFalse(t, *cfg.IncludeHeaders)
 	})
 
 	t.Run("key extractor", func(t *testing.T) {
@@ -96,7 +97,7 @@ func TestRateLimitConfig_MultipleFields(t *testing.T) {
 		KeyExtractor:   customExtractor,
 		StatusCode:     http.StatusForbidden,
 		Message:        "Rate limit reached",
-		IncludeHeaders: false,
+		IncludeHeaders: config.Bool(false),
 		ExcludedPaths:  excludedPaths,
 		IncludedPaths:  includedPaths,
 	}
@@ -107,7 +108,7 @@ func TestRateLimitConfig_MultipleFields(t *testing.T) {
 	zhtest.AssertNotNil(t, cfg.KeyExtractor)
 	zhtest.AssertEqual(t, http.StatusForbidden, cfg.StatusCode)
 	zhtest.AssertEqual(t, "Rate limit reached", cfg.Message)
-	zhtest.AssertFalse(t, cfg.IncludeHeaders)
+	zhtest.AssertFalse(t, *cfg.IncludeHeaders)
 	zhtest.AssertEqual(t, excludedPaths, cfg.ExcludedPaths)
 	zhtest.AssertEqual(t, 1, len(cfg.IncludedPaths))
 	zhtest.AssertEqual(t, includedPaths, cfg.IncludedPaths)

--- a/middleware/ratelimit/rate_limit.go
+++ b/middleware/ratelimit/rate_limit.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alexferl/zerohttp/config"
 	"github.com/alexferl/zerohttp/httpx"
 	zconfig "github.com/alexferl/zerohttp/internal/config"
 	"github.com/alexferl/zerohttp/internal/mwutil"
@@ -58,7 +59,7 @@ func New(cfg ...Config) func(http.Handler) http.Handler {
 			// Skip headers for SSE connections to avoid interfering with streaming responses
 			isSSE := r.Header.Get(httpx.HeaderAccept) == httpx.MIMETextEventStream
 
-			if c.IncludeHeaders && !isSSE {
+			if config.BoolOrDefault(c.IncludeHeaders, true) && !isSSE {
 				w.Header().Set(httpx.HeaderXRateLimitLimit, strconv.Itoa(c.Rate))
 				w.Header().Set(httpx.HeaderXRateLimitRemaining, strconv.Itoa(remaining))
 				w.Header().Set(httpx.HeaderXRateLimitReset, strconv.FormatInt(resetTime.Unix(), 10))

--- a/middleware/ratelimit/rate_limit_test.go
+++ b/middleware/ratelimit/rate_limit_test.go
@@ -164,7 +164,7 @@ func TestRateLimitHeaders(t *testing.T) {
 		Rate:           5,
 		Window:         time.Minute,
 		Algorithm:      TokenBucket,
-		IncludeHeaders: true,
+		IncludeHeaders: config.Bool(true),
 	})
 	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }))
 	req := zhtest.NewRequest(http.MethodGet, "/test").Build()
@@ -184,7 +184,7 @@ func TestRateLimitNoHeaders(t *testing.T) {
 		Rate:           2,
 		Window:         time.Second,
 		Algorithm:      TokenBucket,
-		IncludeHeaders: false,
+		IncludeHeaders: config.Bool(false),
 	})
 	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }))
 	req := zhtest.NewRequest(http.MethodGet, "/test").Build()

--- a/middleware/recover/config.go
+++ b/middleware/recover/config.go
@@ -1,5 +1,7 @@
 package recover
 
+import "github.com/alexferl/zerohttp/config"
+
 // Config allows customization of panic recovery
 type Config struct {
 	// StackSize is the maximum size of the stack trace in bytes.
@@ -7,8 +9,9 @@ type Config struct {
 	StackSize int64
 
 	// EnableStackTrace determines if stack traces should be included.
+	// Use a pointer to distinguish between "not set" and "explicitly false".
 	// Default: true
-	EnableStackTrace bool
+	EnableStackTrace *bool
 
 	// RequestIDHeader is the header name for the request ID.
 	// This should match the header configured in RequestIDConfig.
@@ -19,6 +22,6 @@ type Config struct {
 // DefaultConfig contains the default panic recovery configuration
 var DefaultConfig = Config{
 	StackSize:        4 << 10, // 4KB
-	EnableStackTrace: true,
+	EnableStackTrace: config.Bool(true),
 	RequestIDHeader:  "X-Request-Id",
 }

--- a/middleware/recover/config_test.go
+++ b/middleware/recover/config_test.go
@@ -3,13 +3,14 @@ package recover
 import (
 	"testing"
 
+	"github.com/alexferl/zerohttp/config"
 	"github.com/alexferl/zerohttp/zhtest"
 )
 
 func TestRecoverConfig_DefaultValues(t *testing.T) {
 	cfg := DefaultConfig
 	zhtest.AssertEqual(t, int64(4<<10), cfg.StackSize)
-	zhtest.AssertTrue(t, cfg.EnableStackTrace)
+	zhtest.AssertTrue(t, *cfg.EnableStackTrace)
 
 	// Verify the 4KB calculation
 	expectedSize := int64(4096)
@@ -37,7 +38,7 @@ func TestRecoverConfig_StackSizeBoundaryValues(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := Config{
 				StackSize:        tt.stackSize,
-				EnableStackTrace: true,
+				EnableStackTrace: config.Bool(true),
 			}
 			zhtest.AssertEqual(t, tt.stackSize, cfg.StackSize)
 		})
@@ -67,7 +68,7 @@ func TestRecoverConfig_CommonStackSizes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := Config{
 				StackSize:        tt.stackSize,
-				EnableStackTrace: true,
+				EnableStackTrace: config.Bool(true),
 			}
 			zhtest.AssertEqual(t, tt.stackSize, cfg.StackSize)
 		})
@@ -78,22 +79,22 @@ func TestRecoverConfig_EdgeCases(t *testing.T) {
 	t.Run("zero values", func(t *testing.T) {
 		cfg := Config{} // Zero values
 		zhtest.AssertEqual(t, int64(0), cfg.StackSize)
-		zhtest.AssertFalse(t, cfg.EnableStackTrace)
+		zhtest.AssertNil(t, cfg.EnableStackTrace)
 	})
 
 	t.Run("boolean toggling", func(t *testing.T) {
 		cfg := Config{
 			StackSize:        4096,
-			EnableStackTrace: true,
+			EnableStackTrace: config.Bool(true),
 		}
 		// Start with true
-		zhtest.AssertTrue(t, cfg.EnableStackTrace)
+		zhtest.AssertTrue(t, *cfg.EnableStackTrace)
 		// Toggle to false
-		cfg.EnableStackTrace = false
-		zhtest.AssertFalse(t, cfg.EnableStackTrace)
+		cfg.EnableStackTrace = config.Bool(false)
+		zhtest.AssertFalse(t, *cfg.EnableStackTrace)
 		// Toggle back to true
-		cfg.EnableStackTrace = true
-		zhtest.AssertTrue(t, cfg.EnableStackTrace)
+		cfg.EnableStackTrace = config.Bool(true)
+		zhtest.AssertTrue(t, *cfg.EnableStackTrace)
 	})
 }
 
@@ -115,11 +116,11 @@ func TestRecoverConfig_UsageScenarios(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := Config{
 				StackSize:        tt.stackSize,
-				EnableStackTrace: tt.enableStackTrace,
+				EnableStackTrace: config.Bool(tt.enableStackTrace),
 			}
 
 			zhtest.AssertEqual(t, tt.stackSize, cfg.StackSize)
-			zhtest.AssertEqual(t, tt.enableStackTrace, cfg.EnableStackTrace)
+			zhtest.AssertEqual(t, tt.enableStackTrace, *cfg.EnableStackTrace)
 		})
 	}
 }
@@ -128,11 +129,11 @@ func TestRecoverConfig_StructAssignment(t *testing.T) {
 	t.Run("direct struct assignment", func(t *testing.T) {
 		cfg := Config{
 			StackSize:        8192,
-			EnableStackTrace: false,
+			EnableStackTrace: config.Bool(false),
 		}
 
 		zhtest.AssertEqual(t, int64(8192), cfg.StackSize)
-		zhtest.AssertFalse(t, cfg.EnableStackTrace)
+		zhtest.AssertFalse(t, *cfg.EnableStackTrace)
 	})
 
 	t.Run("modify struct fields", func(t *testing.T) {
@@ -140,9 +141,9 @@ func TestRecoverConfig_StructAssignment(t *testing.T) {
 
 		// Modify fields directly
 		cfg.StackSize = 16384
-		cfg.EnableStackTrace = false
+		cfg.EnableStackTrace = config.Bool(false)
 
 		zhtest.AssertEqual(t, int64(16384), cfg.StackSize)
-		zhtest.AssertFalse(t, cfg.EnableStackTrace)
+		zhtest.AssertFalse(t, *cfg.EnableStackTrace)
 	})
 }

--- a/middleware/recover/recover.go
+++ b/middleware/recover/recover.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/alexferl/zerohttp/config"
 	"github.com/alexferl/zerohttp/httpx"
 	zconfig "github.com/alexferl/zerohttp/internal/config"
 	"github.com/alexferl/zerohttp/internal/problem"
@@ -46,7 +47,7 @@ func New(logger log.Logger, cfg ...Config) func(http.Handler) http.Handler {
 						log.F("request_id", reqID),
 					}
 
-					if c.EnableStackTrace {
+					if config.BoolOrDefault(c.EnableStackTrace, true) {
 						stack := make([]byte, c.StackSize)
 						length := runtime.Stack(stack, false)
 						fields = append(fields, log.F("stack", string(stack[:length])))

--- a/middleware/recover/recover_test.go
+++ b/middleware/recover/recover_test.go
@@ -117,7 +117,7 @@ func TestRecover_CustomConfig(t *testing.T) {
 	logger := &mockLogger{}
 	handler := New(logger, Config{
 		StackSize:        1024,
-		EnableStackTrace: true,
+		EnableStackTrace: config.Bool(true),
 	})(panicHandler("custom config panic"))
 	req := zhtest.NewRequest(http.MethodGet, "/").Build()
 	zhtest.Serve(handler, req)
@@ -140,7 +140,7 @@ func TestRecover_DisabledStackTrace(t *testing.T) {
 	logger := &mockLogger{}
 	handler := New(logger, Config{
 		StackSize:        4096,
-		EnableStackTrace: false,
+		EnableStackTrace: config.Bool(false),
 	})(panicHandler("no stack panic"))
 	req := zhtest.NewRequest(http.MethodGet, "/").Build()
 	zhtest.Serve(handler, req)
@@ -159,7 +159,7 @@ func TestRecover_InvalidStackSize(t *testing.T) {
 	logger := &mockLogger{}
 	handler := New(logger, Config{
 		StackSize:        0,
-		EnableStackTrace: true,
+		EnableStackTrace: config.Bool(true),
 	})(panicHandler("invalid stack size"))
 	req := zhtest.NewRequest(http.MethodGet, "/").Build()
 	zhtest.Serve(handler, req)
@@ -220,14 +220,14 @@ func TestDefaultRecoverConfig(t *testing.T) {
 	cfg := DefaultConfig
 	expectedStackSize := int64(4 << 10)
 	zhtest.AssertEqual(t, expectedStackSize, cfg.StackSize)
-	zhtest.AssertTrue(t, cfg.EnableStackTrace)
+	zhtest.AssertTrue(t, *cfg.EnableStackTrace)
 }
 
 func TestRecover_MultipleOptions(t *testing.T) {
 	logger := &mockLogger{}
 	handler := New(logger, Config{
 		StackSize:        1024,
-		EnableStackTrace: true,
+		EnableStackTrace: config.Bool(true),
 	})(panicHandler("multiple options"))
 	req := zhtest.NewRequest(http.MethodGet, "/").Build()
 	zhtest.Serve(handler, req)
@@ -334,7 +334,7 @@ func TestRecover_CustomRequestIDHeader(t *testing.T) {
 
 	cfg := Config{
 		RequestIDHeader:  customHeader,
-		EnableStackTrace: false,
+		EnableStackTrace: config.Bool(false),
 	}
 
 	handler := New(logger, cfg)(panicHandler("test panic"))

--- a/middleware/reverseproxy/config.go
+++ b/middleware/reverseproxy/config.go
@@ -3,6 +3,8 @@ package reverseproxy
 import (
 	"net/http"
 	"time"
+
+	"github.com/alexferl/zerohttp/config"
 )
 
 // LoadBalancerAlgorithm defines the load balancing strategy
@@ -27,8 +29,9 @@ type Backend struct {
 	Weight int
 
 	// Healthy indicates if the backend is currently healthy.
+	// Use a pointer to distinguish between "not set" and "explicitly false".
 	// Default: true
-	Healthy bool
+	Healthy *bool
 }
 
 // RewriteRule defines a path rewrite pattern
@@ -95,8 +98,9 @@ type Config struct {
 	// X-Forwarded-For: Client IP
 	// X-Forwarded-Proto: Original protocol (http/https)
 	// X-Forwarded-Host: Original host header.
+	// Use a pointer to distinguish between "not set" and "explicitly false".
 	// Default: true
-	ForwardHeaders bool
+	ForwardHeaders *bool
 
 	// ErrorHandler is called when the proxy encounters an error.
 	// If nil, a default error handler is used.
@@ -152,7 +156,7 @@ var DefaultConfig = Config{
 	Rewrites:        []RewriteRule{},
 	SetHeaders:      map[string]string{},
 	RemoveHeaders:   []string{},
-	ForwardHeaders:  true,
+	ForwardHeaders:  config.Bool(true),
 	ExcludedPaths:   []string{},
 	IncludedPaths:   []string{},
 }

--- a/middleware/reverseproxy/config_test.go
+++ b/middleware/reverseproxy/config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alexferl/zerohttp/config"
 	"github.com/alexferl/zerohttp/zhtest"
 )
 
@@ -17,7 +18,7 @@ func TestDefaultReverseProxyConfig(t *testing.T) {
 	zhtest.AssertEqual(t, 0, len(cfg.Rewrites))
 	zhtest.AssertEqual(t, 0, len(cfg.SetHeaders))
 	zhtest.AssertEqual(t, 0, len(cfg.RemoveHeaders))
-	zhtest.AssertTrue(t, cfg.ForwardHeaders)
+	zhtest.AssertTrue(t, *cfg.ForwardHeaders)
 	zhtest.AssertEqual(t, 0, len(cfg.ExcludedPaths))
 	zhtest.AssertEqual(t, 0, len(cfg.IncludedPaths))
 }
@@ -38,12 +39,12 @@ func TestBackend(t *testing.T) {
 	b := Backend{
 		Target:  "http://localhost:8081",
 		Weight:  3,
-		Healthy: true,
+		Healthy: config.Bool(true),
 	}
 
 	zhtest.AssertEqual(t, "http://localhost:8081", b.Target)
 	zhtest.AssertEqual(t, 3, b.Weight)
-	zhtest.AssertTrue(t, b.Healthy)
+	zhtest.AssertTrue(t, *b.Healthy)
 }
 
 func TestRewriteRule(t *testing.T) {
@@ -72,7 +73,7 @@ func TestReverseProxyConfig(t *testing.T) {
 			"X-Custom": "value",
 		},
 		RemoveHeaders:  []string{"X-Internal"},
-		ForwardHeaders: true,
+		ForwardHeaders: config.Bool(true),
 		ExcludedPaths:  []string{"/health", "/metrics"},
 		IncludedPaths:  []string{"/api/public"},
 	}
@@ -89,7 +90,7 @@ func TestReverseProxyConfig(t *testing.T) {
 	zhtest.AssertEqual(t, "value", cfg.SetHeaders["X-Custom"])
 	zhtest.AssertEqual(t, 1, len(cfg.RemoveHeaders))
 	zhtest.AssertEqual(t, "X-Internal", cfg.RemoveHeaders[0])
-	zhtest.AssertTrue(t, cfg.ForwardHeaders)
+	zhtest.AssertTrue(t, *cfg.ForwardHeaders)
 	zhtest.AssertEqual(t, 2, len(cfg.ExcludedPaths))
 	zhtest.AssertEqual(t, 1, len(cfg.IncludedPaths))
 }
@@ -123,9 +124,9 @@ func TestReverseProxyConfig_IncludedPaths(t *testing.T) {
 func TestReverseProxyConfigWithTargets(t *testing.T) {
 	cfg := Config{
 		Targets: []Backend{
-			{Target: "http://backend1:8081", Weight: 1, Healthy: true},
-			{Target: "http://backend2:8081", Weight: 2, Healthy: true},
-			{Target: "http://backend3:8081", Weight: 1, Healthy: false},
+			{Target: "http://backend1:8081", Weight: 1, Healthy: config.Bool(true)},
+			{Target: "http://backend2:8081", Weight: 2, Healthy: config.Bool(true)},
+			{Target: "http://backend3:8081", Weight: 1, Healthy: config.Bool(false)},
 		},
 		LoadBalancer: LeastConnections,
 	}
@@ -133,6 +134,6 @@ func TestReverseProxyConfigWithTargets(t *testing.T) {
 	zhtest.AssertEqual(t, 3, len(cfg.Targets))
 	zhtest.AssertEqual(t, "http://backend1:8081", cfg.Targets[0].Target)
 	zhtest.AssertEqual(t, 1, cfg.Targets[0].Weight)
-	zhtest.AssertTrue(t, cfg.Targets[0].Healthy)
+	zhtest.AssertTrue(t, *cfg.Targets[0].Healthy)
 	zhtest.AssertEqual(t, LeastConnections, cfg.LoadBalancer)
 }

--- a/middleware/reverseproxy/reverse_proxy.go
+++ b/middleware/reverseproxy/reverse_proxy.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/alexferl/zerohttp/config"
 	"github.com/alexferl/zerohttp/httpx"
 	"github.com/alexferl/zerohttp/internal/mwutil"
 	"github.com/alexferl/zerohttp/metrics"
@@ -76,7 +77,7 @@ func New(cfg Config) (func(http.Handler) http.Handler, func()) {
 			if weight <= 0 {
 				weight = 1
 			}
-			rp.initBackend(b.Target, weight, b.Healthy)
+			rp.initBackend(b.Target, weight, config.BoolOrDefault(b.Healthy, true))
 		}
 	} else {
 		panic("reverse proxy: Target or Targets is required")
@@ -158,7 +159,7 @@ func (rp *reverseProxy) initBackend(target string, weight int, healthy bool) {
 	proxy.Director = nil
 	proxy.Rewrite = func(r *httputil.ProxyRequest) {
 		r.SetURL(targetURL)
-		if rp.cfg.ForwardHeaders {
+		if config.BoolOrDefault(rp.cfg.ForwardHeaders, true) {
 			r.SetXForwarded()
 		}
 		// Preserve query parameters from original request
@@ -285,7 +286,7 @@ func (rp *reverseProxy) applyModifications(r *http.Request) {
 		r.Header.Set(key, value)
 	}
 
-	if cfg.ForwardHeaders {
+	if config.BoolOrDefault(cfg.ForwardHeaders, true) {
 		clientIP := r.RemoteAddr
 		if xff := r.Header.Get(httpx.HeaderXForwardedFor); xff != "" {
 			clientIP = xff + ", " + clientIP

--- a/middleware/reverseproxy/reverse_proxy_bench_test.go
+++ b/middleware/reverseproxy/reverse_proxy_bench_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/alexferl/zerohttp/config"
 )
 
 // BenchmarkReverseProxy_Baseline measures basic proxy overhead
@@ -54,9 +56,9 @@ func BenchmarkReverseProxy_LoadBalancers(b *testing.B) {
 	for _, tc := range algorithms {
 		b.Run(tc.name, func(b *testing.B) {
 			targets := []Backend{
-				{Target: upstreams[0].URL, Weight: 1, Healthy: true},
-				{Target: upstreams[1].URL, Weight: 1, Healthy: true},
-				{Target: upstreams[2].URL, Weight: 1, Healthy: true},
+				{Target: upstreams[0].URL, Weight: 1, Healthy: config.Bool(true)},
+				{Target: upstreams[1].URL, Weight: 1, Healthy: config.Bool(true)},
+				{Target: upstreams[2].URL, Weight: 1, Healthy: config.Bool(true)},
 			}
 
 			mw, cleanup := New(Config{
@@ -93,7 +95,7 @@ func BenchmarkReverseProxy_BackendCount(b *testing.B) {
 					w.WriteHeader(http.StatusOK)
 				}))
 				defer upstreams[i].Close()
-				targets[i] = Backend{Target: upstreams[i].URL, Weight: 1, Healthy: true}
+				targets[i] = Backend{Target: upstreams[i].URL, Weight: 1, Healthy: config.Bool(true)}
 			}
 
 			mw, cleanup := New(Config{
@@ -292,7 +294,7 @@ func BenchmarkReverseProxy_ForwardHeaders(b *testing.B) {
 	b.Run("WithoutForwardHeaders", func(b *testing.B) {
 		mw, cleanup := New(Config{
 			Target:         upstream.URL,
-			ForwardHeaders: false,
+			ForwardHeaders: config.Bool(false),
 		})
 		defer cleanup()
 		handler := mw(nil)
@@ -310,7 +312,7 @@ func BenchmarkReverseProxy_ForwardHeaders(b *testing.B) {
 	b.Run("WithForwardHeaders", func(b *testing.B) {
 		mw, cleanup := New(Config{
 			Target:         upstream.URL,
-			ForwardHeaders: true,
+			ForwardHeaders: config.Bool(true),
 		})
 		defer cleanup()
 		handler := mw(nil)
@@ -417,7 +419,7 @@ func BenchmarkReverseProxy_UnhealthyBackends(b *testing.B) {
 				targets[i] = Backend{
 					Target:  upstreams[i].URL,
 					Weight:  1,
-					Healthy: i < tc.healthyCount,
+					Healthy: config.Bool(i < tc.healthyCount),
 				}
 			}
 
@@ -447,9 +449,9 @@ func BenchmarkReverseProxy_Concurrent(b *testing.B) {
 	defer upstream.Close()
 
 	targets := []Backend{
-		{Target: upstream.URL, Weight: 1, Healthy: true},
-		{Target: upstream.URL, Weight: 1, Healthy: true},
-		{Target: upstream.URL, Weight: 1, Healthy: true},
+		{Target: upstream.URL, Weight: 1, Healthy: config.Bool(true)},
+		{Target: upstream.URL, Weight: 1, Healthy: config.Bool(true)},
+		{Target: upstream.URL, Weight: 1, Healthy: config.Bool(true)},
 	}
 
 	mw, cleanup := New(Config{
@@ -489,7 +491,7 @@ func BenchmarkReverseProxy_BackendSelection(b *testing.B) {
 		targets[i] = Backend{
 			Target:  upstream.URL,
 			Weight:  1,
-			Healthy: true,
+			Healthy: config.Bool(true),
 		}
 	}
 

--- a/middleware/reverseproxy/reverse_proxy_test.go
+++ b/middleware/reverseproxy/reverse_proxy_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alexferl/zerohttp/config"
 	"github.com/alexferl/zerohttp/httpx"
 	"github.com/alexferl/zerohttp/zhtest"
 )
@@ -190,7 +191,7 @@ func TestReverseProxy_ForwardHeaders(t *testing.T) {
 
 	mw, _ := New(Config{
 		Target:         upstream.URL,
-		ForwardHeaders: true,
+		ForwardHeaders: config.Bool(true),
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -305,7 +306,7 @@ func TestReverseProxy_ErrorHandler(t *testing.T) {
 func TestReverseProxy_FallbackHandler(t *testing.T) {
 	mw, _ := New(Config{
 		Targets: []Backend{
-			{Target: "http://localhost:1", Healthy: false},
+			{Target: "http://localhost:1", Healthy: config.Bool(false)},
 		},
 		HealthCheckInterval: 0,
 		FallbackHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -335,8 +336,8 @@ func TestReverseProxy_LoadBalancer_RoundRobin(t *testing.T) {
 
 	mw, _ := New(Config{
 		Targets: []Backend{
-			{Target: upstream1.URL, Healthy: true},
-			{Target: upstream2.URL, Healthy: true},
+			{Target: upstream1.URL, Healthy: config.Bool(true)},
+			{Target: upstream2.URL, Healthy: config.Bool(true)},
 		},
 		LoadBalancer: RoundRobin,
 	})
@@ -373,8 +374,8 @@ func TestReverseProxy_LoadBalancer_Random(t *testing.T) {
 
 	mw, _ := New(Config{
 		Targets: []Backend{
-			{Target: upstream1.URL, Healthy: true},
-			{Target: upstream2.URL, Healthy: true},
+			{Target: upstream1.URL, Healthy: config.Bool(true)},
+			{Target: upstream2.URL, Healthy: config.Bool(true)},
 		},
 		LoadBalancer: Random,
 	})
@@ -402,8 +403,8 @@ func TestReverseProxy_LoadBalancer_LeastConnections(t *testing.T) {
 
 	mw, _ := New(Config{
 		Targets: []Backend{
-			{Target: upstream1.URL, Healthy: true},
-			{Target: upstream2.URL, Healthy: true},
+			{Target: upstream1.URL, Healthy: config.Bool(true)},
+			{Target: upstream2.URL, Healthy: config.Bool(true)},
 		},
 		LoadBalancer: LeastConnections,
 	})
@@ -449,7 +450,7 @@ func TestReverseProxy_HealthCheck(t *testing.T) {
 
 	mw, _ := New(Config{
 		Targets: []Backend{
-			{Target: upstream.URL, Healthy: true},
+			{Target: upstream.URL, Healthy: config.Bool(true)},
 		},
 		HealthCheckInterval: 100 * time.Millisecond,
 		HealthCheckPath:     "/health",
@@ -557,7 +558,7 @@ func TestReverseProxy_WithNextHandler(t *testing.T) {
 func TestReverseProxy_NoHealthyBackends(t *testing.T) {
 	mw, _ := New(Config{
 		Targets: []Backend{
-			{Target: "http://localhost:1", Healthy: false},
+			{Target: "http://localhost:1", Healthy: config.Bool(false)},
 		},
 		HealthCheckInterval: 0,
 	})
@@ -634,7 +635,7 @@ func TestReverseProxy_HealthCheckCleanup(t *testing.T) {
 	// Create reverse proxy with health checks
 	mw, cleanup := New(Config{
 		Targets: []Backend{
-			{Target: upstream.URL, Healthy: true},
+			{Target: upstream.URL, Healthy: config.Bool(true)},
 		},
 		HealthCheckInterval: 50 * time.Millisecond,
 		HealthCheckPath:     "/health",


### PR DESCRIPTION
Fixes an issue where bool config fields with `true` defaults (e.g., IncludeHeaders, EnableStackTrace) would be incorrectly set to `false` when users provided any config.

The config.Merge function always copies bool values, including the zero-value `false`, which overwrote the `true` defaults.

Changed to *bool with config.Bool() helper so nil means "use default" while explicit true/false values work correctly.

Affected fields:
- ratelimit.IncludeHeaders
- recover.EnableStackTrace
- cache.ETag, cache.LastModified
- reverseproxy.Backend.Healthy, reverseproxy.ForwardHeaders