### PR TITLE
feat: return 422 for unknown JSON fields and include safe bind error …

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,4 +30,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.11.4
+          version: v2.12.2

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ help:
 GOTESTSUM := go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=1
 TESTFLAGS := -shuffle=on
 COVERFLAGS := -covermode=atomic
-GOLANGCI_LINT := go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+GOLANGCI_LINT := go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 
 check-pre-commit:
 ifeq (, $(shell which pre-commit))

--- a/bind.go
+++ b/bind.go
@@ -9,8 +9,10 @@ import (
 	"net/url"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/alexferl/zerohttp/internal/bind"
+	"github.com/alexferl/zerohttp/validator"
 )
 
 // FileHeader represents an uploaded file in a multipart form.
@@ -75,7 +77,21 @@ type defaultBinder struct{}
 func (b *defaultBinder) JSON(r io.Reader, dst any) error {
 	decoder := json.NewDecoder(r)
 	decoder.DisallowUnknownFields()
-	return decoder.Decode(dst)
+	err := decoder.Decode(dst)
+	if err == nil {
+		return nil
+	}
+
+	// Detect unknown field errors from encoding/json and wrap them
+	// so the router can return 422 instead of 400.
+	msg := err.Error()
+	const unknownFieldPrefix = `json: unknown field "`
+	if field, ok := strings.CutPrefix(msg, unknownFieldPrefix); ok {
+		field = strings.TrimSuffix(field, `"`)
+		return &validator.UnknownFieldError{Field: field}
+	}
+
+	return err
 }
 
 // Form binds form data from a url.Values to a destination struct.
