### PR TITLE
fix: validator had a bug where required on pointer fields was applied…

### DIFF
--- a/validator/validator.go
+++ b/validator/validator.go
@@ -131,7 +131,10 @@ func (v *defaultValidator) validateStruct(val reflect.Value, prefix string, erro
 
 		// Validate field if it has rules
 		if len(fi.rules) > 0 {
-			v.validateFieldWithInfo(field, fieldName, fi, errors)
+			// For pointer fields, required was already handled above (nil check).
+			// Don't re-run required on the dereferenced value.
+			skipRequired := fi.isPtr && fi.hasRequired
+			v.validateFieldWithInfo(field, fieldName, fi, errors, skipRequired)
 		}
 
 		// Recursively validate nested structs
@@ -177,7 +180,10 @@ func (v *defaultValidator) validateStruct(val reflect.Value, prefix string, erro
 }
 
 // validateFieldWithInfo validates a single field using pre-parsed field info.
-func (v *defaultValidator) validateFieldWithInfo(field reflect.Value, fieldName string, fi *validatedFieldInfo, errors ValidationErrors) {
+// skipRequired is true when the field was originally a pointer and required
+// was already handled at the pointer level (nil check); in that case, required
+// should not be re-run on the dereferenced value.
+func (v *defaultValidator) validateFieldWithInfo(field reflect.Value, fieldName string, fi *validatedFieldInfo, errors ValidationErrors, skipRequired bool) {
 	// Check for omitempty first using cached value
 	if fi.omitempty && isZeroValue(field) {
 		return // Skip all other validators
@@ -195,6 +201,9 @@ func (v *defaultValidator) validateFieldWithInfo(field reflect.Value, fieldName 
 		rule := fi.rules[i]
 		if rule.Name == "omitempty" {
 			continue // Already handled above
+		}
+		if skipRequired && rule.Name == "required" {
+			continue // Already handled at pointer level
 		}
 
 		fn, exists := validators[rule.Name]

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -776,6 +776,45 @@ func TestPointerWithOmitEmpty(t *testing.T) {
 	})
 }
 
+func TestPointerRequiredZeroValue(t *testing.T) {
+	type testPtrRequiredZero struct {
+		Lat *float64 `json:"lat" validate:"required,gte=-90,lte=90"`
+		Lng *float64 `json:"lng" validate:"required,gte=-180,lte=180"`
+	}
+
+	v := New()
+
+	t.Run("nil required pointer fails", func(t *testing.T) {
+		input := testPtrRequiredZero{Lat: nil, Lng: nil}
+		err := v.Struct(&input)
+		zhtest.AssertError(t, err)
+	})
+
+	t.Run("zero value pointer passes required", func(t *testing.T) {
+		lat := 0.0
+		lng := 0.0
+		input := testPtrRequiredZero{Lat: &lat, Lng: &lng}
+		err := v.Struct(&input)
+		zhtest.AssertNoError(t, err)
+	})
+
+	t.Run("non-zero value pointer passes", func(t *testing.T) {
+		lat := 45.5
+		lng := -73.5
+		input := testPtrRequiredZero{Lat: &lat, Lng: &lng}
+		err := v.Struct(&input)
+		zhtest.AssertNoError(t, err)
+	})
+
+	t.Run("out of range zero value fails", func(t *testing.T) {
+		lat := 100.0
+		lng := 200.0
+		input := testPtrRequiredZero{Lat: &lat, Lng: &lng}
+		err := v.Struct(&input)
+		zhtest.AssertError(t, err)
+	})
+}
+
 func TestJSONFieldNameInErrors(t *testing.T) {
 	type testRequest struct {
 		UserName string `json:"user_name" validate:"required,min=5"`


### PR DESCRIPTION
… twice - once to check the pointer was non-nil (correct), and again on the dereferenced value (incorrect). So *float64 pointing to 0

failed because 0 is the zero value for float64.