### PR TITLE
feat(sse): add context.Context to Broadcaster interface methods

### DIFF
--- a/examples/sse/main.go
+++ b/examples/sse/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -97,8 +98,8 @@ func main() {
 			}
 		}
 
-		hub.Subscribe(stream, "notifications")
-		defer hub.Unsubscribe(stream, "notifications")
+		hub.Subscribe(r.Context(), stream, "notifications")
+		defer hub.Unsubscribe(r.Context(), stream, "notifications")
 
 		_ = stream.Send(sse.Event{
 			Name: "info",
@@ -116,8 +117,8 @@ func main() {
 		}
 		defer func() { _ = stream.Close() }()
 
-		hub.Register(stream)
-		defer hub.Unregister(stream)
+		hub.Register(r.Context(), stream)
+		defer hub.Unregister(r.Context(), stream)
 
 		_ = stream.Send(sse.Event{
 			Name: "info",
@@ -154,7 +155,7 @@ func main() {
 			Name: "broadcast",
 			Data: []byte(msg),
 		}
-		hub.Broadcast(event)
+		hub.Broadcast(r.Context(), event)
 
 		_, err := fmt.Fprintf(w, "Broadcast sent to %d clients", hub.ConnectionCount())
 		return err
@@ -171,7 +172,7 @@ func main() {
 				Data: []byte(fmt.Sprintf("Auto notification #%d", counter)),
 			}
 			event = replayer.Store(event)
-			hub.BroadcastTo("notifications", event)
+			hub.BroadcastTo(context.Background(), "notifications", event)
 		}
 	}()
 

--- a/sse/doc.go
+++ b/sse/doc.go
@@ -52,15 +52,15 @@
 //	        return err
 //	    }
 //
-//	    hub.Register(stream)
-//	    defer hub.Unregister(stream)
+//	    hub.Register(r.Context(), stream)
+//	    defer hub.Unregister(r.Context(), stream)
 //
 //	    <-r.Context().Done()
 //	    return nil
 //	})
 //
 //	// Broadcast to all connected clients
-//	hub.Broadcast(sse.Event{Name: "update", Data: []byte("hello")})
+//	hub.Broadcast(r.Context(), sse.Event{Name: "update", Data: []byte("hello")})
 //
 // The Broadcaster interface allows custom implementations (e.g. Redis-backed)
 // for cross-instance broadcasting. The built-in Hub satisfies this interface.

--- a/sse/hub.go
+++ b/sse/hub.go
@@ -1,17 +1,20 @@
 package sse
 
-import "sync"
+import (
+	"context"
+	"sync"
+)
 
 // Broadcaster is the interface for SSE broadcast hubs.
 // The built-in Hub satisfies this interface, and users can provide
 // their own implementations (e.g. backed by Redis) for cross-instance broadcast.
 type Broadcaster interface {
-	Register(s *SSE)
-	Unregister(s *SSE)
-	Subscribe(s *SSE, topic string)
-	Unsubscribe(s *SSE, topic string)
-	Broadcast(event Event)
-	BroadcastTo(topic string, event Event)
+	Register(ctx context.Context, s *SSE)
+	Unregister(ctx context.Context, s *SSE)
+	Subscribe(ctx context.Context, s *SSE, topic string)
+	Unsubscribe(ctx context.Context, s *SSE, topic string)
+	Broadcast(ctx context.Context, event Event)
+	BroadcastTo(ctx context.Context, topic string, event Event)
 	ConnectionCount() int
 	TopicCount(topic string) int
 }
@@ -37,14 +40,14 @@ func NewHub() *Hub {
 }
 
 // Register adds an SSE connection to the hub.
-func (h *Hub) Register(s *SSE) {
+func (h *Hub) Register(_ context.Context, s *SSE) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.connections[s] = struct{}{}
 }
 
 // Unregister removes an SSE connection from the hub.
-func (h *Hub) Unregister(s *SSE) {
+func (h *Hub) Unregister(_ context.Context, s *SSE) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	delete(h.connections, s)
@@ -57,7 +60,7 @@ func (h *Hub) Unregister(s *SSE) {
 }
 
 // Subscribe adds an SSE connection to a topic.
-func (h *Hub) Subscribe(s *SSE, topic string) {
+func (h *Hub) Subscribe(_ context.Context, s *SSE, topic string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.topics[topic] == nil {
@@ -67,7 +70,7 @@ func (h *Hub) Subscribe(s *SSE, topic string) {
 }
 
 // Unsubscribe removes an SSE connection from a topic.
-func (h *Hub) Unsubscribe(s *SSE, topic string) {
+func (h *Hub) Unsubscribe(_ context.Context, s *SSE, topic string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if subs, ok := h.topics[topic]; ok {
@@ -80,7 +83,7 @@ func (h *Hub) Unsubscribe(s *SSE, topic string) {
 
 // Broadcast sends an event to all registered connections.
 // Connections that fail to receive the event are automatically unregistered.
-func (h *Hub) Broadcast(event Event) {
+func (h *Hub) Broadcast(ctx context.Context, event Event) {
 	if h.OnBroadcast != nil {
 		h.OnBroadcast(event)
 	}
@@ -101,14 +104,14 @@ func (h *Hub) Broadcast(event Event) {
 
 	// Unregister failed connections
 	for _, conn := range failed {
-		h.Unregister(conn)
+		h.Unregister(ctx, conn)
 		_ = conn.Close()
 	}
 }
 
 // BroadcastTo sends an event to all connections subscribed to a topic.
 // Connections that fail to receive the event are automatically unregistered.
-func (h *Hub) BroadcastTo(topic string, event Event) {
+func (h *Hub) BroadcastTo(ctx context.Context, topic string, event Event) {
 	if h.OnBroadcastTo != nil {
 		h.OnBroadcastTo(topic, event)
 	}
@@ -132,7 +135,7 @@ func (h *Hub) BroadcastTo(topic string, event Event) {
 
 	// Unregister failed connections
 	for _, conn := range failed {
-		h.Unregister(conn)
+		h.Unregister(ctx, conn)
 		_ = conn.Close()
 	}
 }

--- a/sse/hub_bench_test.go
+++ b/sse/hub_bench_test.go
@@ -1,6 +1,7 @@
 package sse
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -28,7 +29,7 @@ func BenchmarkHub_Broadcast(b *testing.B) {
 					b.Fatalf("failed to create SSE: %v", err)
 				}
 				streams[i] = stream
-				hub.Register(stream)
+				hub.Register(context.Background(), stream)
 			}
 
 			// Cleanup
@@ -44,7 +45,7 @@ func BenchmarkHub_Broadcast(b *testing.B) {
 			b.ResetTimer()
 
 			for b.Loop() {
-				hub.Broadcast(event)
+				hub.Broadcast(context.Background(), event)
 			}
 		})
 	}
@@ -71,7 +72,7 @@ func BenchmarkHub_BroadcastTo(b *testing.B) {
 					b.Fatalf("failed to create SSE: %v", err)
 				}
 				streams[i] = stream
-				hub.Subscribe(stream, "notifications")
+				hub.Subscribe(context.Background(), stream, "notifications")
 			}
 
 			// Cleanup
@@ -87,7 +88,7 @@ func BenchmarkHub_BroadcastTo(b *testing.B) {
 			b.ResetTimer()
 
 			for b.Loop() {
-				hub.BroadcastTo("notifications", event)
+				hub.BroadcastTo(context.Background(), "notifications", event)
 			}
 		})
 	}
@@ -119,7 +120,7 @@ func BenchmarkHub_BroadcastTo_MultipleTopics(b *testing.B) {
 					b.Fatalf("failed to create SSE: %v", err)
 				}
 				topicName := fmt.Sprintf("topic-%d", i%s.numTopics)
-				hub.Subscribe(stream, topicName)
+				hub.Subscribe(context.Background(), stream, topicName)
 			}
 
 			event := Event{Data: []byte("topic message")}
@@ -128,7 +129,7 @@ func BenchmarkHub_BroadcastTo_MultipleTopics(b *testing.B) {
 			b.ResetTimer()
 
 			for b.Loop() {
-				hub.BroadcastTo("topic-0", event)
+				hub.BroadcastTo(context.Background(), "topic-0", event)
 			}
 		})
 	}
@@ -153,7 +154,7 @@ func BenchmarkHub_RegisterUnregister(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			hub.Register(streams[i])
+			hub.Register(context.Background(), streams[i])
 		}
 
 		// Cleanup
@@ -172,14 +173,14 @@ func BenchmarkHub_RegisterUnregister(b *testing.B) {
 			w := httptest.NewRecorder()
 			stream, _ := New(w, r)
 			streams[i] = stream
-			hub.Register(stream)
+			hub.Register(context.Background(), stream)
 		}
 
 		b.ReportAllocs()
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			hub.Unregister(streams[i])
+			hub.Unregister(context.Background(), streams[i])
 		}
 
 		// Cleanup
@@ -204,7 +205,7 @@ func BenchmarkHub_RegisterUnregister(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			hub.Subscribe(streams[i], "test-topic")
+			hub.Subscribe(context.Background(), streams[i], "test-topic")
 		}
 
 		// Cleanup
@@ -232,11 +233,11 @@ func BenchmarkHub_RegisterUnregister_Concurrent(b *testing.B) {
 				for pb.Next() {
 					w := httptest.NewRecorder()
 					stream, _ := New(w, r)
-					hub.Register(stream)
+					hub.Register(context.Background(), stream)
 
 					// Alternate between register/unregister
 					if i%2 == 0 {
-						hub.Unregister(stream)
+						hub.Unregister(context.Background(), stream)
 					}
 					i++
 					_ = stream.Close()
@@ -259,7 +260,7 @@ func BenchmarkHub_Broadcast_Stress(b *testing.B) {
 			w := httptest.NewRecorder()
 			stream, _ := New(w, r)
 			streams[i] = stream
-			hub.Register(stream)
+			hub.Register(context.Background(), stream)
 		}
 
 		defer func() {
@@ -275,7 +276,7 @@ func BenchmarkHub_Broadcast_Stress(b *testing.B) {
 
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				hub.Broadcast(event)
+				hub.Broadcast(context.Background(), event)
 			}
 		})
 	})
@@ -329,7 +330,7 @@ func BenchmarkHub_Baseline(b *testing.B) {
 					recorders[i] = httptest.NewRecorder()
 					stream, _ := New(recorders[i], r)
 					streams[i] = stream
-					hub.Register(stream)
+					hub.Register(context.Background(), stream)
 				}
 
 				defer func() {
@@ -344,7 +345,7 @@ func BenchmarkHub_Baseline(b *testing.B) {
 				b.ResetTimer()
 
 				for b.Loop() {
-					hub.Broadcast(event)
+					hub.Broadcast(context.Background(), event)
 				}
 			})
 		})

--- a/sse/hub_test.go
+++ b/sse/hub_test.go
@@ -1,6 +1,7 @@
 package sse
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -17,11 +18,11 @@ func TestHub(t *testing.T) {
 		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
 
 		stream, _ := New(w, r)
-		hub.Register(stream)
+		hub.Register(context.Background(), stream)
 
 		zhtest.AssertEqual(t, 1, hub.ConnectionCount())
 
-		hub.Unregister(stream)
+		hub.Unregister(context.Background(), stream)
 		zhtest.AssertEqual(t, 0, hub.ConnectionCount())
 	})
 
