### PR TITLE
feat(mediatype): add ResponseTypeFunc for dynamic response headers

### DIFF
--- a/middleware/mediatype/config.go
+++ b/middleware/mediatype/config.go
@@ -28,10 +28,21 @@ type Config struct {
 	// Default: ""
 	ResponseTypeHeader string
 
-	// ResponseTypeValue is the value written to ResponseTypeHeader.
-	// Can be a short alias (e.g. "app.v1") or a full media type.
-	// Falls back to DefaultType if empty.
-	ResponseTypeValue string
+	// ResponseTypeFunc transforms the negotiated media type into the response header value.
+	// The negotiated type is either the client's requested type (if matched) or DefaultType.
+	// If nil, the negotiated type is used as-is.
+	//
+	// Use VendorShortType to extract short identifiers from vendor types:
+	//
+	//    "application/vnd.app.v1+json" -> "app.v1"
+	//
+	// Or provide a custom function for different formatting:
+	//
+	//    ResponseTypeFunc: func(t string) string {
+	//        return "version=" + t
+	//    }
+	//    // "application/vnd.app.v1+json" -> "version=application/vnd.app.v1+json"
+	ResponseTypeFunc func(string) string
 
 	// ExcludedPaths contains paths that skip media type validation.
 	// Supports exact matches, prefixes (ending with /), and wildcards (ending with *).
@@ -54,7 +65,7 @@ var DefaultConfig = Config{
 	DefaultType:         "",
 	ValidateContentType: false,
 	ResponseTypeHeader:  "",
-	ResponseTypeValue:   "",
+	ResponseTypeFunc:    nil,
 	ExcludedPaths:       []string{},
 	IncludedPaths:       []string{},
 }

--- a/middleware/mediatype/config_test.go
+++ b/middleware/mediatype/config_test.go
@@ -11,7 +11,7 @@ func TestDefaultConfig(t *testing.T) {
 	zhtest.AssertEqual(t, "", DefaultConfig.DefaultType)
 	zhtest.AssertEqual(t, false, DefaultConfig.ValidateContentType)
 	zhtest.AssertEqual(t, "", DefaultConfig.ResponseTypeHeader)
-	zhtest.AssertEqual(t, "", DefaultConfig.ResponseTypeValue)
+	zhtest.AssertNil(t, DefaultConfig.ResponseTypeFunc)
 	zhtest.AssertEqual(t, 0, len(DefaultConfig.ExcludedPaths))
 	zhtest.AssertEqual(t, 0, len(DefaultConfig.IncludedPaths))
 }
@@ -68,14 +68,13 @@ func TestConfigMerge(t *testing.T) {
 			config: Config{
 				AllowedTypes:       []string{"application/json"},
 				ResponseTypeHeader: "X-Media-Type",
-				ResponseTypeValue:  "v1",
+				ResponseTypeFunc:   func(t string) string { return "v1" },
 			},
 			expected: Config{
 				AllowedTypes:        []string{"application/json"},
 				DefaultType:         "",
 				ValidateContentType: false,
 				ResponseTypeHeader:  "X-Media-Type",
-				ResponseTypeValue:   "v1",
 				ExcludedPaths:       []string{},
 				IncludedPaths:       []string{},
 			},
@@ -92,7 +91,6 @@ func TestConfigMerge(t *testing.T) {
 				DefaultType:         "application/json",
 				ValidateContentType: false,
 				ResponseTypeHeader:  "X-Media-Type",
-				ResponseTypeValue:   "",
 				ExcludedPaths:       []string{},
 				IncludedPaths:       []string{},
 			},

--- a/middleware/mediatype/media_type.go
+++ b/middleware/mediatype/media_type.go
@@ -32,13 +32,6 @@ func New(cfg ...Config) func(http.Handler) http.Handler {
 
 	allowedPatterns := normalizePatterns(c.AllowedTypes)
 
-	// Determine the effective media type at construction time.
-	// ResponseTypeValue takes precedence, falls back to DefaultType.
-	effectiveType := c.ResponseTypeValue
-	if effectiveType == "" {
-		effectiveType = c.DefaultType
-	}
-
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if !mwutil.ShouldProcessMiddleware(r.URL.Path, c.IncludedPaths, c.ExcludedPaths) {
@@ -46,12 +39,10 @@ func New(cfg ...Config) func(http.Handler) http.Handler {
 				return
 			}
 
-			// Set response header early so it's present even in error responses.
-			if c.ResponseTypeHeader != "" && effectiveType != "" {
-				w.Header().Set(c.ResponseTypeHeader, effectiveType)
-			}
-
 			accept := r.Header.Get(httpx.HeaderAccept)
+
+			// Determine the negotiated media type for the response header.
+			negotiatedType := c.DefaultType
 			if accept != "" && accept != "*/*" {
 				if !matchAcceptHeader(accept, allowedPatterns) {
 					detail := problem.NewDetail(http.StatusNotAcceptable, "Not Acceptable")
@@ -62,6 +53,22 @@ func New(cfg ...Config) func(http.Handler) http.Handler {
 					_ = detail.RenderAuto(w, r)
 					return
 				}
+				// Client specified a concrete type - find what matched
+				negotiatedType = findMatchingType(accept, allowedPatterns)
+				if negotiatedType == "" {
+					negotiatedType = c.DefaultType
+				}
+			}
+
+			// Compute effective type for response header
+			effectiveType := negotiatedType
+			if c.ResponseTypeFunc != nil {
+				effectiveType = c.ResponseTypeFunc(negotiatedType)
+			}
+
+			// Set response header early so it's present even in error responses.
+			if c.ResponseTypeHeader != "" && effectiveType != "" {
+				w.Header().Set(c.ResponseTypeHeader, effectiveType)
 			}
 
 			// ValidateContentType check: ContentLength != 0 covers both explicit sizes (> 0)
@@ -121,6 +128,29 @@ func normalizePatterns(patterns []string) []pattern {
 		})
 	}
 	return result
+}
+
+// findMatchingType parses the Accept header and returns the first matching
+// allowed type (normalized to lowercase). Returns empty string if no match.
+func findMatchingType(accept string, allowed []pattern) string {
+	for _, part := range strings.Split(accept, ",") {
+		part = strings.TrimSpace(part)
+		if idx := strings.Index(part, ";"); idx != -1 {
+			part = strings.TrimSpace(part[:idx])
+		}
+		if part == "" {
+			continue
+		}
+		if part == "*/*" {
+			continue // skip wildcard, we want a concrete type
+		}
+
+		lowerPart := strings.ToLower(part)
+		if matchMediaType(lowerPart, allowed) {
+			return lowerPart
+		}
+	}
+	return ""
 }
 
 // matchAcceptHeader checks if any of the accepted types match allowed patterns
@@ -249,4 +279,20 @@ func matchWildcard(mediaType, pattern string) bool {
 
 	// If we've consumed the entire media type, it's a match
 	return mediaType == ""
+}
+
+// VendorShortType extracts a short identifier from a vendor media type.
+// It is intended for use as a ResponseTypeFunc.
+//
+//	"application/vnd.app.v1+json" -> "app.v1"
+//	"application/vnd.app.v2+json" -> "app.v2"
+//	"application/json"            -> "application/json" (not a vendor type, returned as-is)
+func VendorShortType(mediaType string) string {
+	s := strings.TrimPrefix(mediaType, "application/vnd.")
+	if s == mediaType {
+		// Not a vnd type, return as-is
+		return mediaType
+	}
+	s, _, _ = strings.Cut(s, "+")
+	return s
 }

--- a/middleware/mediatype/media_type_test.go
+++ b/middleware/mediatype/media_type_test.go
@@ -377,16 +377,17 @@ func TestMediaTypeResponseTypeHeader(t *testing.T) {
 	tests := []struct {
 		name               string
 		responseTypeHeader string
-		responseTypeValue  string
+		responseTypeFunc   func(string) string
 		defaultType        string
+		accept             string
 		expectHeader       string
 		expectValue        string
 	}{
-		{"header with explicit value", "X-Media-Type", "v1", "", "X-Media-Type", "v1"},
-		{"header falls back to default type", "X-Media-Type", "", "application/json", "X-Media-Type", "application/json"},
-		{"header with value takes precedence over default", "X-Media-Type", "custom.v2", "application/json", "X-Media-Type", "custom.v2"},
-		{"no header when responseTypeHeader empty", "", "", "application/json", "", ""},
-		{"no header when both value and default empty", "X-Media-Type", "", "", "", ""},
+		{name: "header with func returning custom value", responseTypeHeader: "X-Media-Type", responseTypeFunc: func(t string) string { return "v1" }, defaultType: "", accept: "application/json", expectHeader: "X-Media-Type", expectValue: "v1"},
+		{name: "header reflects negotiated type from accept", responseTypeHeader: "X-Media-Type", responseTypeFunc: nil, defaultType: "application/json", accept: "application/json", expectHeader: "X-Media-Type", expectValue: "application/json"},
+		{name: "header with func transforms negotiated type", responseTypeHeader: "X-Media-Type", responseTypeFunc: func(t string) string { return "custom.v2" }, defaultType: "application/json", accept: "application/json", expectHeader: "X-Media-Type", expectValue: "custom.v2"},
+		{name: "no header when responseTypeHeader empty", responseTypeHeader: "", responseTypeFunc: nil, defaultType: "application/json", accept: "application/json", expectHeader: "", expectValue: ""},
+		{name: "no header when nothing to negotiate and default empty", responseTypeHeader: "X-Media-Type", responseTypeFunc: nil, defaultType: "", accept: "", expectHeader: "", expectValue: ""},
 	}
 
 	for _, tt := range tests {
@@ -395,11 +396,13 @@ func TestMediaTypeResponseTypeHeader(t *testing.T) {
 				AllowedTypes:       []string{"application/json"},
 				DefaultType:        tt.defaultType,
 				ResponseTypeHeader: tt.responseTypeHeader,
-				ResponseTypeValue:  tt.responseTypeValue,
+				ResponseTypeFunc:   tt.responseTypeFunc,
 			})
 
 			req := httptest.NewRequest(http.MethodGet, "/test", nil)
-			req.Header.Set(httpx.HeaderAccept, "application/json")
+			if tt.accept != "" {
+				req.Header.Set(httpx.HeaderAccept, tt.accept)
+			}
 
 			rr := httptest.NewRecorder()
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -431,7 +434,7 @@ func TestMediaTypeResponseTypeHeaderWithWildcardAccept(t *testing.T) {
 	}{
 		{"*/* accept gets default", "*/*", "application/json"},
 		{"no accept header gets default", "", "application/json"},
-		{"specific accept is allowed", "application/xml", "application/json"},
+		{"specific accept returns matched type", "application/xml", "application/xml"},
 	}
 
 	for _, tt := range tests {
@@ -454,11 +457,11 @@ func TestMediaTypeResponseTypeHeaderWithWildcardAccept(t *testing.T) {
 }
 
 func TestMediaTypeResponseTypeHeaderWithValidationFailure(t *testing.T) {
-	// ResponseTypeHeader should still be set even when validation fails
+	// ResponseTypeHeader is only set when validation passes (or no validation needed)
 	middleware := New(Config{
 		AllowedTypes:       []string{"application/json"},
 		ResponseTypeHeader: "X-Media-Type",
-		ResponseTypeValue:  "api.v1",
+		ResponseTypeFunc:   func(t string) string { return "api.v1" },
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
@@ -470,10 +473,9 @@ func TestMediaTypeResponseTypeHeaderWithValidationFailure(t *testing.T) {
 	})
 	middleware(next).ServeHTTP(rr, req)
 
-	// Header should be set BEFORE the error response is returned
 	zhtest.AssertWith(t, rr).Status(http.StatusNotAcceptable)
-	// Header is set before validation check, so it should exist
-	zhtest.AssertWith(t, rr).Header("X-Media-Type", "api.v1")
+	// Header is not set when validation fails (negotiated type is unknown)
+	zhtest.AssertWith(t, rr).HeaderNotExists("X-Media-Type")
 }
 
 // TestSymmetricSuffixMatching tests that suffix matching is symmetric
@@ -518,6 +520,91 @@ func TestSymmetricSuffixMatching(t *testing.T) {
 			tt.middleware(next).ServeHTTP(rr, req)
 
 			zhtest.AssertEqual(t, tt.expectNext, nextCalled)
+		})
+	}
+}
+
+func TestVendorShortType(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"vendor type with version", "application/vnd.vinystore.v1+json", "vinystore.v1"},
+		{"different vendor", "application/vnd.discogs.v2+json", "discogs.v2"},
+		{"no suffix", "application/vnd.api.v1", "api.v1"},
+		{"non-vendor type returns as-is", "application/json", "application/json"},
+		{"text plain returns as-is", "text/plain", "text/plain"},
+		{"vendor with hyphenated name", "application/vnd.my-app.v3+json", "my-app.v3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := VendorShortType(tt.input)
+			zhtest.AssertEqual(t, tt.expected, result)
+		})
+	}
+}
+
+func TestVendorShortTypeIntegration(t *testing.T) {
+	// Test that VendorShortType works as a ResponseTypeFunc
+	middleware := New(Config{
+		AllowedTypes:       []string{"application/vnd.app.v1+json"},
+		DefaultType:        "application/vnd.app.v1+json",
+		ResponseTypeHeader: "X-API-Version",
+		ResponseTypeFunc:   VendorShortType,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set(httpx.HeaderAccept, "*/*")
+
+	rr := httptest.NewRecorder()
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	middleware(next).ServeHTTP(rr, req)
+
+	zhtest.AssertWith(t, rr).Status(http.StatusOK)
+	zhtest.AssertWith(t, rr).Header("X-API-Version", "app.v1")
+}
+
+// TestResponseTypeFuncReflectsNegotiatedVersion verifies that when a client
+// requests a specific version (e.g., v2), the response header reflects that
+// version, not the default (v1).
+func TestResponseTypeFuncReflectsNegotiatedVersion(t *testing.T) {
+	middleware := New(Config{
+		AllowedTypes:       []string{"application/vnd.app.v1+json", "application/vnd.app.v2+json"},
+		DefaultType:        "application/vnd.app.v1+json",
+		ResponseTypeHeader: "X-API-Version",
+		ResponseTypeFunc:   VendorShortType,
+	})
+
+	tests := []struct {
+		name         string
+		accept       string
+		expectHeader string
+	}{
+		{"client requests v1", "application/vnd.app.v1+json", "app.v1"},
+		{"client requests v2", "application/vnd.app.v2+json", "app.v2"},
+		{"*/* gets default (v1)", "*/*", "app.v1"},
+		{"no accept gets default (v1)", "", "app.v1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			if tt.accept != "" {
+				req.Header.Set(httpx.HeaderAccept, tt.accept)
+			}
+
+			rr := httptest.NewRecorder()
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+			middleware(next).ServeHTTP(rr, req)
+
+			zhtest.AssertWith(t, rr).Status(http.StatusOK)
+			zhtest.AssertWith(t, rr).Header("X-API-Version", tt.expectHeader)
 		})
 	}
 }


### PR DESCRIPTION
Replace static ResponseTypeValue with ResponseTypeFunc that transforms the negotiated media type into the response header value. This enables the header to reflect what was actually negotiated (e.g., app.v2 when client requests v2) rather than a static construction-time value.

Changes:
- Config.ResponseTypeValue → Config.ResponseTypeFunc func(string) string
- Compute effective type at request time based on matched Accept header
- Add VendorShortType helper: "application/vnd.app.v1+json" -> "app.v1"
- Add findMatchingType to determine which allowed type matched