### PR TITLE
feat(mediatype): add media type negotiation middleware with wildcard …

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -64,6 +64,7 @@ Demonstrations of built-in and custom middleware.
 - [**`jwtauth_golang_jwt/`**](middleware/jwtauth_golang_jwt/) - golang-jwt integration (has go.mod)
 - [**`jwtauth_lestrrat_jwx/`**](middleware/jwtauth_lestrrat_jwx/) - lestrrat-go/jwx integration (has go.mod)
 - [**`jwtauth_refresh/`**](middleware/jwtauth_refresh/) - JWT refresh token flow (has go.mod)
+- [**`mediatype/`**](middleware/mediatype/) - Media type negotiation for content versioning
 - [**`nocache/`**](middleware/nocache/) - Cache control headers
 - [**`ratelimit/`**](middleware/ratelimit/) - Rate limiting (in-memory)
 - [**`ratelimit_redis/`**](middleware/ratelimit_redis/) - Redis-backed rate limiting (has go.mod)

--- a/examples/middleware/mediatype/main.go
+++ b/examples/middleware/mediatype/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	zh "github.com/alexferl/zerohttp"
+	"github.com/alexferl/zerohttp/middleware/mediatype"
+)
+
+func main() {
+	app := zh.New()
+
+	// Accept multiple vendor media types for API versioning
+	app.Use(mediatype.New(mediatype.Config{
+		AllowedTypes: []string{
+			"application/vnd.api.v1+json",
+			"application/vnd.api.v2+json",
+		},
+		DefaultType: "application/vnd.api.v1+json",
+	}))
+
+	// Return different response formats based on Accept header
+	app.GET("/api/users", zh.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		accept := r.Header.Get("Accept")
+
+		if accept == "application/vnd.api.v2+json" {
+			// V2: full user data with metadata
+			return zh.R.JSON(w, http.StatusOK, map[string]any{
+				"data": []map[string]any{
+					{"id": "1", "name": "Alice", "email": "alice@example.com", "role": "admin"},
+					{"id": "2", "name": "Bob", "email": "bob@example.com", "role": "user"},
+				},
+				"meta": map[string]int{
+					"total": 2,
+					"page":  1,
+				},
+			})
+		}
+
+		// V1 (default): simple user list
+		return zh.R.JSON(w, http.StatusOK, []map[string]string{
+			{"id": "1", "name": "Alice"},
+			{"id": "2", "name": "Bob"},
+		})
+	}))
+
+	log.Fatal(app.Start())
+}

--- a/middleware/doc.go
+++ b/middleware/doc.go
@@ -57,6 +57,7 @@
 //   - [github.com/alexferl/zerohttp/middleware/contenttype] - Content-Type header enforcement
 //   - [github.com/alexferl/zerohttp/middleware/contentencoding] - Content-Encoding negotiation
 //   - [github.com/alexferl/zerohttp/middleware/contentcharset] - Content-Type charset validation
+//   - [github.com/alexferl/zerohttp/middleware/mediatype] - Media type negotiation with wildcard and suffix support
 //
 // Caching:
 //   - [github.com/alexferl/zerohttp/middleware/cache] - HTTP caching with ETag and Last-Modified

--- a/middleware/mediatype/config.go
+++ b/middleware/mediatype/config.go
@@ -1,0 +1,47 @@
+package mediatype
+
+// Config allows customization of allowed media types
+type Config struct {
+	// AllowedTypes is a list of allowed media type patterns.
+	// Supports wildcards (*) and suffix matching (+json, +xml, etc.).
+	// Examples:
+	//   - "application/vnd.api+json" - exact vendor type
+	//   - "application/*+json" - any JSON-based media type
+	//   - "application/vnd.company.*+json" - vendor types with wildcards
+	// Default: [] (no validation, allows any)
+	AllowedTypes []string
+
+	// DefaultType is the media type to use when the client accepts any type (*/*)
+	// or when no Accept header is provided. This is set as the response Content-Type.
+	// If empty, no Content-Type is set automatically.
+	// Default: ""
+	DefaultType string
+
+	// ValidateContentType also validates the request Content-Type header.
+	// When true, both Accept and Content-Type must match AllowedTypes.
+	// Default: false
+	ValidateContentType bool
+
+	// ExcludedPaths contains paths that skip media type validation.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// Cannot be used with IncludedPaths - setting both will panic.
+	// Default: []
+	ExcludedPaths []string
+
+	// IncludedPaths contains paths where media type validation is explicitly applied.
+	// If set, validation will only occur for paths matching these patterns.
+	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
+	// If empty, validation applies to all paths (subject to ExcludedPaths).
+	// Cannot be used with ExcludedPaths - setting both will panic.
+	// Default: []
+	IncludedPaths []string
+}
+
+// DefaultConfig contains the default values for media type configuration.
+var DefaultConfig = Config{
+	AllowedTypes:        []string{},
+	DefaultType:         "",
+	ValidateContentType: false,
+	ExcludedPaths:       []string{},
+	IncludedPaths:       []string{},
+}