@@ -31,11 +32,11 @@ func TestHub(t *testing.T) {
 		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
 
 		stream, _ := New(w, r)
-		hub.Subscribe(stream, "notifications")
+		hub.Subscribe(context.Background(), stream, "notifications")
 
 		zhtest.AssertEqual(t, 1, hub.TopicCount("notifications"))
 
-		hub.Unsubscribe(stream, "notifications")
+		hub.Unsubscribe(context.Background(), stream, "notifications")
 		zhtest.AssertEqual(t, 0, hub.TopicCount("notifications"))
 	})
 
@@ -50,10 +51,10 @@ func TestHub(t *testing.T) {
 		stream1, _ := New(w1, r)
 		stream2, _ := New(w2, r)
 
-		hub.Register(stream1)
-		hub.Register(stream2)
+		hub.Register(context.Background(), stream1)
+		hub.Register(context.Background(), stream2)
 
-		hub.Broadcast(Event{Data: []byte("hello all")})
+		hub.Broadcast(context.Background(), Event{Data: []byte("hello all")})
 
 		zhtest.AssertWith(t, w1).BodyContains("hello all")
 		zhtest.AssertWith(t, w2).BodyContains("hello all")
@@ -69,10 +70,10 @@ func TestHub(t *testing.T) {
 		stream1, _ := New(w1, r)
 		stream2, _ := New(w2, r)
 
-		hub.Subscribe(stream1, "topic1")
-		hub.Subscribe(stream2, "topic2")
+		hub.Subscribe(context.Background(), stream1, "topic1")
+		hub.Subscribe(context.Background(), stream2, "topic2")
 
-		hub.BroadcastTo("topic1", Event{Data: []byte("topic1 message")})
+		hub.BroadcastTo(context.Background(), "topic1", Event{Data: []byte("topic1 message")})
 
 		zhtest.AssertWith(t, w1).BodyContains("topic1 message")
 		zhtest.AssertWith(t, w2).BodyNotContains("topic1 message")
@@ -84,10 +85,10 @@ func TestHub(t *testing.T) {
 		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
 
 		stream, _ := New(w, r)
-		hub.Subscribe(stream, "topic1")
-		hub.Subscribe(stream, "topic2")
+		hub.Subscribe(context.Background(), stream, "topic1")
+		hub.Subscribe(context.Background(), stream, "topic2")
 
-		hub.Unregister(stream)
+		hub.Unregister(context.Background(), stream)
 
 		zhtest.AssertEqual(t, 0, hub.TopicCount("topic1"))
 		zhtest.AssertEqual(t, 0, hub.TopicCount("topic2"))
@@ -100,7 +101,7 @@ func TestHub(t *testing.T) {
 		w1 := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
 		stream1, _ := New(w1, r)
-		hub.Register(stream1)
+		hub.Register(context.Background(), stream1)
 
 		// Create a stream with an error writer that will fail on send
 		header := make(http.Header)
@@ -114,12 +115,12 @@ func TestHub(t *testing.T) {
 			done:    make(chan struct{}),
 			cancel:  func() {},
 		}
-		hub.Register(badStream)
+		hub.Register(context.Background(), badStream)
 
 		zhtest.AssertEqual(t, 2, hub.ConnectionCount())
 
 		// Broadcast should auto-unregister the failed connection
-		hub.Broadcast(Event{Data: []byte("test")})
+		hub.Broadcast(context.Background(), Event{Data: []byte("test")})
 
 		zhtest.AssertEqual(t, 1, hub.ConnectionCount())
 	})
@@ -131,7 +132,7 @@ func TestHub(t *testing.T) {
 		w1 := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
 		stream1, _ := New(w1, r)
-		hub.Subscribe(stream1, "test-topic")
+		hub.Subscribe(context.Background(), stream1, "test-topic")
 
 		// Create a stream with an error writer
 		header := make(http.Header)
@@ -145,12 +146,12 @@ func TestHub(t *testing.T) {
 			done:    make(chan struct{}),
 			cancel:  func() {},
 		}
-		hub.Subscribe(badStream, "test-topic")
+		hub.Subscribe(context.Background(), badStream, "test-topic")
 
 		zhtest.AssertEqual(t, 2, hub.TopicCount("test-topic"))
 
 		// Broadcast should auto-unregister the failed connection
-		hub.BroadcastTo("test-topic", Event{Data: []byte("test")})
+		hub.BroadcastTo(context.Background(), "test-topic", Event{Data: []byte("test")})
 
 		zhtest.AssertEqual(t, 1, hub.TopicCount("test-topic"))
 	})
@@ -168,10 +169,10 @@ func TestHub(t *testing.T) {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
 		stream, _ := New(w, r)
-		hub.Register(stream)
+		hub.Register(context.Background(), stream)
 
 		event := Event{Data: []byte("hook test")}
-		hub.Broadcast(event)
+		hub.Broadcast(context.Background(), event)
 
 		zhtest.AssertEqual(t, true, called)
 		zhtest.AssertEqual(t, string(event.Data), string(received.Data))
@@ -192,10 +193,10 @@ func TestHub(t *testing.T) {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodGet, "/sse", nil)
 		stream, _ := New(w, r)
-		hub.Subscribe(stream, "test-topic")
+		hub.Subscribe(context.Background(), stream, "test-topic")
 
 		event := Event{Data: []byte("hook test")}
-		hub.BroadcastTo("test-topic", event)
+		hub.BroadcastTo(context.Background(), "test-topic", event)
 
 		zhtest.AssertEqual(t, true, called)
 		zhtest.AssertEqual(t, "test-topic", receivedTopic)
@@ -221,7 +222,7 @@ func TestHub_BroadcastRaceCondition(t *testing.T) {
 			stream, err := New(w, r)
 			zhtest.AssertNoError(t, err)
 			streams = append(streams, stream)
-			hub.Register(stream)
+			hub.Register(context.Background(), stream)
 		}
 
 		zhtest.AssertEqual(t, 10, hub.ConnectionCount())
@@ -234,7 +235,7 @@ func TestHub_BroadcastRaceCondition(t *testing.T) {
 			// Broadcast from one goroutine
 			go func() {
 				defer wg.Done()
-				hub.Broadcast(Event{Data: []byte("test")})
+				hub.Broadcast(context.Background(), Event{Data: []byte("test")})
 			}()
 
 			// Close connections from another goroutine
@@ -267,7 +268,7 @@ func TestHub_BroadcastRaceCondition(t *testing.T) {
 			stream, err := New(w, r)
 			zhtest.AssertNoError(t, err)
 			streams = append(streams, stream)
-			hub.Subscribe(stream, "test-topic")
+			hub.Subscribe(context.Background(), stream, "test-topic")
 		}
 
 		zhtest.AssertEqual(t, 10, hub.TopicCount("test-topic"))
@@ -280,7 +281,7 @@ func TestHub_BroadcastRaceCondition(t *testing.T) {
 			// BroadcastTo from one goroutine
 			go func() {
 				defer wg.Done()
-				hub.BroadcastTo("test-topic", Event{Data: []byte("test")})
+				hub.BroadcastTo(context.Background(), "test-topic", Event{Data: []byte("test")})
 			}()
 
 			// Close connections from another goroutine
@@ -314,7 +315,7 @@ func TestHub_BroadcastRaceCondition(t *testing.T) {
 			stream, err := New(w, r)
 			zhtest.AssertNoError(t, err)
 			streams = append(streams, stream)
-			hub.Register(stream)
+			hub.Register(context.Background(), stream)
 		}
 
 		var wg sync.WaitGroup
@@ -327,7 +328,7 @@ func TestHub_BroadcastRaceCondition(t *testing.T) {
 			go func(id int) {
 				defer wg.Done()
 				for j := 0; j < iterations; j++ {
-					hub.Broadcast(Event{Data: []byte("test"), ID: fmt.Sprintf("worker-%d-iter-%d", id, j)})
+					hub.Broadcast(context.Background(), Event{Data: []byte("test"), ID: fmt.Sprintf("worker-%d-iter-%d", id, j)})
 				}
 			}(i)
 		}
@@ -342,7 +343,7 @@ func TestHub_BroadcastRaceCondition(t *testing.T) {
 					_ = streams[idx].Close()
 					// Re-register sometimes to keep the pool active
 					if j%3 == 0 {
-						hub.Register(streams[idx])
+						hub.Register(context.Background(), streams[idx])
 					}
 				}
 			}(i)
@@ -355,7 +356,7 @@ func TestHub_BroadcastRaceCondition(t *testing.T) {
 				defer wg.Done()
 				for j := 0; j < iterations; j++ {
 					idx := (id*iterations + j) % len(streams)
-					hub.Register(streams[idx])
+					hub.Register(context.Background(), streams[idx])
 				}
 			}(i)
 		}
@@ -372,11 +373,11 @@ func TestHub_BroadcastRaceCondition(t *testing.T) {
 // customBroadcaster is a minimal implementation of the Broadcaster interface for testing.
 type customBroadcaster struct{}
 
-func (c *customBroadcaster) Register(s *SSE)                       {}
-func (c *customBroadcaster) Unregister(s *SSE)                     {}
-func (c *customBroadcaster) Subscribe(s *SSE, topic string)        {}
-func (c *customBroadcaster) Unsubscribe(s *SSE, topic string)      {}
-func (c *customBroadcaster) Broadcast(event Event)                 {}
-func (c *customBroadcaster) BroadcastTo(topic string, event Event) {}
-func (c *customBroadcaster) ConnectionCount() int                  { return 0 }
-func (c *customBroadcaster) TopicCount(topic string) int           { return 0 }
+func (c *customBroadcaster) Register(_ context.Context, s *SSE)                       {}
+func (c *customBroadcaster) Unregister(_ context.Context, s *SSE)                     {}
+func (c *customBroadcaster) Subscribe(_ context.Context, s *SSE, topic string)        {}
+func (c *customBroadcaster) Unsubscribe(_ context.Context, s *SSE, topic string)      {}
+func (c *customBroadcaster) Broadcast(_ context.Context, event Event)                 {}
+func (c *customBroadcaster) BroadcastTo(_ context.Context, topic string, event Event) {}
+func (c *customBroadcaster) ConnectionCount() int                                     { return 0 }
+func (c *customBroadcaster) TopicCount(topic string) int                              { return 0 }


### PR DESCRIPTION
All Broadcaster methods — Register, Unregister, Subscribe, Unsubscribe, Broadcast, and BroadcastTo — now accept a context.Context as their first parameter. Updated implementations, tests, benchmarks, examples, and documentation accordingly.