@@ -118,7 +134,7 @@ func (b *defaultBinder) Query(r *http.Request, dst any) error {
 // Uses the type registry to cache reflection information for improved performance.
 func bindValues(values url.Values, dst any, tagName string, allowFiles bool) error {
 	v := reflect.ValueOf(dst)
-	if v.Kind() != reflect.Ptr || v.IsNil() {
+	if v.Kind() != reflect.Pointer || v.IsNil() {
 		return fmt.Errorf("destination must be a non-nil pointer")
 	}
 
@@ -197,7 +213,7 @@ func setFieldValue(field reflect.Value, values []string) error {
 	case reflect.Slice:
 		return setSliceValue(field, values)
 
-	case reflect.Ptr:
+	case reflect.Pointer:
 		// If value is empty, leave pointer as nil (optional parameter)
 		if values[0] == "" {
 			return nil
@@ -238,7 +254,7 @@ func BindMultipartFormFiles(r *http.Request, dst any) error {
 	}
 
 	v := reflect.ValueOf(dst)
-	if v.Kind() != reflect.Ptr || v.IsNil() {
+	if v.Kind() != reflect.Pointer || v.IsNil() {
 		return fmt.Errorf("destination must be a non-nil pointer")
 	}
 

--- a/bind_test.go
+++ b/bind_test.go
@@ -2,6 +2,7 @@ package zerohttp
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"mime/multipart"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/alexferl/zerohttp/httpx"
+	"github.com/alexferl/zerohttp/validator"
 	"github.com/alexferl/zerohttp/zhtest"
 )
 
@@ -64,6 +66,11 @@ func TestBinder_JSON(t *testing.T) {
 				zhtest.AssertError(t, err)
 				if tt.errorMsg != "" {
 					zhtest.AssertErrorContains(t, err, tt.errorMsg)
+				}
+				if tt.name == "unknown field" {
+					var ufe *validator.UnknownFieldError
+					zhtest.AssertTrue(t, errors.As(err, &ufe))
+					zhtest.AssertEqual(t, "unknown", ufe.Field)
 				}
 				return
 			}

--- a/internal/bind/registry.go
+++ b/internal/bind/registry.go
@@ -274,7 +274,7 @@ func (ti *typeInfo) collectFieldsRecursive(path fieldPath, tagName string, allow
 
 	// Skip pointer-to-struct fields (except file fields) — they are not bindable
 	// primitives and pointer embeds are not expanded (Kind() == Ptr bypassed isEmbedded check).
-	if !isFileField && fieldType.Kind() == reflect.Ptr &&
+	if !isFileField && fieldType.Kind() == reflect.Pointer &&
 		fieldType.Elem().Kind() == reflect.Struct {
 		return result, nil
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,13 +30,13 @@ func Merge(dst, src any) {
 	}
 
 	dv := reflect.ValueOf(dst)
-	if dv.Kind() != reflect.Ptr || dv.IsNil() {
+	if dv.Kind() != reflect.Pointer || dv.IsNil() {
 		panic("config.Merge: dst must be a non-nil pointer")
 	}
 
 	sv := reflect.ValueOf(src)
 	// Dereference pointer src so callers can pass either &cfg or cfg
-	if sv.Kind() == reflect.Ptr {
+	if sv.Kind() == reflect.Pointer {
 		sv = sv.Elem()
 	}
 	if sv.Kind() != reflect.Struct {
@@ -52,11 +52,11 @@ func mergeValue(dst, src reflect.Value) {
 	}
 
 	switch src.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if src.IsNil() {
 			return
 		}
-		if dst.Kind() == reflect.Ptr || dst.Kind() == reflect.Interface {
+		if dst.Kind() == reflect.Pointer || dst.Kind() == reflect.Interface {
 			dst.Set(src)
 			return
 		}

--- a/router.go
+++ b/router.go
@@ -51,6 +51,7 @@ func init() {
 //
 // Errors are automatically converted to appropriate HTTP responses:
 //   - Validation errors return 422 Unprocessable Entity with field details
+//   - Unknown fields return 422 Unprocessable Entity
 //   - Binding errors return 400 Bad Request
 //   - Request too large returns 413 Payload Too Large
 //   - ProblemDetail errors return their specified status code
@@ -112,14 +113,40 @@ func handleHandlerError(w http.ResponseWriter, err error) {
 		return
 	}
 
+	// Check for unknown field errors (422)
+	if IsUnknownFieldError(err) {
+		var ufe *validator.UnknownFieldError
+		errors.As(err, &ufe)
+		w.Header().Set(httpx.HeaderContentType, httpx.MIMEApplicationProblemJSON)
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		response := map[string]any{
+			"title":  "Unprocessable Entity",
+			"status": http.StatusUnprocessableEntity,
+			"detail": "Validation failed",
+			"errors": map[string][]string{ufe.Field: {"extra inputs are not permitted"}},
+		}
+		if encErr := json.NewEncoder(w).Encode(response); encErr != nil {
+			log.GetGlobalLogger().Error("Failed to encode unknown field error response", log.E(encErr))
+		}
+		return
+	}
+
 	// Check for binding errors (400)
 	if IsBindError(err) {
 		w.Header().Set(httpx.HeaderContentType, httpx.MIMEApplicationProblemJSON)
 		w.WriteHeader(http.StatusBadRequest)
+		detail := "Invalid request body"
+		var be *validator.BindError
+		if errors.As(err, &be) {
+			var syntaxErr *json.SyntaxError
+			if errors.As(be.Unwrap(), &syntaxErr) {
+				detail = syntaxErr.Error()
+			}
+		}
 		response := map[string]any{
 			"title":  "Bad Request",
 			"status": http.StatusBadRequest,
-			"detail": "Invalid request body",
+			"detail": detail,
 		}
 		if encErr := json.NewEncoder(w).Encode(response); encErr != nil {
 			log.GetGlobalLogger().Error("Failed to encode binding error response", log.E(encErr))

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -62,7 +62,7 @@ func TestContextWithSpan(t *testing.T) {
 	zhtest.AssertNotNil(t, retrieved)
 
 	// Nil context should return nil
-	zhtest.AssertNil(t, SpanFromContext(context.TODO()))
+	zhtest.AssertNil(t, SpanFromContext(context.Background()))
 
 	// Context without span should return nil
 	emptyCtx := context.Background()

--- a/validate.go
+++ b/validate.go
@@ -41,7 +41,7 @@ var DefaultMultipartMaxMemory int64 = 32 << 20
 // BindAndValidate binds request data based on Content-Type and validates the result.
 // It returns appropriate errors:
 //   - 400 Bad Request for binding failures (malformed JSON, type mismatches)
-//   - 422 Unprocessable Entity for validation failures
+//   - 422 Unprocessable Entity for unknown fields or validation failures
 //
 // Supported Content-Types:
 //   - application/json
@@ -85,6 +85,10 @@ func BindAndValidate(r *http.Request, dst any) error {
 	}
 
 	if bindErr != nil {
+		// Unknown fields are returned as 422, not 400.
+		if validator.IsUnknownFieldError(bindErr) {
+			return bindErr
+		}
 		// Wrap as binding error (400)
 		return &validator.BindError{Err: bindErr}
 	}
@@ -99,6 +103,11 @@ func BindAndValidate(r *http.Request, dst any) error {
 // IsBindError checks if an error is a binding error (should return 400).
 func IsBindError(err error) bool {
 	return validator.IsBindError(err)
+}
+
+// IsUnknownFieldError checks if an error is an unknown field error (should return 422).
+func IsUnknownFieldError(err error) bool {
+	return validator.IsUnknownFieldError(err)
 }
 
 // IsValidationError checks if an error is a validation error (should return 422).
@@ -134,7 +143,7 @@ func validateResponseData(data any) error {
 	v := reflect.ValueOf(data)
 
 	// Handle pointer
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 

--- a/validate_test.go
+++ b/validate_test.go
@@ -402,6 +402,11 @@ func TestBindingHTTPResponse(t *testing.T) {
 			body:       `not json at all`,
 			wantStatus: http.StatusBadRequest,
 		},
+		{
+			name:       "unknown field",
+			body:       `{"name":"John","unknown":"field"}`,
+			wantStatus: http.StatusUnprocessableEntity,
+		},
 	}
 
 	for _, tt := range tests {
@@ -413,6 +418,47 @@ func TestBindingHTTPResponse(t *testing.T) {
 			zhtest.AssertEqual(t, tt.wantStatus, resp.StatusCode)
 		})
 	}
+}
+
+func TestUnknownFieldHTTPResponse(t *testing.T) {
+	type TestRequest struct {
+		Name string `json:"name" validate:"required"`
+	}
+
+	handler := HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		var req TestRequest
+		if err := BindAndValidate(r, &req); err != nil {
+			return err
+		}
+		return R.JSON(w, http.StatusOK, M{"name": req.Name})
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	body := `{"name":"John","unknown":"field"}`
+	resp, err := http.Post(server.URL, "application/json", bytes.NewReader([]byte(body)))
+	zhtest.AssertNoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	zhtest.AssertEqual(t, http.StatusUnprocessableEntity, resp.StatusCode)
+
+	var result map[string]any
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	zhtest.AssertNoError(t, err)
+
+	zhtest.AssertEqual(t, "Unprocessable Entity", result["title"])
+	zhtest.AssertEqual(t, float64(http.StatusUnprocessableEntity), result["status"])
+	zhtest.AssertEqual(t, "Validation failed", result["detail"])
+
+	e, ok := result["errors"].(map[string]any)
+	zhtest.AssertTrue(t, ok)
+	zhtest.AssertEqual(t, 1, len(e))
+
+	unknownErrs, ok := e["unknown"].([]any)
+	zhtest.AssertTrue(t, ok)
+	zhtest.AssertEqual(t, 1, len(unknownErrs))
+	zhtest.AssertEqual(t, "extra inputs are not permitted", unknownErrs[0])
 }
 
 // crossFieldOrder for testing cross-field validation

--- a/validator/errors.go
+++ b/validator/errors.go
@@ -80,3 +80,23 @@ func IsBindError(err error) bool {
 	var be *BindError
 	return errors.As(err, &be)
 }
+
+// UnknownFieldError indicates a JSON payload contained a field not present
+// in the target struct. The default error handler uses this to return
+// 422 Unprocessable Entity instead of 400 Bad Request.
+type UnknownFieldError struct {
+	Field string
+}
+
+func (e *UnknownFieldError) Error() string {
+	return "unknown field: " + e.Field
+}
+
+// IsUnknownFieldError checks if an error is an unknown field error.
+func IsUnknownFieldError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ufe *UnknownFieldError
+	return errors.As(err, &ufe)
+}

--- a/validator/errors_test.go
+++ b/validator/errors_test.go
@@ -202,3 +202,29 @@ func TestIsBindError(t *testing.T) {
 	wrappedErr := fmt.Errorf("wrapped: %w", bindErr)
 	zhtest.AssertTrue(t, IsBindError(wrappedErr))
 }
+
+func TestUnknownFieldError(t *testing.T) {
+	ufe := &UnknownFieldError{Field: "foo"}
+	zhtest.AssertEqual(t, "unknown field: foo", ufe.Error())
+}
+
+func TestIsUnknownFieldError(t *testing.T) {
+	// Test with nil
+	zhtest.AssertFalse(t, IsUnknownFieldError(nil))
+
+	// Test with regular error
+	regularErr := errors.New("some error")
+	zhtest.AssertFalse(t, IsUnknownFieldError(regularErr))
+
+	// Test with UnknownFieldError
+	ufe := &UnknownFieldError{Field: "foo"}
+	zhtest.AssertTrue(t, IsUnknownFieldError(ufe))
+
+	// Test with wrapped UnknownFieldError
+	wrappedErr := fmt.Errorf("wrapped: %w", ufe)
+	zhtest.AssertTrue(t, IsUnknownFieldError(wrappedErr))
+
+	// Test with UnknownFieldError wrapped in BindError
+	bindWrapped := &BindError{Err: ufe}
+	zhtest.AssertTrue(t, IsUnknownFieldError(bindWrapped))
+}

--- a/validator/registry.go
+++ b/validator/registry.go
@@ -92,7 +92,7 @@ func (tr *typeRegistry) analyzeType(t reflect.Type) *typeInfo {
 
 		// Unwrap pointer if needed
 		fieldType := field.Type
-		if fieldType.Kind() == reflect.Ptr {
+		if fieldType.Kind() == reflect.Pointer {
 			fi.isPtr = true
 			fieldType = fieldType.Elem()
 		}

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -60,7 +60,7 @@ func (v *defaultValidator) Struct(dst any) error {
 	}
 
 	val := reflect.ValueOf(dst)
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		if val.IsNil() {
 			return ValidationErrors{"": {"nil pointer"}}
 		}
@@ -158,7 +158,7 @@ func (v *defaultValidator) validateStruct(val reflect.Value, prefix string, erro
 				elemName := fmt.Sprintf("%s[%d]", fieldName, j)
 				if elem.Kind() == reflect.Struct {
 					v.validateStruct(elem, elemName, errors)
-				} else if elem.Kind() == reflect.Ptr && !elem.IsNil() && elem.Elem().Kind() == reflect.Struct {
+				} else if elem.Kind() == reflect.Pointer && !elem.IsNil() && elem.Elem().Kind() == reflect.Struct {
 					v.validateStruct(elem.Elem(), elemName, errors)
 				}
 			}
@@ -169,7 +169,7 @@ func (v *defaultValidator) validateStruct(val reflect.Value, prefix string, erro
 				elemName := fmt.Sprintf("%s[%v]", fieldName, key)
 				if elem.Kind() == reflect.Struct {
 					v.validateStruct(elem, elemName, errors)
-				} else if elem.Kind() == reflect.Ptr && !elem.IsNil() && elem.Elem().Kind() == reflect.Struct {
+				} else if elem.Kind() == reflect.Pointer && !elem.IsNil() && elem.Elem().Kind() == reflect.Struct {
 					v.validateStruct(elem.Elem(), elemName, errors)
 				}
 			}
@@ -236,7 +236,7 @@ func (v *defaultValidator) validateElements(field reflect.Value, fieldName strin
 			elemName := fmt.Sprintf("%s[%d]", fieldName, j)
 
 			// Handle pointer elements
-			if elem.Kind() == reflect.Ptr && !elem.IsNil() {
+			if elem.Kind() == reflect.Pointer && !elem.IsNil() {
 				elem = elem.Elem()
 			}
 
@@ -345,7 +345,7 @@ func isZeroValue(v reflect.Value) bool {
 		return !v.Bool()
 	case reflect.Slice, reflect.Map, reflect.Array:
 		return v.Len() == 0
-	case reflect.Ptr, reflect.Interface:
+	case reflect.Pointer, reflect.Interface:
 		return v.IsNil()
 	case reflect.Struct:
 		// Check if struct is zero by comparing with a new instance

--- a/zhtest/assert.go
+++ b/zhtest/assert.go
@@ -722,7 +722,7 @@ func AssertNil(t testing.TB, v any) {
 		// Handle wrapped nil values (typed nil pointers, interfaces, etc.)
 		rv := reflect.ValueOf(v)
 		switch rv.Kind() {
-		case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Chan, reflect.Func, reflect.Interface:
+		case reflect.Pointer, reflect.Slice, reflect.Map, reflect.Chan, reflect.Func, reflect.Interface:
 			if !rv.IsNil() {
 				fail(t, "expected nil, got %v", v)
 			}
@@ -747,7 +747,7 @@ func AssertNotNil(t testing.TB, v any) {
 	// Handle wrapped nil values (typed nil pointers, interfaces, etc.)
 	rv := reflect.ValueOf(v)
 	switch rv.Kind() {
-	case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Chan, reflect.Func, reflect.Interface:
+	case reflect.Pointer, reflect.Slice, reflect.Map, reflect.Chan, reflect.Func, reflect.Interface:
 		if rv.IsNil() {
 			fail(t, "expected non-nil value, got nil")
 		}
@@ -1046,7 +1046,7 @@ func isEmpty(v any) bool {
 	switch rv.Kind() {
 	case reflect.String, reflect.Slice, reflect.Map, reflect.Array, reflect.Chan:
 		return rv.Len() == 0
-	case reflect.Ptr, reflect.Interface:
+	case reflect.Pointer, reflect.Interface:
 		if rv.IsNil() {
 			return true
 		}
@@ -1163,9 +1163,9 @@ func AssertIsType(t testing.TB, expectedType any, actual any) {
 	actualReflectType := reflect.TypeOf(actual)
 
 	// Handle nil pointer types for expected (e.g., (*MyType)(nil))
-	if expectedReflectType != nil && expectedReflectType.Kind() == reflect.Ptr && actualReflectType != nil {
+	if expectedReflectType != nil && expectedReflectType.Kind() == reflect.Pointer && actualReflectType != nil {
 		// If expected is a pointer type but actual is not, compare the underlying type
-		if actualReflectType.Kind() != reflect.Ptr {
+		if actualReflectType.Kind() != reflect.Pointer {
 			expectedReflectType = expectedReflectType.Elem()
 		}
 	}
@@ -1191,7 +1191,7 @@ func AssertIsType(t testing.TB, expectedType any, actual any) {
 func AssertImplements(t testing.TB, interfaceType any, actual any) {
 	interfaceReflectType := reflect.TypeOf(interfaceType)
 
-	if interfaceReflectType == nil || interfaceReflectType.Kind() != reflect.Ptr || interfaceReflectType.Elem().Kind() != reflect.Interface {
+	if interfaceReflectType == nil || interfaceReflectType.Kind() != reflect.Pointer || interfaceReflectType.Elem().Kind() != reflect.Interface {
 		fail(t, "AssertImplements requires a pointer to an interface as the first argument (e.g., (*io.Reader)(nil)), got %T", interfaceType)
 		return
 	}


### PR DESCRIPTION
…details

Unknown fields from DisallowUnknownFields now return 422 Unprocessable Entity with the field name in the errors response: {"field": ["extra inputs are not permitted"]}

Invalid JSON syntax still returns 400 Bad Request, and now includes the actual syntax error detail safely without leaking struct internals.

Also fixes all reflect.Ptr -> reflect.Pointer occurrences to satisfy the inline linter check.