--- a/middleware/mediatype/config_test.go
+++ b/middleware/mediatype/config_test.go
@@ -1,0 +1,72 @@
+package mediatype
+
+import (
+	"testing"
+
+	"github.com/alexferl/zerohttp/zhtest"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	zhtest.AssertEqual(t, 0, len(DefaultConfig.AllowedTypes))
+	zhtest.AssertEqual(t, "", DefaultConfig.DefaultType)
+	zhtest.AssertEqual(t, false, DefaultConfig.ValidateContentType)
+	zhtest.AssertEqual(t, 0, len(DefaultConfig.ExcludedPaths))
+	zhtest.AssertEqual(t, 0, len(DefaultConfig.IncludedPaths))
+}
+
+func TestConfigMerge(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   Config
+		expected Config
+	}{
+		{
+			name: "custom allowed types",
+			config: Config{
+				AllowedTypes: []string{"application/vnd.api+json"},
+			},
+			expected: Config{
+				AllowedTypes:        []string{"application/vnd.api+json"},
+				DefaultType:         "",
+				ValidateContentType: false,
+				ExcludedPaths:       []string{},
+				IncludedPaths:       []string{},
+			},
+		},
+		{
+			name: "with default type",
+			config: Config{
+				AllowedTypes: []string{"application/vnd.api+json"},
+				DefaultType:  "application/vnd.api+json",
+			},
+			expected: Config{
+				AllowedTypes:        []string{"application/vnd.api+json"},
+				DefaultType:         "application/vnd.api+json",
+				ValidateContentType: false,
+				ExcludedPaths:       []string{},
+				IncludedPaths:       []string{},
+			},
+		},
+		{
+			name: "with content type validation",
+			config: Config{
+				AllowedTypes:        []string{"application/json"},
+				ValidateContentType: true,
+			},
+			expected: Config{
+				AllowedTypes:        []string{"application/json"},
+				DefaultType:         "",
+				ValidateContentType: true,
+				ExcludedPaths:       []string{},
+				IncludedPaths:       []string{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			middleware := New(tt.config)
+			zhtest.AssertNotNil(t, middleware)
+		})
+	}
+}

--- a/middleware/mediatype/doc.go
+++ b/middleware/mediatype/doc.go
@@ -1,0 +1,28 @@
+// Package mediatype provides media type negotiation and validation middleware.
+//
+// Validates Accept headers against allowed media types and ensures
+// clients can receive the response formats the server provides.
+// Supports suffix matching (+json, +xml) and wildcard patterns.
+//
+// # Usage
+//
+//	import "github.com/alexferl/zerohttp/middleware/mediatype"
+//
+//	// Accept only specific vendor types
+//	app.Use(mediatype.New(mediatype.Config{
+//	    AllowedTypes: []string{"application/vnd.api+json"},
+//	}))
+//
+//	// Accept any +json suffix
+//	app.Use(mediatype.New(mediatype.Config{
+//	    AllowedTypes: []string{"application/*+json"},
+//	}))
+//
+//	// Accept multiple patterns
+//	app.Use(mediatype.New(mediatype.Config{
+//	    AllowedTypes: []string{
+//	        "application/vnd.api+json",
+//	        "application/vnd.company.*+json",
+//	    },
+//	}))
+package mediatype

