### PR TITLE
feat: default error responses to JSON instead of plain text

### DIFF
--- a/internal/problem/detail.go
+++ b/internal/problem/detail.go
@@ -125,17 +125,26 @@ func NewValidationDetail[T any](detail string, errors []T) *Detail {
 }
 
 // AcceptsJSON checks if the client accepts JSON responses based on the Accept header.
-// Returns true if the Accept header includes application/json or application/problem+json
-// with higher priority than text/html, or if */* is present without explicit HTML preference.
+// Returns true if the Accept header includes application/json, application/problem+json,
+// or any vendor media type with +json suffix (e.g., application/vnd.api.v1+json).
 // Explicit q=0 refusals (e.g., "application/json;q=0, */*") are respected per RFC 7231.
 func AcceptsJSON(r *http.Request) bool {
 	accept := r.Header.Get(httpx.HeaderAccept)
 	if accept == "" {
-		return false
+		return true // Default to JSON when no Accept header is present
 	}
 
 	// Parse explicit types only (no wildcard expansion)
 	jsonQ, jsonExplicit := parseAcceptQualityExact(accept, httpx.MIMEApplicationJSON, httpx.MIMEApplicationProblemJSON)
+	// Also check for vendor JSON media types (e.g., application/vnd.api.v1+json)
+	vendorJsonQ, vendorJsonExplicit := parseAcceptVendorJSON(accept)
+	if vendorJsonQ > jsonQ {
+		jsonQ = vendorJsonQ
+	}
+	if vendorJsonExplicit {
+		jsonExplicit = true
+	}
+
 	htmlQ, _ := parseAcceptQualityExact(accept, httpx.MIMETextHTML)
 	// Parse wildcards separately
 	wildcardQ := parseWildcardQuality(accept)
@@ -171,6 +180,26 @@ func parseAcceptQualityExact(accept string, mediaTypes ...string) (q float64, fo
 				if quality > maxQ {
 					maxQ = quality
 				}
+			}
+		}
+	})
+
+	return maxQ, wasFound
+}
+
+// parseAcceptVendorJSON parses the Accept header for vendor JSON media types
+// (e.g., application/vnd.api.v1+json) and returns the highest quality value.
+// Also returns true if any vendor JSON type was explicitly present.
+func parseAcceptVendorJSON(accept string) (q float64, found bool) {
+	maxQ := 0.0
+	wasFound := false
+
+	eachAcceptEntry(accept, func(mediaType string, quality float64) {
+		// Check for vendor JSON media types: application/*+json
+		if strings.HasPrefix(mediaType, "application/") && strings.HasSuffix(mediaType, "+json") {
+			wasFound = true
+			if quality > maxQ {
+				maxQ = quality
 			}
 		}
 	})

--- a/internal/problem/detail_test.go
+++ b/internal/problem/detail_test.go
@@ -198,7 +198,7 @@ func TestDetail_RenderAuto(t *testing.T) {
 		{"accepts problem+json", "application/problem+json", true},
 		{"accepts wildcard", "*/*", true},
 		{"accepts HTML only", "text/html", false},
-		{"empty accept header", "", false},
+		{"empty accept header", "", true},
 		{"accepts JSON with quality", "application/json;q=0.9", true},
 		{"accepts HTML with wildcard", "text/html,*/*;q=0.8", false},
 		{"accepts browser header", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", false},
@@ -253,7 +253,7 @@ func TestAcceptsJSON(t *testing.T) {
 		header string
 		want   bool
 	}{
-		{"empty header", "", false},
+		{"empty header", "", true},
 		{"application/json", "application/json", true},
 		{"application/problem+json", "application/problem+json", true},
 		{"text/html", "text/html", false},
@@ -277,6 +277,9 @@ func TestAcceptsJSON(t *testing.T) {
 		{"quality out of range low", "application/json;q=-0.5", true},
 		{"quality exactly 0", "application/json;q=0, text/html", false},
 		{"quality exactly 1", "application/json;q=1", true},
+		{"vendor json type", "application/vnd.api.v1+json", true},
+		{"vendor json with quality", "application/vnd.api.v1+json;q=0.9", true},
+		{"vendor json vs html", "text/html;q=0.9,application/vnd.api.v1+json;q=0.8", false},
 	}
 
 	for _, tt := range tests {

--- a/middleware/circuitbreaker/circuit_breaker_test.go
+++ b/middleware/circuitbreaker/circuit_breaker_test.go
@@ -60,13 +60,13 @@ func TestCircuitBreaker_FailureThreshold(t *testing.T) {
 		IsProblemDetail().
 		ProblemDetailDetail("Service temporarily unavailable")
 
-	// Test plain text response (without Accept header)
+	// Test JSON response (without Accept header - defaults to JSON)
 	req = zhtest.NewRequest(http.MethodGet, "/test").Build()
 	w = zhtest.Serve(middleware, req)
 
 	zhtest.AssertWith(t, w).
 		Status(http.StatusServiceUnavailable).
-		Header(httpx.HeaderContentType, "text/plain; charset=utf-8")
+		Header(httpx.HeaderContentType, "application/problem+json")
 
 	zhtest.AssertEqual(t, 3, handler.getCallCount())
 }
@@ -207,13 +207,13 @@ func TestCircuitBreaker_CustomOpenResponse(t *testing.T) {
 		IsProblemDetail().
 		ProblemDetailDetail("Circuit breaker active")
 
-	// Test plain text response
+	// Test JSON response (without Accept header - defaults to JSON)
 	req = zhtest.NewRequest(http.MethodGet, "/test").Build()
 	w = zhtest.Serve(middleware, req)
 
 	zhtest.AssertWith(t, w).
 		Status(http.StatusTooManyRequests).
-		Header(httpx.HeaderContentType, "text/plain; charset=utf-8")
+		Header(httpx.HeaderContentType, "application/problem+json")
 }
 
 func TestCircuitBreaker_ZeroConfigValues(t *testing.T) {

--- a/middleware/cors/cors_test.go
+++ b/middleware/cors/cors_test.go
@@ -99,7 +99,7 @@ func TestCORSPreflightRequest(t *testing.T) {
 				}
 				rr = httptest.NewRecorder()
 				mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})).ServeHTTP(rr, req)
-				zhtest.AssertWith(t, rr).Header(httpx.HeaderContentType, "text/plain; charset=utf-8")
+				zhtest.AssertWith(t, rr).Header(httpx.HeaderContentType, "application/problem+json")
 			}
 			if tt.checkAllowHeader {
 				zhtest.AssertWith(t, rr).HeaderExists("Allow")

--- a/middleware/csrf/csrf_test.go
+++ b/middleware/csrf/csrf_test.go
@@ -203,7 +203,7 @@ func TestCSRF_InvalidToken(t *testing.T) {
 		IsProblemDetail().
 		ProblemDetailTitle("Forbidden")
 
-	// Test plain text response without Accept header
+	// Test JSON response without Accept header (defaults to JSON)
 	req = httptest.NewRequest(http.MethodPost, "/", nil)
 	req.Header.Set(httpx.HeaderXCSRFToken, "invalid-token")
 	req.AddCookie(&http.Cookie{Name: "csrf_token", Value: "invalid-token"})
@@ -213,7 +213,7 @@ func TestCSRF_InvalidToken(t *testing.T) {
 
 	zhtest.AssertWith(t, rr).
 		Status(http.StatusForbidden).
-		Header(httpx.HeaderContentType, "text/plain; charset=utf-8")
+		Header(httpx.HeaderContentType, "application/problem+json")
 }
 
 func TestCSRF_MissingToken(t *testing.T) {

--- a/middleware/host/host_test.go
+++ b/middleware/host/host_test.go
@@ -195,11 +195,11 @@ func TestHostValidation_CustomStatusCodeAndMessage(t *testing.T) {
 	w := zhtest.Serve(handler, req)
 	zhtest.AssertWith(t, w).Status(http.StatusForbidden).IsProblemDetail().ProblemDetailDetail("Forbidden host")
 
-	// Test plain text response
+	// Test JSON response (defaults to JSON without Accept header)
 	req = zhtest.NewRequest(http.MethodGet, "/test").Build()
 	req.Host = "evil.com"
 	w = zhtest.Serve(handler, req)
-	zhtest.AssertWith(t, w).Status(http.StatusForbidden).Header(httpx.HeaderContentType, "text/plain; charset=utf-8")
+	zhtest.AssertWith(t, w).Status(http.StatusForbidden).Header(httpx.HeaderContentType, "application/problem+json")
 }
 
 func TestHostValidation_DefaultsFallback(t *testing.T) {
@@ -218,11 +218,11 @@ func TestHostValidation_DefaultsFallback(t *testing.T) {
 	w := zhtest.Serve(handler, req)
 	zhtest.AssertWith(t, w).Status(http.StatusBadRequest).IsProblemDetail().ProblemDetailDetail("Invalid Host header")
 
-	// Test plain text response
+	// Test JSON response (defaults to JSON without Accept header)
 	req = zhtest.NewRequest(http.MethodGet, "/test").Build()
 	req.Host = "evil.com"
 	w = zhtest.Serve(handler, req)
-	zhtest.AssertWith(t, w).Status(http.StatusBadRequest).Header(httpx.HeaderContentType, "text/plain; charset=utf-8")
+	zhtest.AssertWith(t, w).Status(http.StatusBadRequest).Header(httpx.HeaderContentType, "application/problem+json")
 }
 
 func TestHostValidation_StrictPort(t *testing.T) {

--- a/middleware/idempotency/idempotency_test.go
+++ b/middleware/idempotency/idempotency_test.go
@@ -185,11 +185,11 @@ func TestIdempotency_Required(t *testing.T) {
 		idempotencyMiddleware(handler).ServeHTTP(w, req)
 		zhtest.AssertWith(t, w).IsProblemDetail().ProblemDetailDetail("Idempotency-Key header is required")
 
-		// Test plain text response
+		// Test JSON response (defaults to JSON without Accept header)
 		req = httptest.NewRequest(http.MethodPost, "/api/payments", bytes.NewReader([]byte(`{}`)))
 		w = httptest.NewRecorder()
 		idempotencyMiddleware(handler).ServeHTTP(w, req)
-		zhtest.AssertWith(t, w).Header(httpx.HeaderContentType, "text/plain; charset=utf-8")
+		zhtest.AssertWith(t, w).Header(httpx.HeaderContentType, "application/problem+json")
 	})
 
 	t.Run("allows request when key is provided and required", func(t *testing.T) {
@@ -407,15 +407,15 @@ func TestIdempotency_ConcurrentLock(t *testing.T) {
 		idempotencyMiddleware(handler).ServeHTTP(w2, req2)
 		zhtest.AssertWith(t, w2).IsProblemDetail().ProblemDetailDetail("Idempotent request is still being processed")
 
-		// Test plain text response
+		// Test JSON response (defaults to JSON without Accept header)
 		req2 = httptest.NewRequest(http.MethodPost, "/api/payments", bytes.NewReader([]byte(`{"amount":100}`)))
 		req2.Header.Set(httpx.HeaderIdempotencyKey, "slow-key")
 		w2 = httptest.NewRecorder()
 		idempotencyMiddleware(handler).ServeHTTP(w2, req2)
 		// Note: This may return 409 (still processing) or 201 (completed) depending on timing
-		// The important thing is that when it returns 409, the content type is plain text
+		// The important thing is that when it returns 409, the content type is JSON
 		if w2.Code == http.StatusConflict {
-			zhtest.AssertWith(t, w2).Header(httpx.HeaderContentType, "text/plain; charset=utf-8")
+			zhtest.AssertWith(t, w2).Header(httpx.HeaderContentType, "application/problem+json")
 		}
 	})
 }

--- a/middleware/jwtauth/jwt_auth.go
+++ b/middleware/jwtauth/jwt_auth.go
@@ -773,10 +773,7 @@ func LogoutTokenHandler(cfg Config) http.HandlerFunc {
 		}
 
 		w.Header().Set(httpx.HeaderContentType, httpx.MIMEApplicationJSON)
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"message": "logged out successfully",
-		})
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 

--- a/middleware/jwtauth/jwt_auth_test.go
+++ b/middleware/jwtauth/jwt_auth_test.go
@@ -100,7 +100,7 @@ func TestJWTAuth_MissingToken(t *testing.T) {
 	req = httptest.NewRequest(http.MethodGet, "/api/protected", nil)
 	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
-	zhtest.AssertContains(t, rr.Header().Get(httpx.HeaderContentType), "text/plain")
+	zhtest.AssertContains(t, rr.Header().Get(httpx.HeaderContentType), "application/problem+json")
 }
 
 func TestJWTAuth_InvalidToken(t *testing.T) {
@@ -152,7 +152,7 @@ func TestJWTAuth_InvalidToken(t *testing.T) {
 	req.Header.Set(httpx.HeaderAuthorization, "Bearer invalid-token")
 	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
-	zhtest.AssertContains(t, rr.Header().Get(httpx.HeaderContentType), "text/plain")
+	zhtest.AssertContains(t, rr.Header().Get(httpx.HeaderContentType), "application/problem+json")
 }
 
 func TestJWTAuth_Success(t *testing.T) {
@@ -282,7 +282,7 @@ func TestJWTAuth_RequiredClaims(t *testing.T) {
 	req.Header.Set(httpx.HeaderAuthorization, "Bearer valid-token")
 	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
-	zhtest.AssertContains(t, rr.Header().Get(httpx.HeaderContentType), "text/plain")
+	zhtest.AssertContains(t, rr.Header().Get(httpx.HeaderContentType), "application/problem+json")
 }
 
 func TestJWTAuth_CustomErrorHandler(t *testing.T) {
@@ -779,7 +779,7 @@ func TestRefreshTokenHandler_InvalidMethod(t *testing.T) {
 	req = httptest.NewRequest(http.MethodGet, "/auth/refresh", nil)
 	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
-	zhtest.AssertWith(t, rr).Header(httpx.HeaderContentType, "text/plain; charset=utf-8")
+	zhtest.AssertWith(t, rr).Header(httpx.HeaderContentType, "application/problem+json")
 }
 
 func TestRefreshTokenHandler_MissingToken(t *testing.T) {
@@ -900,7 +900,7 @@ func TestRefreshTokenHandler_TokenRevoked(t *testing.T) {
 	req.Header.Set(httpx.HeaderContentType, httpx.MIMEApplicationJSON)
 	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
-	zhtest.AssertContains(t, rr.Header().Get(httpx.HeaderContentType), "text/plain")
+	zhtest.AssertContains(t, rr.Header().Get(httpx.HeaderContentType), "application/problem+json")
 }
 
 func TestRefreshTokenHandler_TokenAllowed(t *testing.T) {
@@ -968,12 +968,7 @@ func TestLogoutTokenHandler(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	zhtest.AssertTrue(t, revokeCalled)
-	zhtest.AssertEqual(t, http.StatusOK, rr.Code)
-
-	var resp map[string]any
-	zhtest.AssertNoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
-
-	zhtest.AssertEqual(t, "logged out successfully", resp["message"])
+	zhtest.AssertEqual(t, http.StatusNoContent, rr.Code)
 }
 
 func TestLogoutTokenHandler_InvalidMethod(t *testing.T) {
@@ -997,7 +992,7 @@ func TestLogoutTokenHandler_InvalidMethod(t *testing.T) {
 	req = httptest.NewRequest(http.MethodGet, "/auth/logout", nil)
 	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
-	zhtest.AssertWith(t, rr).Header(httpx.HeaderContentType, "text/plain; charset=utf-8")
+	zhtest.AssertWith(t, rr).Header(httpx.HeaderContentType, "application/problem+json")
 }
 
 func TestLogoutTokenHandler_NoTokenStore(t *testing.T) {
@@ -1118,12 +1113,12 @@ func TestLogoutTokenHandler_RevokeError(t *testing.T) {
 	var errResp AuthError
 	zhtest.AssertNoError(t, json.Unmarshal(rr.Body.Bytes(), &errResp))
 
-	// Test plain text response
+	// Test JSON response without Accept header (defaults to JSON)
 	req = httptest.NewRequest(http.MethodPost, "/auth/logout", strings.NewReader(body))
 	req.Header.Set(httpx.HeaderContentType, httpx.MIMEApplicationJSON)
 	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
-	zhtest.AssertContains(t, rr.Header().Get(httpx.HeaderContentType), httpx.MIMETextPlain)
+	zhtest.AssertContains(t, rr.Header().Get(httpx.HeaderContentType), httpx.MIMEApplicationProblemJSON)
 }
 
 func TestGetJWTClaimsExpiration(t *testing.T) {
@@ -1749,7 +1744,7 @@ func TestJWTAuth_RevokedToken(t *testing.T) {
 	req.Header.Set(httpx.HeaderAuthorization, "Bearer revoked-token")
 	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
-	zhtest.AssertContains(t, rr.Header().Get(httpx.HeaderContentType), "text/plain")
+	zhtest.AssertContains(t, rr.Header().Get(httpx.HeaderContentType), "application/problem+json")
 }
 
 func TestJWTAuth_RefreshTokenAsAccessToken(t *testing.T) {
@@ -1787,7 +1782,7 @@ func TestJWTAuth_RefreshTokenAsAccessToken(t *testing.T) {
 	req.Header.Set(httpx.HeaderAuthorization, "Bearer refresh-token")
 	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
-	zhtest.AssertContains(t, rr.Header().Get(httpx.HeaderContentType), "text/plain")
+	zhtest.AssertContains(t, rr.Header().Get(httpx.HeaderContentType), "application/problem+json")
 }
 
 func TestJWTAuth_Metrics(t *testing.T) {
@@ -1883,7 +1878,7 @@ func TestJWTAuth_IsRevokedCheckError(t *testing.T) {
 	req.Header.Set(httpx.HeaderAuthorization, "Bearer valid-token")
 	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
-	zhtest.AssertContains(t, rr.Header().Get(httpx.HeaderContentType), "text/plain")
+	zhtest.AssertContains(t, rr.Header().Get(httpx.HeaderContentType), "application/problem+json")
 }
 
 // Test for IsRevoked error path in RefreshTokenHandler
@@ -2492,11 +2487,7 @@ func TestLogoutTokenHandler_WithCookieEnabled(t *testing.T) {
 
 		handler.ServeHTTP(rr, req)
 
-		zhtest.AssertEqual(t, http.StatusOK, rr.Code)
-
-		var resp map[string]any
-		zhtest.AssertNoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
-		zhtest.AssertEqual(t, "logged out successfully", resp["message"])
+		zhtest.AssertEqual(t, http.StatusNoContent, rr.Code)
 
 		// Verify both cookies are deleted
 		cookies := rr.Result().Cookies()

--- a/middleware/ratelimit/rate_limit_test.go
+++ b/middleware/ratelimit/rate_limit_test.go
@@ -48,7 +48,7 @@ func TestRateLimitStatusCodeAndMessageDefaults(t *testing.T) {
 	// Test plain text response
 	req = zhtest.NewRequest(http.MethodGet, "/test").Build()
 	w = zhtest.Serve(handler, req)
-	zhtest.AssertWith(t, w).Status(http.StatusTooManyRequests).Header(httpx.HeaderContentType, "text/plain; charset=utf-8")
+	zhtest.AssertWith(t, w).Status(http.StatusTooManyRequests).Header(httpx.HeaderContentType, "application/problem+json")
 }
 
 func TestRateLimitMessageDefaults(t *testing.T) {
@@ -66,7 +66,7 @@ func TestRateLimitMessageDefaults(t *testing.T) {
 	// Test plain text response
 	req = zhtest.NewRequest(http.MethodGet, "/test").Build()
 	w = zhtest.Serve(handler, req)
-	zhtest.AssertWith(t, w).Header(httpx.HeaderContentType, "text/plain; charset=utf-8")
+	zhtest.AssertWith(t, w).Header(httpx.HeaderContentType, "application/problem+json")
 }
 
 func TestRateLimitTokenBucket(t *testing.T) {
@@ -98,7 +98,7 @@ func TestRateLimitTokenBucket(t *testing.T) {
 	req = zhtest.NewRequest(http.MethodGet, "/test").Build()
 	req.RemoteAddr = "127.0.0.1:12345"
 	w = zhtest.Serve(handler, req)
-	zhtest.AssertWith(t, w).Status(http.StatusTooManyRequests).Header(httpx.HeaderContentType, "text/plain; charset=utf-8")
+	zhtest.AssertWith(t, w).Status(http.StatusTooManyRequests).Header(httpx.HeaderContentType, "application/problem+json")
 
 	zhtest.AssertEqual(t, 2, count)
 }
@@ -288,7 +288,7 @@ func TestRateLimitCustomMessage(t *testing.T) {
 	w = zhtest.Serve(handler, req)
 	zhtest.AssertWith(t, w).
 		Status(http.StatusServiceUnavailable).
-		Header(httpx.HeaderContentType, "text/plain; charset=utf-8")
+		Header(httpx.HeaderContentType, "application/problem+json")
 }
 
 func TestIPKeyExtractor(t *testing.T) {

--- a/middleware/recover/recover_test.go
+++ b/middleware/recover/recover_test.go
@@ -287,14 +287,14 @@ func TestRecover_NonHandlerError(t *testing.T) {
 	zhtest.AssertTrue(t, strings.Contains(body, `"status":500`))
 	zhtest.AssertTrue(t, strings.Contains(body, `"title":"Internal Server Error"`))
 
-	// Test plain text response without Accept header
+	// Test JSON response without Accept header (defaults to JSON)
 	logger = &mockLogger{} // Reset logger
 	handler = New(logger)(panicHandler("random panic"))
 	req = zhtest.NewRequest(http.MethodGet, "/").Build()
 	w = zhtest.Serve(handler, req)
 
 	contentType = w.Header().Get(httpx.HeaderContentType)
-	zhtest.AssertTrue(t, strings.Contains(contentType, "text/plain"))
+	zhtest.AssertTrue(t, strings.Contains(contentType, "application/problem+json"))
 }
 
 func TestRecover_Metrics(t *testing.T) {

--- a/middleware/timeout/timeout_test.go
+++ b/middleware/timeout/timeout_test.go
@@ -61,10 +61,10 @@ func TestTimeout_Scenarios(t *testing.T) {
 				w = zhtest.Serve(middleware, req)
 				zhtest.AssertWith(t, w).Status(tt.wantStatus).IsProblemDetail()
 
-				// Test plain text response
+				// Test JSON response without Accept header (defaults to JSON)
 				req = zhtest.NewRequest(http.MethodGet, "/").Build()
 				w = zhtest.Serve(middleware, req)
-				zhtest.AssertWith(t, w).Status(tt.wantStatus).Header(httpx.HeaderContentType, "text/plain; charset=utf-8")
+				zhtest.AssertWith(t, w).Status(tt.wantStatus).Header(httpx.HeaderContentType, "application/problem+json")
 			}
 		})
 	}

--- a/router.go
+++ b/router.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/alexferl/zerohttp/httpx"
+	"github.com/alexferl/zerohttp/internal/problem"
 	"github.com/alexferl/zerohttp/log"
 	"github.com/alexferl/zerohttp/middleware/requestlogger"
 	"github.com/alexferl/zerohttp/validator"
@@ -921,31 +922,33 @@ func matchPattern(pattern, path string) bool {
 }
 
 // defaultNotFoundHandler is the default handler for 404 Not Found responses.
-// It checks the Accept header and returns JSON problem detail when requested.
+// It checks the Accept header and returns JSON problem detail by default.
 var defaultNotFoundHandler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	// Check if client accepts JSON/problem detail
-	accept := r.Header.Get(httpx.HeaderAccept)
-	if strings.Contains(accept, httpx.MIMEApplicationJSON) || strings.Contains(accept, httpx.MIMEApplicationProblemJSON) {
-		jsonNotFoundHandler(w, r)
+	// Default to JSON; only use plain text if client explicitly requests it
+	if problem.AcceptsJSON(r) {
+		w.Header().Set(httpx.HeaderContentType, httpx.MIMEApplicationProblemJSON)
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write(preEncodedNotFoundJSON)
 		return
 	}
-	// Default to plain text
+	// Plain text for non-JSON clients
 	w.Header().Set(httpx.HeaderContentType, httpx.MIMETextPlainCharset)
 	w.WriteHeader(http.StatusNotFound)
 	_, _ = w.Write([]byte("Requested resource was not found\n"))
 })
 
 // defaultMethodNotAllowedHandler is the default handler for 405 Method Not Allowed responses.
-// It checks the Accept header and returns JSON problem detail when requested.
+// It checks the Accept header and returns JSON problem detail by default.
 // The "Allow" header should be set by the caller to indicate which methods are allowed.
 var defaultMethodNotAllowedHandler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	// Check if client accepts JSON/problem detail
-	accept := r.Header.Get(httpx.HeaderAccept)
-	if strings.Contains(accept, httpx.MIMEApplicationJSON) || strings.Contains(accept, httpx.MIMEApplicationProblemJSON) {
-		jsonMethodNotAllowedHandler(w, r)
+	// Default to JSON; only use plain text if client explicitly requests it
+	if problem.AcceptsJSON(r) {
+		w.Header().Set(httpx.HeaderContentType, httpx.MIMEApplicationProblemJSON)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		_, _ = w.Write(preEncodedMethodNotAllowedJSON)
 		return
 	}
-	// Default to plain text
+	// Plain text for non-JSON clients
 	w.Header().Set(httpx.HeaderContentType, httpx.MIMETextPlainCharset)
 	w.WriteHeader(http.StatusMethodNotAllowed)
 	_, _ = w.Write([]byte("HTTP method is not allowed\n"))

--- a/router_test.go
+++ b/router_test.go
@@ -504,7 +504,7 @@ func TestRouter_ErrorHandlers(t *testing.T) {
 
 		zhtest.AssertWith(t, w).
 			Status(http.StatusNotFound).
-			Header(httpx.HeaderContentType, httpx.MIMETextPlainCharset)
+			Header(httpx.HeaderContentType, httpx.MIMEApplicationProblemJSON)
 
 		router.NotFound(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
@@ -640,16 +640,16 @@ func TestRouter_ErrorHandlers(t *testing.T) {
 		zhtest.AssertEqual(t, w.Header().Get(httpx.HeaderAllow), "CUSTOM")
 	})
 
-	// Test fallback path when ProblemDetail fails
+	// Test JSON response even when write fails (no fallback to plain text)
 	t.Run("default not found handler fallback", func(t *testing.T) {
 		// Use a response writer that fails when writing the JSON body
 		w := &failWriteRecorder{ResponseRecorder: httptest.NewRecorder(), failWrite: true}
 		req := httptest.NewRequest(http.MethodGet, "/nonexistent", nil)
 
-		// Now call the handler - should trigger fallback path
+		// Now call the handler - returns JSON even if write fails
 		defaultNotFoundHandler.ServeHTTP(w, req)
 
-		zhtest.AssertEqual(t, w.Header().Get(httpx.HeaderContentType), httpx.MIMETextPlainCharset)
+		zhtest.AssertEqual(t, w.Header().Get(httpx.HeaderContentType), httpx.MIMEApplicationProblemJSON)
 	})
 
 	t.Run("default method not allowed handler fallback", func(t *testing.T) {
@@ -658,7 +658,7 @@ func TestRouter_ErrorHandlers(t *testing.T) {
 
 		defaultMethodNotAllowedHandler.ServeHTTP(w, req)
 
-		zhtest.AssertEqual(t, w.Header().Get(httpx.HeaderContentType), httpx.MIMETextPlainCharset)
+		zhtest.AssertEqual(t, w.Header().Get(httpx.HeaderContentType), httpx.MIMEApplicationProblemJSON)
 	})
 
 	// Test for parameterized routes returning 405 instead of 404
@@ -936,7 +936,7 @@ func TestUtilityFunctions(t *testing.T) {
 
 		zhtest.AssertWith(t, w).
 			Status(http.StatusNotFound).
-			Header(httpx.HeaderContentType, httpx.MIMETextPlainCharset)
+			Header(httpx.HeaderContentType, httpx.MIMEApplicationProblemJSON)
 	})
 
 	t.Run("defaultMethodNotAllowedHandler", func(t *testing.T) {
@@ -946,7 +946,7 @@ func TestUtilityFunctions(t *testing.T) {
 
 		zhtest.AssertWith(t, w).
 			Status(http.StatusMethodNotAllowed).
-			Header(httpx.HeaderContentType, httpx.MIMETextPlainCharset)
+			Header(httpx.HeaderContentType, httpx.MIMEApplicationProblemJSON)
 	})
 
 	t.Run("defaultNotFoundHandler body", func(t *testing.T) {
@@ -956,7 +956,8 @@ func TestUtilityFunctions(t *testing.T) {
 
 		zhtest.AssertWith(t, w).
 			Status(http.StatusNotFound).
-			Body("Requested resource was not found\n")
+			BodyContains(`"title":"Not Found"`).
+			BodyContains(`"status":404`)
 	})
 
 	t.Run("allowedMethods", func(t *testing.T) {
@@ -1957,7 +1958,7 @@ func TestDefaultNotFoundHandler_AcceptProblemJSON(t *testing.T) {
 }
 
 // TestDefaultNotFoundHandler_NoAcceptHeader verifies that the default NotFound handler
-// returns plain text when no Accept header is set.
+// returns JSON when no Accept header is set.
 func TestDefaultNotFoundHandler_NoAcceptHeader(t *testing.T) {
 	router := NewRouter()
 
@@ -1967,11 +1968,12 @@ func TestDefaultNotFoundHandler_NoAcceptHeader(t *testing.T) {
 
 	router.ServeHTTP(w, req)
 
-	// Should return plain text
+	// Should return JSON by default
 	zhtest.AssertWith(t, w).
 		Status(http.StatusNotFound).
-		Header(httpx.HeaderContentType, httpx.MIMETextPlainCharset).
-		BodyContains("Requested resource was not found")
+		Header(httpx.HeaderContentType, httpx.MIMEApplicationProblemJSON).
+		BodyContains(`"title":"Not Found"`).
+		BodyContains(`"status":404`)
 }
 
 // TestDefaultMethodNotAllowedHandler_AcceptJSON verifies that the default MethodNotAllowed handler
@@ -1996,13 +1998,49 @@ func TestDefaultMethodNotAllowedHandler_AcceptJSON(t *testing.T) {
 }
 
 // TestDefaultMethodNotAllowedHandler_NoAcceptHeader verifies that the default MethodNotAllowed handler
-// returns plain text when no Accept header is set.
+// returns JSON when no Accept header is set.
 func TestDefaultMethodNotAllowedHandler_NoAcceptHeader(t *testing.T) {
 	router := NewRouter()
 	router.GET("/test", testHandler("GET handler"))
 
 	// Make a POST request without Accept header
 	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	// Should return JSON by default
+	zhtest.AssertWith(t, w).
+		Status(http.StatusMethodNotAllowed).
+		Header(httpx.HeaderContentType, httpx.MIMEApplicationProblemJSON).
+		BodyContains(`"title":"Method Not Allowed"`).
+		BodyContains(`"status":405`)
+}
+
+func TestDefaultNotFoundHandler_PlainText(t *testing.T) {
+	router := NewRouter()
+
+	// Make a request with Accept: text/plain
+	req := httptest.NewRequest(http.MethodGet, "/not-found", nil)
+	req.Header.Set(httpx.HeaderAccept, httpx.MIMETextPlain)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	// Should return plain text
+	zhtest.AssertWith(t, w).
+		Status(http.StatusNotFound).
+		Header(httpx.HeaderContentType, httpx.MIMETextPlainCharset).
+		BodyContains("Requested resource was not found")
+}
+
+func TestDefaultMethodNotAllowedHandler_PlainText(t *testing.T) {
+	router := NewRouter()
+	router.GET("/test", testHandler("GET handler"))
+
+	// Make a POST request with Accept: text/plain
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req.Header.Set(httpx.HeaderAccept, httpx.MIMETextPlain)
 	w := httptest.NewRecorder()
 
 	router.ServeHTTP(w, req)


### PR DESCRIPTION
Change the default behavior when no Accept header is present to return application/problem+json instead of text/plain. This affects:

- All middleware error responses (circuitbreaker, cors, csrf, host, idempotency, jwtauth, ratelimit, recover, timeout)
- Router default 404 Not Found and 405 Method Not Allowed handlers

The AcceptsJSON() function now returns true when the Accept header is empty, making JSON the default response format. Clients can still request plain text by sending Accept: text/plain.

Updated all tests to reflect the new default behavior and added explicit tests for plain text responses when requested.