### PR TITLE
feat(mediatype): add response media type header config

### DIFF
--- a/middleware/mediatype/config.go
+++ b/middleware/mediatype/config.go
@@ -23,6 +23,16 @@ type Config struct {
 	// Default: false
 	ValidateContentType bool
 
+	// ResponseTypeHeader is the response header name to set with the effective
+	// media type. e.g. "X-App-Media-Type"
+	// Default: ""
+	ResponseTypeHeader string
+
+	// ResponseTypeValue is the value written to ResponseTypeHeader.
+	// Can be a short alias (e.g. "app.v1") or a full media type.
+	// Falls back to DefaultType if empty.
+	ResponseTypeValue string
+
 	// ExcludedPaths contains paths that skip media type validation.
 	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
 	// Cannot be used with IncludedPaths - setting both will panic.
@@ -43,6 +53,8 @@ var DefaultConfig = Config{
 	AllowedTypes:        []string{},
 	DefaultType:         "",
 	ValidateContentType: false,
+	ResponseTypeHeader:  "",
+	ResponseTypeValue:   "",
 	ExcludedPaths:       []string{},
 	IncludedPaths:       []string{},
 }

--- a/middleware/mediatype/config_test.go
+++ b/middleware/mediatype/config_test.go
@@ -10,6 +10,8 @@ func TestDefaultConfig(t *testing.T) {
 	zhtest.AssertEqual(t, 0, len(DefaultConfig.AllowedTypes))
 	zhtest.AssertEqual(t, "", DefaultConfig.DefaultType)
 	zhtest.AssertEqual(t, false, DefaultConfig.ValidateContentType)
+	zhtest.AssertEqual(t, "", DefaultConfig.ResponseTypeHeader)
+	zhtest.AssertEqual(t, "", DefaultConfig.ResponseTypeValue)
 	zhtest.AssertEqual(t, 0, len(DefaultConfig.ExcludedPaths))
 	zhtest.AssertEqual(t, 0, len(DefaultConfig.IncludedPaths))
 }
@@ -57,6 +59,40 @@ func TestConfigMerge(t *testing.T) {
 				AllowedTypes:        []string{"application/json"},
 				DefaultType:         "",
 				ValidateContentType: true,
+				ExcludedPaths:       []string{},
+				IncludedPaths:       []string{},
+			},
+		},
+		{
+			name: "with response type header",
+			config: Config{
+				AllowedTypes:       []string{"application/json"},
+				ResponseTypeHeader: "X-Media-Type",
+				ResponseTypeValue:  "v1",
+			},
+			expected: Config{
+				AllowedTypes:        []string{"application/json"},
+				DefaultType:         "",
+				ValidateContentType: false,
+				ResponseTypeHeader:  "X-Media-Type",
+				ResponseTypeValue:   "v1",
+				ExcludedPaths:       []string{},
+				IncludedPaths:       []string{},
+			},
+		},
+		{
+			name: "with response type header fallback to default",
+			config: Config{
+				AllowedTypes:       []string{"application/json"},
+				DefaultType:        "application/json",
+				ResponseTypeHeader: "X-Media-Type",
+			},
+			expected: Config{
+				AllowedTypes:        []string{"application/json"},
+				DefaultType:         "application/json",
+				ValidateContentType: false,
+				ResponseTypeHeader:  "X-Media-Type",
+				ResponseTypeValue:   "",
 				ExcludedPaths:       []string{},
 				IncludedPaths:       []string{},
 			},

--- a/middleware/mediatype/media_type.go
+++ b/middleware/mediatype/media_type.go
@@ -32,11 +32,23 @@ func New(cfg ...Config) func(http.Handler) http.Handler {
 
 	allowedPatterns := normalizePatterns(c.AllowedTypes)
 
+	// Determine the effective media type at construction time.
+	// ResponseTypeValue takes precedence, falls back to DefaultType.
+	effectiveType := c.ResponseTypeValue
+	if effectiveType == "" {
+		effectiveType = c.DefaultType
+	}
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if !mwutil.ShouldProcessMiddleware(r.URL.Path, c.IncludedPaths, c.ExcludedPaths) {
 				next.ServeHTTP(w, r)
 				return
+			}
+
+			// Set response header early so it's present even in error responses.
+			if c.ResponseTypeHeader != "" && effectiveType != "" {
+				w.Header().Set(c.ResponseTypeHeader, effectiveType)
 			}
 
 			accept := r.Header.Get(httpx.HeaderAccept)

--- a/middleware/mediatype/media_type_test.go
+++ b/middleware/mediatype/media_type_test.go
@@ -373,6 +373,109 @@ func TestContentTypeValidationChunked(t *testing.T) {
 	zhtest.AssertWith(t, rr).Status(http.StatusUnsupportedMediaType)
 }
 
+func TestMediaTypeResponseTypeHeader(t *testing.T) {
+	tests := []struct {
+		name               string
+		responseTypeHeader string
+		responseTypeValue  string
+		defaultType        string
+		expectHeader       string
+		expectValue        string
+	}{
+		{"header with explicit value", "X-Media-Type", "v1", "", "X-Media-Type", "v1"},
+		{"header falls back to default type", "X-Media-Type", "", "application/json", "X-Media-Type", "application/json"},
+		{"header with value takes precedence over default", "X-Media-Type", "custom.v2", "application/json", "X-Media-Type", "custom.v2"},
+		{"no header when responseTypeHeader empty", "", "", "application/json", "", ""},
+		{"no header when both value and default empty", "X-Media-Type", "", "", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			middleware := New(Config{
+				AllowedTypes:       []string{"application/json"},
+				DefaultType:        tt.defaultType,
+				ResponseTypeHeader: tt.responseTypeHeader,
+				ResponseTypeValue:  tt.responseTypeValue,
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set(httpx.HeaderAccept, "application/json")
+
+			rr := httptest.NewRecorder()
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+			middleware(next).ServeHTTP(rr, req)
+
+			zhtest.AssertWith(t, rr).Status(http.StatusOK)
+			if tt.expectHeader != "" {
+				zhtest.AssertWith(t, rr).Header(tt.expectHeader, tt.expectValue)
+			} else {
+				zhtest.AssertWith(t, rr).HeaderNotExists("X-Media-Type")
+			}
+		})
+	}
+}
+
+func TestMediaTypeResponseTypeHeaderWithWildcardAccept(t *testing.T) {
+	middleware := New(Config{
+		AllowedTypes:       []string{"application/json", "application/xml"},
+		DefaultType:        "application/json",
+		ResponseTypeHeader: "X-Response-Type",
+	})
+
+	tests := []struct {
+		name         string
+		accept       string
+		expectHeader string
+	}{
+		{"*/* accept gets default", "*/*", "application/json"},
+		{"no accept header gets default", "", "application/json"},
+		{"specific accept is allowed", "application/xml", "application/json"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			if tt.accept != "" {
+				req.Header.Set(httpx.HeaderAccept, tt.accept)
+			}
+
+			rr := httptest.NewRecorder()
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+			middleware(next).ServeHTTP(rr, req)
+
+			zhtest.AssertWith(t, rr).Status(http.StatusOK)
+			zhtest.AssertWith(t, rr).Header("X-Response-Type", tt.expectHeader)
+		})
+	}
+}
+
+func TestMediaTypeResponseTypeHeaderWithValidationFailure(t *testing.T) {
+	// ResponseTypeHeader should still be set even when validation fails
+	middleware := New(Config{
+		AllowedTypes:       []string{"application/json"},
+		ResponseTypeHeader: "X-Media-Type",
+		ResponseTypeValue:  "api.v1",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set(httpx.HeaderAccept, "text/plain")
+
+	rr := httptest.NewRecorder()
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("next should not be called when validation fails")
+	})
+	middleware(next).ServeHTTP(rr, req)
+
+	// Header should be set BEFORE the error response is returned
+	zhtest.AssertWith(t, rr).Status(http.StatusNotAcceptable)
+	// Header is set before validation check, so it should exist
+	zhtest.AssertWith(t, rr).Header("X-Media-Type", "api.v1")
+}
+
 // TestSymmetricSuffixMatching tests that suffix matching is symmetric
 func TestSymmetricSuffixMatching(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Add ResponseTypeHeader and ResponseTypeValue to allow setting a response header (e.g., X-App-Media-Type) with the effective media type.