--- a/middleware/mediatype/media_type.go
+++ b/middleware/mediatype/media_type.go
@@ -1,0 +1,252 @@
+package mediatype
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/alexferl/zerohttp/httpx"
+	zconfig "github.com/alexferl/zerohttp/internal/config"
+	"github.com/alexferl/zerohttp/internal/mwutil"
+	"github.com/alexferl/zerohttp/internal/problem"
+)
+
+// New creates a media type middleware with the provided configuration.
+// It validates the Accept header against allowed patterns and responds with
+// 406 Not Acceptable if no match is found.
+// When ValidateContentType is true, it also validates the Content-Type header
+// and responds with 415 Unsupported Media Type on mismatch.
+func New(cfg ...Config) func(http.Handler) http.Handler {
+	c := DefaultConfig
+	if len(cfg) > 0 {
+		zconfig.Merge(&c, cfg[0])
+	}
+
+	mwutil.ValidatePathConfig(c.ExcludedPaths, c.IncludedPaths, "MediaType")
+
+	// If no allowed types configured, skip validation entirely
+	if len(c.AllowedTypes) == 0 {
+		return func(next http.Handler) http.Handler {
+			return next
+		}
+	}
+
+	allowedPatterns := normalizePatterns(c.AllowedTypes)
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !mwutil.ShouldProcessMiddleware(r.URL.Path, c.IncludedPaths, c.ExcludedPaths) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			accept := r.Header.Get(httpx.HeaderAccept)
+			if accept != "" && accept != "*/*" {
+				if !matchAcceptHeader(accept, allowedPatterns) {
+					detail := problem.NewDetail(http.StatusNotAcceptable, "Not Acceptable")
+					detail.Detail = "The requested media type is not supported"
+					w.Header().Set(httpx.HeaderAccept, strings.Join(c.AllowedTypes, ", "))
+					_ = detail.RenderAuto(w, r)
+					return
+				}
+			}
+
+			if c.ValidateContentType && r.ContentLength > 0 {
+				contentType := r.Header.Get(httpx.HeaderContentType)
+				contentType, _, _ = strings.Cut(contentType, ";")
+				contentType = strings.TrimSpace(strings.ToLower(contentType))
+
+				if contentType != "" && !matchMediaType(contentType, allowedPatterns) {
+					detail := problem.NewDetail(http.StatusUnsupportedMediaType, "Unsupported Media Type")
+					detail.Detail = "The request body content type is not supported"
+					w.Header().Set(httpx.HeaderAccept, strings.Join(c.AllowedTypes, ", "))
+					_ = detail.RenderAuto(w, r)
+					return
+				}
+			}
+
+			// Wrap response writer to set default content type if needed
+			if c.DefaultType != "" {
+				w = &responseWriter{
+					ResponseWriter: w,
+					defaultType:    c.DefaultType,
+				}
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// responseWriter wraps http.ResponseWriter to set a default Content-Type
+type responseWriter struct {
+	http.ResponseWriter
+	defaultType string
+	wroteHeader bool
+}
+
+func (w *responseWriter) WriteHeader(code int) {
+	if !w.wroteHeader {
+		w.wroteHeader = true
+		if w.Header().Get(httpx.HeaderContentType) == "" {
+			w.Header().Set(httpx.HeaderContentType, w.defaultType)
+		}
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *responseWriter) Write(b []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(b)
+}
+
+// normalizePatterns prepares patterns for matching
+type pattern struct {
+	mediaType   string
+	suffix      string
+	hasWildcard bool
+}
+
+func normalizePatterns(patterns []string) []pattern {
+	result := make([]pattern, 0, len(patterns))
+	for _, p := range patterns {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if p == "" {
+			continue
+		}
+
+		mediaType, suffix, hasSuffix := strings.Cut(p, "+")
+		if !hasSuffix {
+			suffix = ""
+			mediaType = p
+		}
+
+		result = append(result, pattern{
+			mediaType:   mediaType,
+			suffix:      suffix,
+			hasWildcard: strings.Contains(p, "*"),
+		})
+	}
+	return result
+}
+
+// matchAcceptHeader checks if any of the accepted types match allowed patterns
+func matchAcceptHeader(accept string, allowed []pattern) bool {
+	// Parse Accept header (can contain multiple types with q-values)
+	// e.g., "application/json, application/xml;q=0.9, */*;q=0.1"
+	for _, part := range strings.Split(accept, ",") {
+		part = strings.TrimSpace(part)
+		// Remove q-value if present
+		if idx := strings.Index(part, ";"); idx != -1 {
+			part = strings.TrimSpace(part[:idx])
+		}
+
+		if part == "" {
+			continue
+		}
+
+		// */* matches everything
+		if part == "*/*" {
+			return true
+		}
+
+		if matchMediaType(strings.ToLower(part), allowed) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchMediaType checks if a media type matches any of the allowed patterns
+func matchMediaType(mediaType string, allowed []pattern) bool {
+	// Extract suffix from media type if present
+	baseType, suffix, hasSuffix := strings.Cut(mediaType, "+")
+	if !hasSuffix {
+		suffix = ""
+	}
+
+	for _, p := range allowed {
+		if matchPattern(baseType, suffix, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchPattern checks if a media type matches a specific pattern
+func matchPattern(baseType, suffix string, p pattern) bool {
+	// If pattern has a suffix requirement, check it
+	if p.suffix != "" {
+		// If media type has no suffix, check if the last part of baseType matches the suffix
+		// e.g., "application/json" with suffix "json" should match "*+json"
+		if suffix == "" {
+			// Check if baseType ends with "/" + p.suffix (e.g., "/json")
+			if strings.HasSuffix(baseType, "/"+p.suffix) {
+				// Now match the base type part before the suffix
+				baseWithoutSuffix := baseType[:len(baseType)-len(p.suffix)-1]
+				if p.hasWildcard {
+					return matchWildcard(baseWithoutSuffix, p.mediaType)
+				}
+				return baseWithoutSuffix == p.mediaType
+			}
+			// Also try matching full type against pattern (for cases like "json" matching "*+json")
+			if p.hasWildcard {
+				fullPattern := p.mediaType + "+" + p.suffix
+				if matchWildcard(baseType, fullPattern) {
+					return true
+				}
+			}
+			return false
+		}
+		if suffix != p.suffix {
+			return false
+		}
+	}
+
+	// Match the base type (with wildcard support)
+	if p.hasWildcard {
+		return matchWildcard(baseType, p.mediaType)
+	}
+	return baseType == p.mediaType
+}
+
+// matchWildcard matches a media type against a pattern with wildcards
+func matchWildcard(mediaType, pattern string) bool {
+	// Simple wildcard matching - * matches any sequence
+	parts := strings.Split(pattern, "*")
+
+	// No wildcards (shouldn't happen due to hasWildcard check)
+	if len(parts) == 1 {
+		return mediaType == pattern
+	}
+
+	// Check prefix
+	if !strings.HasPrefix(mediaType, parts[0]) {
+		return false
+	}
+
+	// Move past the prefix
+	mediaType = mediaType[len(parts[0]):]
+
+	// Match remaining parts
+	for i := 1; i < len(parts); i++ {
+		part := parts[i]
+		if part == "" {
+			// Trailing wildcard
+			if i == len(parts)-1 {
+				return true
+			}
+			continue
+		}
+
+		idx := strings.Index(mediaType, part)
+		if idx == -1 {
+			return false
+		}
+		mediaType = mediaType[idx+len(part):]
+	}
+
+	// If we've consumed the entire media type, it's a match
+	return mediaType == ""
+}

--- a/middleware/mediatype/media_type_test.go
+++ b/middleware/mediatype/media_type_test.go
@@ -1,0 +1,284 @@
+package mediatype
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/alexferl/zerohttp/httpx"
+	"github.com/alexferl/zerohttp/zhtest"
+)
+
+func TestMediaTypeAcceptValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		accept     string
+		expectNext bool
+		expectCode int
+	}{
+		{"allowed exact type", "application/vnd.api+json", true, http.StatusOK},
+		{"allowed wildcard suffix", "application/custom+json", true, http.StatusOK},
+		{"disallowed type", "text/plain", false, http.StatusNotAcceptable},
+		{"disallowed xml", "application/xml", false, http.StatusNotAcceptable},
+		{"*/* allowed", "*/*", true, http.StatusOK},
+		{"no accept header", "", true, http.StatusOK},
+		{"multiple with valid", "text/plain, application/vnd.api+json", true, http.StatusOK},
+		{"multiple invalid", "text/plain, application/xml", false, http.StatusNotAcceptable},
+		{"with q-value", "application/vnd.api+json;q=0.9", true, http.StatusOK},
+		{"case insensitive", "APPLICATION/VND.API+JSON", true, http.StatusOK},
+		{"whitespace trimmed", " application/vnd.api+json ", true, http.StatusOK},
+		{"malformed accept header rejected", ";;;", false, http.StatusNotAcceptable},
+		{"q-value ignored", "application/vnd.api+json;q=0", true, http.StatusOK},
+		{"accept with charset", "application/vnd.api+json; charset=utf-8", true, http.StatusOK},
+	}
+
+	middleware := New(Config{AllowedTypes: []string{"application/vnd.api+json", "application/*+json"}})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			if tt.accept != "" {
+				req.Header.Set(httpx.HeaderAccept, tt.accept)
+			}
+
+			rr := httptest.NewRecorder()
+			nextCalled := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+			middleware(next).ServeHTTP(rr, req)
+
+			zhtest.AssertEqual(t, tt.expectNext, nextCalled)
+			zhtest.AssertWith(t, rr).Status(tt.expectCode)
+		})
+	}
+}
+
+func TestMediaTypeContentTypeValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		body        string
+		expectNext  bool
+		expectCode  int
+	}{
+		{"allowed vendor type", "application/vnd.api+json", `{"test": "data"}`, true, http.StatusOK},
+		{"allowed with suffix", "application/custom+json", `{"test": "data"}`, true, http.StatusOK},
+		{"disallowed plain json", "application/json", `{"test": "data"}`, false, http.StatusUnsupportedMediaType},
+		{"disallowed text", "text/plain", "plain text", false, http.StatusUnsupportedMediaType},
+		{"empty body skipped", "text/plain", "", true, http.StatusOK},
+		{"case insensitive", "APPLICATION/VND.API+JSON", `{"test": "data"}`, true, http.StatusOK},
+		{"charset parameter", "application/vnd.api+json; charset=utf-8", `{"test": "data"}`, true, http.StatusOK},
+		{"boundary parameter", "multipart/form-data; boundary=----WebKit", "form data", false, http.StatusUnsupportedMediaType},
+		{"whitespace in content-type", " application/vnd.api+json ", `{"test": "data"}`, true, http.StatusOK},
+	}
+
+	middleware := New(Config{
+		AllowedTypes:        []string{"application/vnd.api+json", "application/*+json"},
+		ValidateContentType: true,
+	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req *http.Request
+			if tt.body != "" {
+				req = httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(tt.body))
+			} else {
+				req = httptest.NewRequest(http.MethodPost, "/test", nil)
+			}
+			if tt.contentType != "" {
+				req.Header.Set(httpx.HeaderContentType, tt.contentType)
+			}
+
+			rr := httptest.NewRecorder()
+			nextCalled := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+			middleware(next).ServeHTTP(rr, req)
+
+			zhtest.AssertEqual(t, tt.expectNext, nextCalled)
+			zhtest.AssertWith(t, rr).Status(tt.expectCode)
+		})
+	}
+}
+
+func TestMediaTypeWildcardPatterns(t *testing.T) {
+	tests := []struct {
+		name       string
+		accept     string
+		expectNext bool
+	}{
+		{"exact match", "application/vnd.api+json", true},
+		{"company wildcard", "application/vnd.company.resource+json", true},
+		{"other company", "application/vnd.other+json", true},
+		{"no match wrong suffix", "application/vnd.api+xml", false},
+		{"no match wrong type", "text/plain", false},
+	}
+
+	middleware := New(Config{AllowedTypes: []string{"application/vnd.*+json"}})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set(httpx.HeaderAccept, tt.accept)
+
+			rr := httptest.NewRecorder()
+			nextCalled := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+			middleware(next).ServeHTTP(rr, req)
+
+			zhtest.AssertEqual(t, tt.expectNext, nextCalled)
+		})
+	}
+}
+
+func TestMediaTypeDefaultType(t *testing.T) {
+	tests := []struct {
+		name                string
+		accept              string
+		expectContentType   string
+		expectHeaderPresent bool
+	}{
+		{"*/* gets default", "*/*", "application/vnd.api+json", true},
+		{"no accept gets default", "", "application/vnd.api+json", true},
+		{"specific accept", "application/vnd.api+json", "application/vnd.api+json", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			middleware := New(Config{
+				AllowedTypes: []string{"application/vnd.api+json"},
+				DefaultType:  "application/vnd.api+json",
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			if tt.accept != "" {
+				req.Header.Set(httpx.HeaderAccept, tt.accept)
+			}
+
+			rr := httptest.NewRecorder()
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(`{"test": "data"}`))
+			})
+			middleware(next).ServeHTTP(rr, req)
+
+			zhtest.AssertWith(t, rr).Status(http.StatusOK)
+			if tt.expectHeaderPresent {
+				zhtest.AssertEqual(t, tt.expectContentType, rr.Header().Get(httpx.HeaderContentType))
+			}
+		})
+	}
+}
+
+func TestMediaTypeNoValidation(t *testing.T) {
+	middleware := New()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set(httpx.HeaderAccept, "text/plain")
+
+	rr := httptest.NewRecorder()
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+	middleware(next).ServeHTTP(rr, req)
+
+	zhtest.AssertTrue(t, nextCalled)
+	zhtest.AssertWith(t, rr).Status(http.StatusOK)
+}
+
+func TestMediaTypeExcludedPaths(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		expectNext bool
+	}{
+		{"excluded /health", "/health", true},
+		{"excluded prefix /public/", "/public/css", true},
+		{"not excluded /api", "/api", false},
+	}
+
+	middleware := New(Config{
+		AllowedTypes:  []string{"application/json"},
+		ExcludedPaths: []string{"/health", "/public/"},
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			req.Header.Set(httpx.HeaderAccept, "text/plain")
+
+			rr := httptest.NewRecorder()
+			nextCalled := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+			middleware(next).ServeHTTP(rr, req)
+
+			zhtest.AssertEqual(t, tt.expectNext, nextCalled)
+		})
+	}
+}
+
+func TestMediaTypeBothExcludedAndIncludedPathsPanics(t *testing.T) {
+	zhtest.AssertPanic(t, func() {
+		_ = New(Config{
+			AllowedTypes:  []string{"application/json"},
+			ExcludedPaths: []string{"/health"},
+			IncludedPaths: []string{"/api"},
+		})
+	})
+}
+
+func TestMatchWildcard(t *testing.T) {
+	tests := []struct {
+		pattern string
+		input   string
+		match   bool
+	}{
+		{"application/*", "application/json", true},
+		{"application/*", "application/xml", true},
+		{"application/*", "text/plain", false},
+		{"application/vnd.*+json", "application/vnd.api+json", true},
+		{"application/vnd.*+json", "application/vnd.company.resource+json", true},
+		{"application/vnd.*+json", "application/vnd.api+xml", false},
+		{"*+json", "application/json", false},
+		{"*+json", "application/vnd.api+json", true},
+		{"*+json", "application/xml", false},
+		{"application/*+json", "application/json", false},
+		{"application/*+json", "application/vnd.api+json", true},
+		{"application/json*", "application/json", true},
+		{"application/json*", "application/json-patch", true},
+		{"application/*xml*", "application/xml", true},
+		{"application/*xml*", "application/vnd.xml+json", true},
+		{"*", "anything", true},
+		{"*", "", true},
+		{"", "", true},
+		{"", "something", false},
+		{"application/*/*", "application/api/v1", true},
+		{"application/*/*", "application/api", false},
+		{"*/*", "application/json", true},
+		{"*/*", "text/plain", true},
+		{"application/json", "application/json", true},
+		{"application/json", "application/xml", false},
+		{"application/**", "application/json", true},
+		{"application/*", "application/", true},
+		{"*/json", "application/json", true},
+		{"*/json", "text/json", true},
+		{"*/json", "application/xml", false},
+		{"*/*+json", "application/vnd.api+json", true},
+		{"*/*+json", "application/json", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"_"+tt.input, func(t *testing.T) {
+			result := matchWildcard(tt.input, tt.pattern)
+			zhtest.AssertEqual(t, tt.match, result)
+		})
+	}
+}


### PR DESCRIPTION
…support

Adds new mediatype middleware for validating Accept and Content-Type headers against patterns with wildcard and suffix matching.

Features:
- Pattern matching with * wildcards (e.g., application/vnd.*+json)
- Suffix matching for +json, +xml, etc.
- Optional Content-Type validation on requests
- DefaultType response header when client sends */*
- Path exclusion/inclusion support

Includes example demonstrating API versioning with vendor media types.