### PR TITLE
fix(mediatype): correct DefaultType to set Accept header on request

### DIFF
--- a/examples/middleware/mediatype/README.md
+++ b/examples/middleware/mediatype/README.md
@@ -1,0 +1,55 @@
+# Media Type Example
+
+This example demonstrates media type negotiation and validation with zerohttp.
+
+## Features
+
+- Accept header validation against allowed media types
+- Vendor media type support (+json suffix matching)
+- Default media type for clients that accept anything (*/*)
+- Versioned API responses based on Accept header
+
+## Running the Example
+
+```bash
+go run .
+```
+
+The server starts on `http://localhost:8080`.
+
+## Endpoints
+
+| Endpoint        | Description                   |
+|-----------------|-------------------------------|
+| `GET /api/users` | Returns users (versioned)    |
+
+## Test Commands
+
+### With default version (no Accept header)
+```bash
+curl -i http://localhost:8080/api/users
+```
+
+### With V1 media type
+```bash
+curl -i http://localhost:8080/api/users \
+  -H 'Accept: application/vnd.api.v1+json'
+```
+
+### With V2 media type
+```bash
+curl -i http://localhost:8080/api/users \
+  -H 'Accept: application/vnd.api.v2+json'
+```
+
+### With unsupported media type (will fail with 406)
+```bash
+curl -i http://localhost:8080/api/users \
+  -H 'Accept: application/xml'
+```
+
+### With */* (gets default version)
+```bash
+curl -i http://localhost:8080/api/users \
+  -H 'Accept: */*'
+```

--- a/middleware/mediatype/config.go
+++ b/middleware/mediatype/config.go
@@ -12,8 +12,9 @@ type Config struct {
 	AllowedTypes []string
 
 	// DefaultType is the media type to use when the client accepts any type (*/*)
-	// or when no Accept header is provided. This is set as the response Content-Type.
-	// If empty, no Content-Type is set automatically.
+	// or when no Accept header is provided. This value is set as the Accept header
+	// on the request, allowing handlers to perform content negotiation.
+	// If empty, the Accept header is left as-is.
 	// Default: ""
 	DefaultType string
 

--- a/middleware/mediatype/media_type.go
+++ b/middleware/mediatype/media_type.go
@@ -44,13 +44,17 @@ func New(cfg ...Config) func(http.Handler) http.Handler {
 				if !matchAcceptHeader(accept, allowedPatterns) {
 					detail := problem.NewDetail(http.StatusNotAcceptable, "Not Acceptable")
 					detail.Detail = "The requested media type is not supported"
+					// NOTE: Accept header in response is non-standard here but commonly used
+					// to indicate what Content-Types the server accepts for the request body.
 					w.Header().Set(httpx.HeaderAccept, strings.Join(c.AllowedTypes, ", "))
 					_ = detail.RenderAuto(w, r)
 					return
 				}
 			}
 
-			if c.ValidateContentType && r.ContentLength > 0 {
+			// ValidateContentType check: ContentLength != 0 covers both explicit sizes (> 0)
+			// and unknown chunked bodies (-1). Go sets ContentLength = -1 for chunked encoding.
+			if c.ValidateContentType && r.ContentLength != 0 && r.Body != nil && r.Body != http.NoBody {
 				contentType := r.Header.Get(httpx.HeaderContentType)
 				contentType, _, _ = strings.Cut(contentType, ";")
 				contentType = strings.TrimSpace(strings.ToLower(contentType))
@@ -58,13 +62,15 @@ func New(cfg ...Config) func(http.Handler) http.Handler {
 				if contentType != "" && !matchMediaType(contentType, allowedPatterns) {
 					detail := problem.NewDetail(http.StatusUnsupportedMediaType, "Unsupported Media Type")
 					detail.Detail = "The request body content type is not supported"
+					// NOTE: Accept header in response is non-standard here but commonly used
+					// to indicate what Content-Types the server accepts for the request body.
 					w.Header().Set(httpx.HeaderAccept, strings.Join(c.AllowedTypes, ", "))
 					_ = detail.RenderAuto(w, r)
 					return
 				}
 			}
 
-			// Set default Accept header if client accepts anything
+			// Normalize Accept so downstream handlers always receive a concrete media type.
 			if c.DefaultType != "" {
 				accept := r.Header.Get(httpx.HeaderAccept)
 				if accept == "" || accept == "*/*" {
@@ -79,9 +85,10 @@ func New(cfg ...Config) func(http.Handler) http.Handler {
 
 // normalizePatterns prepares patterns for matching
 type pattern struct {
-	mediaType   string
-	suffix      string
-	hasWildcard bool
+	mediaType            string
+	suffix               string
+	hasMediaTypeWildcard bool
+	hasSuffixWildcard    bool
 }
 
 func normalizePatterns(patterns []string) []pattern {
@@ -92,16 +99,13 @@ func normalizePatterns(patterns []string) []pattern {
 			continue
 		}
 
-		mediaType, suffix, hasSuffix := strings.Cut(p, "+")
-		if !hasSuffix {
-			suffix = ""
-			mediaType = p
-		}
+		mediaType, suffix, _ := strings.Cut(p, "+")
 
 		result = append(result, pattern{
-			mediaType:   mediaType,
-			suffix:      suffix,
-			hasWildcard: strings.Contains(p, "*"),
+			mediaType:            mediaType,
+			suffix:               suffix,
+			hasMediaTypeWildcard: strings.Contains(mediaType, "*"),
+			hasSuffixWildcard:    strings.Contains(suffix, "*"),
 		})
 	}
 	return result
@@ -111,6 +115,9 @@ func normalizePatterns(patterns []string) []pattern {
 func matchAcceptHeader(accept string, allowed []pattern) bool {
 	// Parse Accept header (can contain multiple types with q-values)
 	// e.g., "application/json, application/xml;q=0.9, */*;q=0.1"
+	// NOTE: q-values are stripped and not used for priority ordering.
+	// This middleware only validates presence of an acceptable type, not preference.
+	// If format selection is added in the future, q-values must be respected per RFC 7231 §5.3.
 	for _, part := range strings.Split(accept, ",") {
 		part = strings.TrimSpace(part)
 		// Remove q-value if present
@@ -135,64 +142,69 @@ func matchAcceptHeader(accept string, allowed []pattern) bool {
 }
 
 // matchMediaType checks if a media type matches any of the allowed patterns
+// Supports bidirectional wildcard matching per RFC 7231 §5.3.2:
+// - Server pattern wildcards (e.g., application/*) match client types
+// - Client wildcard types (e.g., application/*) match server allowed types
 func matchMediaType(mediaType string, allowed []pattern) bool {
 	// Extract suffix from media type if present
-	baseType, suffix, hasSuffix := strings.Cut(mediaType, "+")
-	if !hasSuffix {
-		suffix = ""
-	}
+	baseType, suffix, _ := strings.Cut(mediaType, "+")
 
 	for _, p := range allowed {
 		if matchPattern(baseType, suffix, p) {
 			return true
 		}
 	}
+
+	// Bidirectional wildcard: client's wildcard covers a server-allowed type
+	// e.g., client sends "Accept: application/*" should match "application/json"
+	if strings.Contains(mediaType, "*") {
+		for _, p := range allowed {
+			// If client specified a +suffix, the allowed type must also carry that suffix
+			if suffix != "" && p.suffix != suffix {
+				continue
+			}
+			if matchWildcard(strings.ToLower(p.mediaType), baseType) {
+				return true
+			}
+		}
+	}
+
 	return false
 }
 
 // matchPattern checks if a media type matches a specific pattern
 func matchPattern(baseType, suffix string, p pattern) bool {
-	// If pattern has a suffix requirement, check it
-	if p.suffix != "" {
-		// If media type has no suffix, check if the last part of baseType matches the suffix
-		// e.g., "application/json" with suffix "json" should match "*+json"
+	// Match suffix (with wildcard support if present)
+	if p.hasSuffixWildcard {
+		// Pattern like "application/vnd+*" requires input to HAVE a suffix
 		if suffix == "" {
-			// Check if baseType ends with "/" + p.suffix (e.g., "/json")
-			if strings.HasSuffix(baseType, "/"+p.suffix) {
-				// Now match the base type part before the suffix
-				baseWithoutSuffix := baseType[:len(baseType)-len(p.suffix)-1]
-				if p.hasWildcard {
-					return matchWildcard(baseWithoutSuffix, p.mediaType)
-				}
-				return baseWithoutSuffix == p.mediaType
-			}
-			// Also try matching full type against pattern (for cases like "json" matching "*+json")
-			if p.hasWildcard {
-				fullPattern := p.mediaType + "+" + p.suffix
-				if matchWildcard(baseType, fullPattern) {
-					return true
-				}
-			}
 			return false
 		}
-		if suffix != p.suffix {
+		if !matchWildcard(suffix, p.suffix) {
 			return false
 		}
+	} else if p.suffix != suffix {
+		// Both must agree on suffix: either both empty, or both the same value
+		// Only matches literal +suffixes per RFC 6838 §4.2.8
+		return false
 	}
 
 	// Match the base type (with wildcard support)
-	if p.hasWildcard {
+	if p.hasMediaTypeWildcard {
 		return matchWildcard(baseType, p.mediaType)
 	}
 	return baseType == p.mediaType
 }
 
-// matchWildcard matches a media type against a pattern with wildcards
+// matchWildcard matches a media type against a pattern with wildcards.
+// NOTE: Only single-wildcard patterns per segment are fully supported.
+// Patterns with multiple wildcards in the same segment (e.g., "application/x*x*x")
+// use first-match greedy logic and may produce unexpected results.
 func matchWildcard(mediaType, pattern string) bool {
 	// Simple wildcard matching - * matches any sequence
 	parts := strings.Split(pattern, "*")
 
-	// No wildcards (shouldn't happen due to hasWildcard check)
+	// No wildcards (shouldn't happen due to hasMediaTypeWildcard/hasSuffixWildcard check)
 	if len(parts) == 1 {
 		return mediaType == pattern
 	}

--- a/middleware/mediatype/media_type.go
+++ b/middleware/mediatype/media_type.go
@@ -64,41 +64,17 @@ func New(cfg ...Config) func(http.Handler) http.Handler {
 				}
 			}
 
-			// Wrap response writer to set default content type if needed
+			// Set default Accept header if client accepts anything
 			if c.DefaultType != "" {
-				w = &responseWriter{
-					ResponseWriter: w,
-					defaultType:    c.DefaultType,
+				accept := r.Header.Get(httpx.HeaderAccept)
+				if accept == "" || accept == "*/*" {
+					r.Header.Set(httpx.HeaderAccept, c.DefaultType)
 				}
 			}
 
 			next.ServeHTTP(w, r)
 		})
 	}
-}
-
-// responseWriter wraps http.ResponseWriter to set a default Content-Type
-type responseWriter struct {
-	http.ResponseWriter
-	defaultType string
-	wroteHeader bool
-}
-
-func (w *responseWriter) WriteHeader(code int) {
-	if !w.wroteHeader {
-		w.wroteHeader = true
-		if w.Header().Get(httpx.HeaderContentType) == "" {
-			w.Header().Set(httpx.HeaderContentType, w.defaultType)
-		}
-	}
-	w.ResponseWriter.WriteHeader(code)
-}
-
-func (w *responseWriter) Write(b []byte) (int, error) {
-	if !w.wroteHeader {
-		w.WriteHeader(http.StatusOK)
-	}
-	return w.ResponseWriter.Write(b)
 }
 
 // normalizePatterns prepares patterns for matching

--- a/middleware/mediatype/media_type_test.go
+++ b/middleware/mediatype/media_type_test.go
@@ -138,20 +138,19 @@ func TestMediaTypeWildcardPatterns(t *testing.T) {
 
 func TestMediaTypeDefaultType(t *testing.T) {
 	tests := []struct {
-		name                string
-		accept              string
-		expectContentType   string
-		expectHeaderPresent bool
+		name         string
+		accept       string
+		expectAccept string
 	}{
-		{"*/* gets default", "*/*", "application/vnd.api+json", true},
-		{"no accept gets default", "", "application/vnd.api+json", true},
-		{"specific accept", "application/vnd.api+json", "application/vnd.api+json", true},
+		{"*/* gets default", "*/*", "application/vnd.api+json"},
+		{"no accept gets default", "", "application/vnd.api+json"},
+		{"specific accept preserved", "application/vnd.api.v2+json", "application/vnd.api.v2+json"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			middleware := New(Config{
-				AllowedTypes: []string{"application/vnd.api+json"},
+				AllowedTypes: []string{"application/vnd.api+json", "application/vnd.api.v2+json"},
 				DefaultType:  "application/vnd.api+json",
 			})
 
@@ -161,15 +160,15 @@ func TestMediaTypeDefaultType(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
+			var receivedAccept string
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				_, _ = w.Write([]byte(`{"test": "data"}`))
+				receivedAccept = r.Header.Get(httpx.HeaderAccept)
+				w.WriteHeader(http.StatusOK)
 			})
 			middleware(next).ServeHTTP(rr, req)
 
 			zhtest.AssertWith(t, rr).Status(http.StatusOK)
-			if tt.expectHeaderPresent {
-				zhtest.AssertEqual(t, tt.expectContentType, rr.Header().Get(httpx.HeaderContentType))
-			}
+			zhtest.AssertEqual(t, tt.expectAccept, receivedAccept)
 		})
 	}
 }

--- a/middleware/mediatype/media_type_test.go
+++ b/middleware/mediatype/media_type_test.go
@@ -281,3 +281,140 @@ func TestMatchWildcard(t *testing.T) {
 		})
 	}
 }
+
+// TestBidirectionalWildcard tests that client-side wildcards match server allowed types
+func TestBidirectionalWildcard(t *testing.T) {
+	tests := []struct {
+		name       string
+		accept     string
+		expectNext bool
+	}{
+		{"client wildcard type/* matches json", "application/*", true},
+		{"client wildcard type/* matches vendor", "application/vnd.api+json", true},
+		{"client wildcard */* matches everything", "*/*", true},
+		{"client suffix wildcard *+json matches json type", "*+json", true},
+		{"client suffix wildcard *+json does not match xml", "*+xml", false},
+		{"client exact match for plain json", "application/json", true}, // exact match in allowed types
+		{"client full wildcard matches allowed", "*", true},
+	}
+
+	middleware := New(Config{AllowedTypes: []string{"application/json", "application/vnd.api+json"}})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set(httpx.HeaderAccept, tt.accept)
+
+			rr := httptest.NewRecorder()
+			nextCalled := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+			middleware(next).ServeHTTP(rr, req)
+
+			zhtest.AssertEqual(t, tt.expectNext, nextCalled)
+		})
+	}
+}
+
+// TestSuffixWildcardPatterns tests patterns with wildcards in the suffix
+func TestSuffixWildcardPatterns(t *testing.T) {
+	tests := []struct {
+		name       string
+		accept     string
+		expectNext bool
+	}{
+		{"wildcard suffix matches json", "application/vnd.discogs+json", true},
+		{"wildcard suffix matches xml", "application/vnd.discogs+xml", true},
+		{"no suffix does not match", "application/vnd.discogs", false},
+		{"different prefix does not match", "application/other+json", false},
+	}
+
+	middleware := New(Config{AllowedTypes: []string{"application/vnd.discogs+*"}})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set(httpx.HeaderAccept, tt.accept)
+
+			rr := httptest.NewRecorder()
+			nextCalled := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+			middleware(next).ServeHTTP(rr, req)
+
+			zhtest.AssertEqual(t, tt.expectNext, nextCalled)
+		})
+	}
+}
+
+// TestContentTypeValidationChunked tests that chunked request bodies are validated
+func TestContentTypeValidationChunked(t *testing.T) {
+	middleware := New(Config{
+		AllowedTypes:        []string{"application/json"},
+		ValidateContentType: true,
+	})
+
+	// Create a request and force ContentLength = -1 to simulate chunked encoding
+	req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"test": "data"}`))
+	req.ContentLength = -1                                     // simulate chunked: unknown length
+	req.Header.Set(httpx.HeaderContentType, "application/xml") // disallowed type
+
+	rr := httptest.NewRecorder()
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+	middleware(next).ServeHTTP(rr, req)
+
+	zhtest.AssertFalse(t, nextCalled)
+	zhtest.AssertWith(t, rr).Status(http.StatusUnsupportedMediaType)
+}
+
+// TestSymmetricSuffixMatching tests that suffix matching is symmetric
+func TestSymmetricSuffixMatching(t *testing.T) {
+	tests := []struct {
+		name       string
+		middleware func(http.Handler) http.Handler
+		accept     string
+		expectNext bool
+	}{
+		// Pattern has no suffix, request has suffix - should NOT match
+		{
+			"json pattern does not match json+foo",
+			New(Config{AllowedTypes: []string{"application/json"}}),
+			"application/json+foo", false,
+		},
+		// Pattern has suffix, request has no suffix - should NOT match
+		{
+			"json+suffix pattern does not match json",
+			New(Config{AllowedTypes: []string{"application/json+foo"}}),
+			"application/json", false,
+		},
+		// Both have same suffix - should match
+		{
+			"json+suffix pattern matches json+suffix",
+			New(Config{AllowedTypes: []string{"application/json+foo"}}),
+			"application/json+foo", true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set(httpx.HeaderAccept, tt.accept)
+
+			rr := httptest.NewRecorder()
+			nextCalled := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+			tt.middleware(next).ServeHTTP(rr, req)
+
+			zhtest.AssertEqual(t, tt.expectNext, nextCalled)
+		})
+	}
+}


### PR DESCRIPTION
The DefaultType config was incorrectly trying to set the response Content-Type via a response writer wrapper. This never worked in practice because renderers (R.JSON, etc.) always set their own Content-Type headers, overwriting the middleware's value.

Changed DefaultType to instead set the Accept header on the request when the client sends an empty Accept header or */*, allowing handlers to perform proper content negotiation.